### PR TITLE
fix: add SIGTERM handler and periodic backup cleanup to guard daemon

### DIFF
--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -275,6 +275,15 @@ def start_guard(
         )
         watcher_thread.start()
 
+    # Graceful shutdown on SIGTERM
+    def _graceful_shutdown(signum, frame):
+        print(f"\n  [{_now()}] Signal {signum} received — final checkpoint...")
+        checkpoint_team(session_path=session_path, quiet=False)
+        if overflow_watcher:
+            overflow_watcher.stop()
+        sys.exit(0)
+    signal.signal(signal.SIGTERM, _graceful_shutdown)
+
     # Claude process watchdog — detect exit even if Stop hook doesn't fire (#29767)
     claude_pid = find_claude_pid()
     claude_alive = True
@@ -282,12 +291,18 @@ def start_guard(
     prune_count = 0
     soft_prune_count = 0
     checkpoint_count = 0
+    cycle_count = 0
     last_team_hash = ""
     consecutive_empty_hard_prunes = 0
 
     try:
         while True:
             time.sleep(interval)
+            cycle_count += 1
+
+            # Periodic backup cleanup every 10 cycles (~5min)
+            if cycle_count % 10 == 0:
+                cleanup_old_backups(session_path, keep=3)
 
             # Re-check file exists
             if not session_path.exists():

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -1,0 +1,20 @@
+"""Tests for guard daemon robustness improvements."""
+import unittest
+
+
+class TestGuardSignalHandling(unittest.TestCase):
+    def test_sigterm_constant_exists(self):
+        """SIGTERM is available on this platform."""
+        import signal
+        self.assertTrue(hasattr(signal, 'SIGTERM'))
+
+
+class TestBackupCleanupIntegration(unittest.TestCase):
+    def test_cleanup_old_backups_importable(self):
+        """cleanup_old_backups can be imported from session module."""
+        from cozempic.session import cleanup_old_backups
+        self.assertTrue(callable(cleanup_old_backups))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Improve guard daemon resilience with graceful signal handling and periodic backup cleanup.

## Changes

- **SIGTERM handler**: Register signal handler after overflow watcher creation. On SIGTERM, performs final team checkpoint, stops watcher, and exits cleanly. SIGINT/KeyboardInterrupt handling unchanged.
- **Periodic backup cleanup**: Add cycle counter to guard main loop. Every 10 cycles (~5min at 30s interval), runs `cleanup_old_backups(keep=3)` to prevent backup file accumulation when prune cycles fail to free space.

## Test plan
- [x] All existing tests pass
- [x] Manual: `kill -TERM <guard_pid>` triggers checkpoint before exit
- [x] Manual: backup files cleaned up after 10 cycles