### PR TITLE
fix: token total formula missing output_tokens from last turn

### DIFF
--- a/src/cozempic/tokens.py
+++ b/src/cozempic/tokens.py
@@ -239,8 +239,8 @@ def extract_usage_tokens(messages: list[Message]) -> dict | None:
         cache_create = usage.get("cache_creation_input_tokens", 0)
         cache_read = usage.get("cache_read_input_tokens", 0)
 
-        # The cumulative context size is the sum of all input components
-        total = input_tok + cache_create + cache_read
+        # The cumulative context size is the sum of all input components plus the last output
+        total = input_tok + cache_create + cache_read + output_tok
 
         return {
             "input_tokens": input_tok,
@@ -422,9 +422,10 @@ def quick_token_estimate(path: Path, context_window: int = DEFAULT_CONTEXT_WINDO
                 continue
 
             input_tok = usage.get("input_tokens", 0)
+            output_tok = usage.get("output_tokens", 0)
             cache_create = usage.get("cache_creation_input_tokens", 0)
             cache_read = usage.get("cache_read_input_tokens", 0)
-            return input_tok + cache_create + cache_read
+            return input_tok + cache_create + cache_read + output_tok
 
     except (OSError, UnicodeDecodeError):
         pass


### PR DESCRIPTION
## Description

Corrects the token calculation in `extract_usage_tokens()` and `quick_token_estimate()` to include `output_tokens` from the last assistant turn, matching the formula used in Claude Code.

## Changes

- Updated `extract_usage_tokens()` to include `output_tokens` in `total`.
- Updated `quick_token_estimate()` to include `output_tokens` in the final return value.

Fixes #36