### PR TITLE
feat: add PostCompact hook for team state recovery after compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cozempic init
 That's it. This auto-wires everything:
 
 1. **Guard daemon auto-start** — `SessionStart` hook spawns `cozempic guard --daemon` when Claude Code opens. Background process, PID file prevents double-starts, logs to `/tmp/cozempic_guard_*.log`
-2. **Checkpoint hooks** — `PostToolUse[Task|TaskCreate|TaskUpdate]`, `PreCompact`, `Stop` capture team state at every critical moment
+2. **Checkpoint hooks** — `PostToolUse[Task|TaskCreate|TaskUpdate]`, `PreCompact`, `PostCompact`, `Stop` capture team state at every critical moment
 3. **`/cozempic` slash command** — installed to `~/.claude/commands/` for in-session diagnosis and treatment
 
 Idempotent — safe to run multiple times. Existing hooks and settings are preserved. No second terminal needed.
@@ -165,6 +165,7 @@ cozempic treat <session> --execute          Apply changes with backup
 cozempic strategy <name> <session>          Run single strategy
 cozempic reload [-rx PRESET]                Treat + auto-resume in new terminal
 cozempic checkpoint [--show]                Save team/agent state to disk (no pruning)
+cozempic post-compact                       Output team state after compaction (PostCompact hook)
 cozempic guard [--threshold MB]             Tiered guard: checkpoint + soft/hard prune
 cozempic guard --soft-threshold 25          Custom soft threshold (default: 60% of hard)
 cozempic guard --threshold-tokens 180000    Override hard threshold in tokens (default: 75% of context window)
@@ -369,6 +370,17 @@ Add to your project's `.claude/settings.json`:
         ]
       }
     ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cozempic post-compact 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",
@@ -391,13 +403,14 @@ This checkpoints team state:
 | `PostToolUse[Task]` | After every subagent spawn | Capture new agent immediately |
 | `PostToolUse[TaskCreate\|TaskUpdate]` | After todo list changes | Track task progress |
 | `PreCompact` | Right before auto-compaction | Last chance to save state |
+| `PostCompact` | Right after auto-compaction | Re-inject team state into conversation |
 | `Stop` | Session end | Final checkpoint |
 
 ### Protection layers summary
 
 | Layer | Trigger | What it does |
 |-------|---------|-------------|
-| **Hooks** | Every Task/TaskCreate/TaskUpdate, PreCompact, Stop | Instant checkpoint to disk |
+| **Hooks** | Every Task/TaskCreate/TaskUpdate, PreCompact, PostCompact, Stop | Instant checkpoint to disk |
 | **Guard (checkpoint)** | Every N seconds | Extract team state + config.json, write checkpoint |
 | **Guard (soft prune)** | At soft threshold (default 60% of hard) | Gentle prune, no reload, no disruption |
 | **Guard (hard prune)** | At hard threshold | Full prune + team-protect + optional reload |
@@ -486,6 +499,7 @@ The plugin registers:
 | `SessionStart` | Start guard daemon in background |
 | `PostToolUse` (Task/TaskCreate/TaskUpdate) | Checkpoint agent team state |
 | `PreCompact` | Emergency checkpoint before compaction |
+| `PostCompact` | Re-inject team state after compaction |
 | `Stop` | Final checkpoint on session end |
 
 The MCP server requires `fastmcp` (installed automatically via `uv`). See [plugin/README.md](plugin/README.md) for details.

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -478,6 +478,26 @@ def cmd_checkpoint(args):
             print()
 
 
+def cmd_post_compact(args):
+    """Output recovery context after native compaction. Designed for PostCompact hook.
+
+    Reads team-checkpoint.md saved by PreCompact and outputs it to stdout,
+    where Claude Code picks it up as hook feedback. Silent when no checkpoint
+    exists (solo sessions without agent teams).
+    """
+    from .team import read_team_checkpoint
+
+    cwd = args.cwd or os.getcwd()
+
+    # Try to find project dir from current session
+    sess = find_current_session(cwd)
+    project_dir = Path(sess["path"]).parent if sess else Path(cwd)
+
+    content = read_team_checkpoint(project_dir)
+    if content:
+        print(content)
+
+
 def cmd_guard(args):
     """Start the guard daemon to prevent compaction-induced state loss."""
     session_id = args.session or None
@@ -619,6 +639,7 @@ def cmd_init(args):
     print(f"    - Guard daemon auto-starts on every session (SessionStart hook)")
     print(f"    - Team state checkpointed on every agent event (PostToolUse hooks)")
     print(f"    - Emergency checkpoint before compaction (PreCompact hook)")
+    print(f"    - Recovery context after compaction (PostCompact hook)")
     print(f"    - Final checkpoint on session end (Stop hook)")
     print()
     print(f"  Just start Claude Code normally. No second terminal needed.")
@@ -707,6 +728,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_cp.add_argument("--cwd", help="Working directory (default: current)")
     p_cp.add_argument("--show", action="store_true", help="Print the team state after saving")
 
+    # post-compact
+    p_post_compact = sub.add_parser("post-compact", help="Output team state after compaction (for PostCompact hook)")
+    p_post_compact.add_argument("--cwd", help="Working directory (default: current)")
+
     # guard
     p_guard = sub.add_parser("guard", help="Background sentinel — auto-prune before compaction triggers")
     p_guard.add_argument("--cwd", help="Working directory (default: current)")
@@ -739,7 +764,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 _SUBCOMMANDS = {
     "list", "current", "diagnose", "treat", "strategy", "reload",
-    "checkpoint", "guard", "init", "doctor", "formulary",
+    "checkpoint", "post-compact", "guard", "init", "doctor", "formulary",
 }
 
 
@@ -805,6 +830,7 @@ def main():
         "strategy": cmd_strategy,
         "reload": cmd_reload,
         "checkpoint": cmd_checkpoint,
+        "post-compact": cmd_post_compact,
         "guard": cmd_guard,
         "init": cmd_init,
         "doctor": cmd_doctor,

--- a/src/cozempic/data/cozempic_slash_command.md
+++ b/src/cozempic/data/cozempic_slash_command.md
@@ -128,6 +128,9 @@ Guard prevents state loss by:
 5. Injecting team state as a synthetic message pair
 6. Triggering reload so Claude resumes with clean context + team state baked in
 
+After native compaction, the `PostCompact` hook runs `cozempic post-compact` to
+re-inject the team checkpoint (saved by `PreCompact`) into the conversation.
+
 Use `--no-reload` if the user just wants background pruning without restarting:
 ```bash
 cozempic guard --threshold 50 --no-reload

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -763,6 +763,62 @@ def check_agent_model_mismatch() -> CheckResult:
     )
 
 
+def check_cozempic_hooks() -> CheckResult:
+    """Check that all expected cozempic hooks are wired in settings.json.
+
+    Verifies that SessionStart, PostToolUse, PreCompact, PostCompact, and Stop
+    hooks are present. Missing hooks mean protection gaps — e.g., no PostCompact
+    means team state isn't re-injected after native compaction.
+    """
+    claude_dir = get_claude_dir()
+    settings_path = claude_dir / "settings.json"
+
+    if not settings_path.exists():
+        return CheckResult(
+            name="cozempic-hooks",
+            status="warning",
+            message="No ~/.claude/settings.json found — no hooks configured",
+            fix_description="Run: cozempic init",
+        )
+
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return CheckResult(
+            name="cozempic-hooks",
+            status="warning",
+            message=f"Could not read settings.json: {e}",
+        )
+
+    hooks = settings.get("hooks", {})
+    expected = {"SessionStart", "PreCompact", "PostCompact", "Stop"}
+    missing = []
+
+    for event in expected:
+        entries = hooks.get(event, [])
+        has_cozempic = any(
+            "cozempic" in h.get("command", "")
+            for entry in entries
+            for h in entry.get("hooks", [])
+        )
+        if not has_cozempic:
+            missing.append(event)
+
+    if not missing:
+        return CheckResult(
+            name="cozempic-hooks",
+            status="ok",
+            message="All cozempic hooks are wired (SessionStart, PreCompact, PostCompact, Stop)",
+        )
+
+    return CheckResult(
+        name="cozempic-hooks",
+        status="warning",
+        message=f"Missing cozempic hooks: {', '.join(missing)}. Protection gaps exist.",
+        fix_description="Run: cozempic init",
+    )
+
+
 def check_zombie_teams() -> CheckResult:
     """Check for stale/zombie team directories in ~/.claude/teams/.
 
@@ -882,6 +938,7 @@ def fix_zombie_teams() -> str:
 ALL_CHECKS: list[tuple[str, callable, callable | None]] = [
     ("trust-dialog-hang", check_trust_dialog_hang, fix_trust_dialog_hang),
     ("hooks-trust-flag", check_hooks_trust_flag, fix_hooks_trust_flag),
+    ("cozempic-hooks", check_cozempic_hooks, None),
     ("claude-json-corruption", check_claude_json_corruption, fix_claude_json_corruption),
     ("corrupted-tool-use", check_corrupted_tool_use, fix_corrupted_tool_use),
     ("orphaned-tool-results", check_orphaned_tool_results, fix_orphaned_tool_results),

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -69,6 +69,17 @@ COZEMPIC_HOOKS = {
             ],
         },
     ],
+    "PostCompact": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "cozempic post-compact 2>/dev/null || true",
+                }
+            ],
+        },
+    ],
     "Stop": [
         {
             "matcher": "",

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -627,6 +627,29 @@ def write_team_checkpoint(state: TeamState, project_dir: Path | None = None) -> 
     return path
 
 
+def read_team_checkpoint(project_dir: Path | None = None) -> str | None:
+    """Read saved team checkpoint from disk.
+
+    Returns the checkpoint content, or None if not found or empty.
+    Used by PostCompact hook to re-inject team state after compaction.
+    The checkpoint is written by PreCompact (before compaction), so reading
+    from disk is safer than re-scanning the compacted JSONL.
+    """
+    from .session import get_claude_dir
+
+    candidates = []
+    if project_dir and project_dir.exists():
+        candidates.append(project_dir / "team-checkpoint.md")
+    candidates.append(get_claude_dir() / "team-checkpoint.md")
+
+    for path in candidates:
+        if path.exists():
+            content = path.read_text(encoding="utf-8").strip()
+            if content:
+                return content
+    return None
+
+
 def inject_team_recovery(messages: list[Message], state: TeamState) -> list[Message]:
     """Inject team state as a synthetic message pair at the end of the session.
 

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -1,0 +1,133 @@
+"""Tests for PostCompact recovery — read_team_checkpoint, cmd_post_compact, and hook config."""
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cozempic.team import read_team_checkpoint
+from cozempic.init import COZEMPIC_HOOKS
+
+
+class TestReadTeamCheckpoint(unittest.TestCase):
+
+    def test_returns_content_when_file_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint = Path(tmpdir) / "team-checkpoint.md"
+            checkpoint.write_text("# Team State\nTeam: test-team\n", encoding="utf-8")
+            result = read_team_checkpoint(Path(tmpdir))
+            self.assertIsNotNone(result)
+            self.assertIn("Team: test-team", result)
+
+    def test_returns_none_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = read_team_checkpoint(Path(tmpdir))
+            self.assertIsNone(result)
+
+    def test_returns_none_when_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint = Path(tmpdir) / "team-checkpoint.md"
+            checkpoint.write_text("", encoding="utf-8")
+            result = read_team_checkpoint(Path(tmpdir))
+            self.assertIsNone(result)
+
+    def test_returns_none_when_whitespace_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint = Path(tmpdir) / "team-checkpoint.md"
+            checkpoint.write_text("   \n\n  ", encoding="utf-8")
+            result = read_team_checkpoint(Path(tmpdir))
+            self.assertIsNone(result)
+
+    def test_prefers_project_dir_over_global(self):
+        with tempfile.TemporaryDirectory() as project_dir:
+            checkpoint = Path(project_dir) / "team-checkpoint.md"
+            checkpoint.write_text("# Project Team", encoding="utf-8")
+
+            # Even if global exists, project dir should win
+            result = read_team_checkpoint(Path(project_dir))
+            self.assertEqual(result, "# Project Team")
+
+    def test_falls_back_to_none_when_dir_missing(self):
+        result = read_team_checkpoint(Path("/nonexistent/dir"))
+        # Should not raise, just return None (falls through to global check)
+        # Global checkpoint may or may not exist, but shouldn't crash
+
+
+class TestCmdPostCompact(unittest.TestCase):
+
+    @patch("cozempic.team.read_team_checkpoint")
+    @patch("cozempic.session.find_current_session")
+    def test_outputs_recovery_when_checkpoint_exists(self, mock_session, mock_read):
+        from cozempic.cli import cmd_post_compact
+        import argparse
+
+        mock_session.return_value = {
+            "path": Path("/fake/project/session.jsonl"),
+            "session_id": "test-123",
+        }
+        mock_read.return_value = "# Team State\nTeam: recovery-test"
+
+        args = argparse.Namespace(cwd=None)
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            cmd_post_compact(args)
+        finally:
+            sys.stdout = sys.__stdout__
+
+        self.assertIn("Team: recovery-test", captured.getvalue())
+
+    @patch("cozempic.team.read_team_checkpoint")
+    @patch("cozempic.session.find_current_session")
+    def test_silent_when_no_checkpoint(self, mock_session, mock_read):
+        from cozempic.cli import cmd_post_compact
+        import argparse
+
+        mock_session.return_value = {
+            "path": Path("/fake/project/session.jsonl"),
+            "session_id": "test-123",
+        }
+        mock_read.return_value = None
+
+        args = argparse.Namespace(cwd=None)
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            cmd_post_compact(args)
+        finally:
+            sys.stdout = sys.__stdout__
+
+        self.assertEqual(captured.getvalue(), "")
+
+
+class TestInitHooksIncludePostCompact(unittest.TestCase):
+
+    def test_post_compact_in_cozempic_hooks(self):
+        self.assertIn("PostCompact", COZEMPIC_HOOKS)
+
+    def test_post_compact_hook_command_correct(self):
+        entries = COZEMPIC_HOOKS["PostCompact"]
+        self.assertEqual(len(entries), 1)
+
+        hooks = entries[0]["hooks"]
+        self.assertEqual(len(hooks), 1)
+
+        command = hooks[0]["command"]
+        self.assertIn("cozempic post-compact", command)
+
+    def test_pre_compact_still_exists(self):
+        """Ensure PreCompact wasn't accidentally removed."""
+        self.assertIn("PreCompact", COZEMPIC_HOOKS)
+
+    def test_all_expected_hooks_present(self):
+        """Verify all expected hook events are defined."""
+        expected = {"SessionStart", "PostToolUse", "PreCompact", "PostCompact", "Stop"}
+        self.assertEqual(expected, set(COZEMPIC_HOOKS.keys()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the gap between `PreCompact` (saves state) and post-compaction (state lost). After Claude Code's native compaction, team coordination context (teammates, tasks, subagents) is discarded. The existing `PreCompact` hook saves `team-checkpoint.md` to disk, but nothing re-injects it after compaction completes.

This PR adds a `PostCompact` hook that reads the saved checkpoint and outputs it to stdout — Claude sees it immediately in conversation, no rules or manual intervention needed.

### Recovery flow

```
Context grows → Claude native compaction triggers
  ↓
PreCompact hook: cozempic checkpoint → team-checkpoint.md saved to disk
  ↓
Claude compacts (context compressed, prior messages summarized)
  ↓
PostCompact hook: cozempic post-compact → reads team-checkpoint.md
  ↓ Outputs to stdout → Claude sees team state immediately
  ↓
Claude has full team coordination context without relying on rules
```

### Changes

- **`team.py`**: Add `read_team_checkpoint()` — reads checkpoint from disk (safer than re-scanning compacted JSONL)
- **`cli.py`**: Add `post-compact` subcommand — outputs recovery context to stdout. Silent when no checkpoint exists (solo sessions)
- **`init.py`**: Add `PostCompact` entry to `COZEMPIC_HOOKS` registry
- **`doctor.py`**: Add `check_cozempic_hooks()` health check — warns when expected hooks (SessionStart, PreCompact, PostCompact, Stop) are missing
- **`README.md`**: Update hook tables, JSON example, and protection layers summary
- **`cozempic_slash_command.md`**: Document PostCompact in guard mode section
- **`tests/test_post_compact.py`**: 12 new tests covering read, CLI, and hook config

### Why from disk, not JSONL?

After native compaction, the JSONL is modified/compressed. The `team-checkpoint.md` was saved by `PreCompact` *before* compaction — reading from disk is the reliable source.

### Backward compatible

- Solo sessions (no agent teams): `post-compact` is silent — zero noise
- Existing hooks untouched — PostCompact is additive
- Users with old configs can run `cozempic init` to wire the new hook

## Test plan

- [x] 101/101 tests pass (12 new + 89 existing)
- [x] `cozempic checkpoint && cozempic post-compact` → outputs team state
- [x] `cozempic post-compact` with no checkpoint → silent (exit 0)
- [x] Manual: verify `cozempic init` wires PostCompact hook
- [x] Manual: verify `cozempic doctor` reports missing PostCompact