### PR TITLE
fix: add JSONL line size limit and CLI arg validation

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -762,19 +762,43 @@ def _prescan_argv(argv: list[str]) -> list[str]:
             continue
         if sub_seen:
             if tok == "--context-window" and i + 1 < len(argv):
-                os.environ["COZEMPIC_CONTEXT_WINDOW"] = argv[i + 1]
+                val = argv[i + 1]
+                try:
+                    if int(val) <= 0:
+                        raise ValueError
+                    os.environ["COZEMPIC_CONTEXT_WINDOW"] = val
+                except ValueError:
+                    print(f"Warning: ignoring invalid --context-window '{val}'", file=sys.stderr)
                 i += 2
                 continue
             if tok.startswith("--context-window="):
-                os.environ["COZEMPIC_CONTEXT_WINDOW"] = tok.split("=", 1)[1]
+                val = tok.split("=", 1)[1]
+                try:
+                    if int(val) <= 0:
+                        raise ValueError
+                    os.environ["COZEMPIC_CONTEXT_WINDOW"] = val
+                except ValueError:
+                    print(f"Warning: ignoring invalid --context-window '{val}'", file=sys.stderr)
                 i += 1
                 continue
             if tok == "--system-overhead-tokens" and i + 1 < len(argv):
-                os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = argv[i + 1]
+                val = argv[i + 1]
+                try:
+                    if int(val) <= 0:
+                        raise ValueError
+                    os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = val
+                except ValueError:
+                    print(f"Warning: ignoring invalid --system-overhead-tokens '{val}'", file=sys.stderr)
                 i += 2
                 continue
             if tok.startswith("--system-overhead-tokens="):
-                os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = tok.split("=", 1)[1]
+                val = tok.split("=", 1)[1]
+                try:
+                    if int(val) <= 0:
+                        raise ValueError
+                    os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = val
+                except ValueError:
+                    print(f"Warning: ignoring invalid --system-overhead-tokens '{val}'", file=sys.stderr)
                 i += 1
                 continue
         cleaned.append(tok)

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -237,6 +237,9 @@ def resolve_session(session_arg: str, project_filter: str | None = None) -> Path
     sys.exit(1)
 
 
+MAX_LINE_BYTES = 10 * 1024 * 1024  # 10MB per-line safety limit
+
+
 def load_messages(path: Path) -> list[Message]:
     """Load JSONL file. Returns list of (line_index, message_dict, byte_size)."""
     messages: list[Message] = []
@@ -244,6 +247,9 @@ def load_messages(path: Path) -> list[Message]:
         for i, line in enumerate(f):
             line = line.strip()
             if not line:
+                continue
+            if len(line) > MAX_LINE_BYTES:
+                print(f"  Warning: skipping oversized line {i} ({len(line)} bytes)", file=sys.stderr)
                 continue
             try:
                 msg = json.loads(line)

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,0 +1,61 @@
+"""Tests for CLI argument validation (BMAD R4-12)."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from cozempic.cli import _prescan_argv
+
+
+class TestPrescanArgvValidation:
+    def test_invalid_context_window_ignored(self):
+        """Non-numeric --context-window is ignored with a warning."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+            _prescan_argv(["treat", "current", "--context-window", "abc"])
+            assert "COZEMPIC_CONTEXT_WINDOW" not in os.environ
+
+    def test_negative_context_window_ignored(self):
+        """Negative --context-window is ignored."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+            _prescan_argv(["treat", "current", "--context-window", "-500"])
+            assert "COZEMPIC_CONTEXT_WINDOW" not in os.environ
+
+    def test_zero_context_window_ignored(self):
+        """Zero --context-window is ignored."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+            _prescan_argv(["treat", "current", "--context-window", "0"])
+            assert "COZEMPIC_CONTEXT_WINDOW" not in os.environ
+
+    def test_valid_context_window_set(self):
+        """Valid positive --context-window is accepted."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+            _prescan_argv(["treat", "current", "--context-window", "1000000"])
+            assert os.environ["COZEMPIC_CONTEXT_WINDOW"] == "1000000"
+            os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+
+    def test_invalid_system_overhead_tokens_ignored(self):
+        """Non-numeric --system-overhead-tokens is ignored."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", None)
+            _prescan_argv(["treat", "current", "--system-overhead-tokens", "xyz"])
+            assert "COZEMPIC_SYSTEM_OVERHEAD_TOKENS" not in os.environ
+
+    def test_valid_system_overhead_tokens_set(self):
+        """Valid positive --system-overhead-tokens is accepted."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", None)
+            _prescan_argv(["treat", "current", "--system-overhead-tokens", "25000"])
+            assert os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] == "25000"
+            os.environ.pop("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", None)
+
+    def test_invalid_context_window_equals_form_ignored(self):
+        """--context-window=abc (equals form) is ignored."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+            _prescan_argv(["treat", "current", "--context-window=notanumber"])
+            assert "COZEMPIC_CONTEXT_WINDOW" not in os.environ

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
+
 from pathlib import Path
 from unittest.mock import patch
 
-from cozempic.session import get_claude_dir, get_claude_json_path
+from cozempic.session import MAX_LINE_BYTES, get_claude_dir, get_claude_json_path, load_messages
 
 
 class TestGetClaudeDir:
@@ -31,3 +33,28 @@ class TestGetClaudeJsonPath:
         """Default .claude.json is at ~/.claude.json, not ~/.claude/.claude.json."""
         with patch.dict("os.environ", {}, clear=True):
             assert get_claude_json_path() != get_claude_dir() / ".claude.json"
+
+
+class TestLoadMessagesLimits:
+    def test_skips_oversized_lines(self, tmp_path):
+        """Lines exceeding MAX_LINE_BYTES are silently skipped."""
+        jsonl = tmp_path / "test.jsonl"
+        normal = json.dumps({"role": "user", "content": "hello"})
+        oversized = json.dumps({"role": "user", "content": "x" * (MAX_LINE_BYTES + 1)})
+        jsonl.write_text(normal + "\n" + oversized + "\n")
+        messages = load_messages(jsonl)
+        assert len(messages) == 1
+        assert messages[0][1]["content"] == "hello"
+
+    def test_normal_lines_unaffected(self, tmp_path):
+        """Normal-sized lines parse correctly."""
+        jsonl = tmp_path / "test.jsonl"
+        lines = [
+            json.dumps({"role": "user", "content": "first"}),
+            json.dumps({"role": "assistant", "content": "second"}),
+        ]
+        jsonl.write_text("\n".join(lines) + "\n")
+        messages = load_messages(jsonl)
+        assert len(messages) == 2
+        assert messages[0][1]["content"] == "first"
+        assert messages[1][1]["content"] == "second"


### PR DESCRIPTION
## Summary

Add safety limits to prevent memory issues from oversized JSONL lines and validate CLI arguments.

## Changes

- **`session.py`**: Add `MAX_LINE_BYTES = 10MB` per-line safety limit in `load_messages()`. Lines exceeding this limit are skipped to prevent unbounded memory consumption from malformed or corrupted session data.
- **`tests/test_session.py`**: Tests for oversized line skipping and normal line parsing
- **`tests/test_cli_validation.py`**: Tests for CLI argument validation (--context-window, --system-overhead-tokens)

## Test plan
- [x] All 104 tests pass
- [x] Oversized JSONL lines are skipped gracefully
- [x] Normal lines unaffected by size limit
- [x] Invalid CLI args produce warning and are ignored