### PR TITLE
fix: include output_tokens in token total calculation

### DIFF
--- a/src/cozempic/tokens.py
+++ b/src/cozempic/tokens.py
@@ -240,7 +240,8 @@ def extract_usage_tokens(messages: list[Message]) -> dict | None:
         cache_read = usage.get("cache_read_input_tokens", 0)
 
         # The cumulative context size is the sum of all input components
-        total = input_tok + cache_create + cache_read
+        # plus the output tokens from the last turn.
+        total = input_tok + cache_create + cache_read + output_tok
 
         return {
             "input_tokens": input_tok,
@@ -424,7 +425,8 @@ def quick_token_estimate(path: Path, context_window: int = DEFAULT_CONTEXT_WINDO
             input_tok = usage.get("input_tokens", 0)
             cache_create = usage.get("cache_creation_input_tokens", 0)
             cache_read = usage.get("cache_read_input_tokens", 0)
-            return input_tok + cache_create + cache_read
+            output_tok = usage.get("output_tokens", 0)
+            return input_tok + cache_create + cache_read + output_tok
 
     except (OSError, UnicodeDecodeError):
         pass


### PR DESCRIPTION
Updated `extract_usage_tokens` and `quick_token_estimate` to include `output_tokens` in the total token count calculation. This matches Claude Code's own formula (`input_tokens + cache_creation_input_tokens + cache_read_input_tokens + output_tokens`) and fixes an undercounting issue in context window estimation.

Fixes #36