### PR TITLE
Pass Claude PID into detached guard instead of guessing parent PID

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -582,6 +582,7 @@ def cmd_post_compact(args):
 def cmd_guard(args):
     """Start the guard daemon to prevent compaction-induced state loss."""
     session_id = args.session or None
+    claude_pid = args.claude_pid or find_claude_pid()
 
     if getattr(args, "system_overhead_tokens", None):
         os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = str(args.system_overhead_tokens)
@@ -598,6 +599,7 @@ def cmd_guard(args):
             threshold_tokens=args.threshold_tokens,
             soft_threshold_tokens=args.soft_threshold_tokens,
             session_id=session_id,
+            claude_pid=claude_pid,
         )
         if result["already_running"]:
             print(f"  Guard already running (PID {result['pid']})")
@@ -617,6 +619,7 @@ def cmd_guard(args):
         threshold_tokens=args.threshold_tokens,
         soft_threshold_tokens=args.soft_threshold_tokens,
         session_id=session_id,
+        claude_pid=claude_pid,
     )
 
 
@@ -983,6 +986,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_guard.add_argument("--no-reactive", action="store_true", help="Disable reactive overflow recovery (kqueue/polling watcher)")
     p_guard.add_argument("--daemon", action="store_true", help="Run in background (PID file prevents double-starts)")
     p_guard.add_argument("--session", help="Explicit session ID or path (bypasses auto-detection)")
+    p_guard.add_argument("--claude-pid", type=int, default=None, help=argparse.SUPPRESS)
     p_guard.add_argument("--system-overhead-tokens", type=int, default=None, help="Override system overhead token estimate (default: 21000). Increase for heavy configs with many rules files, MCP servers, or large CLAUDE.md")
 
     # init

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -214,6 +214,7 @@ def start_guard(
     threshold_tokens: int | None = None,
     soft_threshold_tokens: int | None = None,
     session_id: str | None = None,
+    claude_pid: int | None = None,
 ) -> None:
     """Start the guard daemon with tiered pruning.
 
@@ -327,6 +328,7 @@ def start_guard(
             session_path, sess["session_id"], cwd or os.getcwd(), breaker,
             danger_threshold_mb=danger_mb,
             danger_threshold_tokens=danger_tokens,
+            claude_pid=claude_pid,
         )
         overflow_watcher = JsonlWatcher(
             str(session_path), on_growth=recovery.on_file_growth,
@@ -345,8 +347,9 @@ def start_guard(
         sys.exit(0)
     signal.signal(signal.SIGTERM, _graceful_shutdown)
 
-    # Claude process watchdog — detect exit even if Stop hook doesn't fire (#29767)
-    claude_pid = find_claude_pid()
+    # Resolve Claude before daemonization or other reparenting can obscure it.
+    if claude_pid is None:
+        claude_pid = find_claude_pid()
     claude_alive = True
 
     prune_count = 0
@@ -547,6 +550,7 @@ def guard_prune_cycle(
     auto_reload: bool = True,
     cwd: str = "",
     session_id: str | None = None,
+    claude_pid: int | None = None,
 ) -> dict:
     """Execute a single guard prune cycle.
 
@@ -655,9 +659,9 @@ def guard_prune_cycle(
 
     # Trigger reload if configured — terminate Claude then auto-resume
     if auto_reload:
-        claude_pid = find_claude_pid()
-        if claude_pid:
-            _terminate_and_resume(claude_pid, cwd, session_id=session_id)
+        reload_pid = claude_pid if claude_pid is not None else find_claude_pid()
+        if reload_pid:
+            _terminate_and_resume(reload_pid, cwd, session_id=session_id)
             result["reloading"] = True
         else:
             resume_flag = f"--resume {session_id}" if session_id else "--resume"
@@ -975,6 +979,7 @@ def start_guard_daemon(
     threshold_tokens: int | None = None,
     soft_threshold_tokens: int | None = None,
     session_id: str | None = None,
+    claude_pid: int | None = None,
 ) -> dict:
     """Start the guard as a background daemon.
 
@@ -1027,6 +1032,9 @@ def start_guard_daemon(
     log_file = Path("/tmp") / f"cozempic_guard_{pid_key}.log"
     pid_path = Path("/tmp") / f"cozempic_guard_{pid_key}.pid"
 
+    if claude_pid is None:
+        claude_pid = find_claude_pid()
+
     # Build the guard command
     cmd_parts = [
         sys.executable, "-m", "cozempic.cli", "guard",
@@ -1047,6 +1055,8 @@ def start_guard_daemon(
         cmd_parts.extend(["--soft-threshold-tokens", str(soft_threshold_tokens)])
     if session_id is not None:
         cmd_parts.extend(["--session", _normalize_session_id(session_id)])
+    if claude_pid is not None:
+        cmd_parts.extend(["--claude-pid", str(claude_pid)])
 
     # Spawn detached process
     with open(log_file, "a", encoding="utf-8") as lf:

--- a/src/cozempic/overflow.py
+++ b/src/cozempic/overflow.py
@@ -115,6 +115,7 @@ class OverflowRecovery:
         breaker: CircuitBreaker,
         danger_threshold_mb: float = 90.0,
         danger_threshold_tokens: int | None = None,
+        claude_pid: int | None = None,
     ):
         self.session_path = session_path
         self.session_id = session_id
@@ -122,6 +123,7 @@ class OverflowRecovery:
         self.breaker = breaker
         self.danger_threshold_bytes = int(danger_threshold_mb * 1024 * 1024)
         self.danger_threshold_tokens = danger_threshold_tokens
+        self.claude_pid = claude_pid
         self._recovering = False  # Prevent re-entrant recovery
 
     def detect_overflow(self) -> bool:
@@ -250,7 +252,7 @@ class OverflowRecovery:
             )
 
         # 6. Terminate Claude + auto-resume
-        claude_pid = find_claude_pid()
+        claude_pid = self.claude_pid if self.claude_pid is not None else find_claude_pid()
         if claude_pid:
             _terminate_and_resume(claude_pid, self.cwd, session_id=self.session_id)
             print(

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -218,8 +218,6 @@ def project_slug_to_path(slug: str) -> str:
 
 def find_claude_pid() -> int | None:
     """Walk up the process tree to find the Claude Code node process."""
-    from .helpers import is_ssh_session
-
     try:
         pid = os.getpid()
         for _ in range(10):
@@ -238,13 +236,10 @@ def find_claude_pid() -> int | None:
                 break
     except (ValueError, OSError):
         pass
-    # Fallback: PPID is often Claude when invoked from within a session.
-    # Skip over SSH — PPID would be the SSH shell, not Claude.
-    if is_ssh_session():
-        return None
-    ppid = os.getppid()
-    if ppid > 1:
-        return ppid
+
+    # No Claude ancestor found. Do not fall back to the immediate parent PID:
+    # detached guards can be reparented under systemd --user, and treating that
+    # parent as Claude can terminate the whole desktop session on reload.
     return None
 
 

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -1,5 +1,8 @@
 """Tests for guard daemon robustness improvements."""
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 
 class TestGuardSignalHandling(unittest.TestCase):
@@ -14,6 +17,42 @@ class TestBackupCleanupIntegration(unittest.TestCase):
         """cleanup_old_backups can be imported from session module."""
         from cozempic.session import cleanup_old_backups
         self.assertTrue(callable(cleanup_old_backups))
+
+
+class TestGuardDaemonPidHandoff(unittest.TestCase):
+    def test_start_guard_daemon_passes_explicit_claude_pid_to_child(self):
+        from cozempic.guard import start_guard_daemon
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_log = Path("/tmp/cozempic_guard_test-session.log")
+            session_pid = Path("/tmp/cozempic_guard_test-session.pid")
+            captured = {}
+
+            class DummyProc:
+                pid = 4242
+
+            def fake_popen(cmd_parts, **kwargs):
+                captured["cmd_parts"] = cmd_parts
+                return DummyProc()
+
+            with (
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard.find_claude_pid", return_value=9999),
+                patch("cozempic.guard.subprocess.Popen", side_effect=fake_popen),
+            ):
+                result = start_guard_daemon(
+                    cwd=tmpdir,
+                    session_id="test-session",
+                    threshold_tokens=123,
+                )
+
+            self.assertTrue(result["started"])
+            self.assertIn("--claude-pid", captured["cmd_parts"])
+            self.assertIn("9999", captured["cmd_parts"])
+
+            session_log.unlink(missing_ok=True)
+            session_pid.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -208,6 +208,36 @@ class TestOverflowDetection(unittest.TestCase):
         finally:
             breaker.reset()
 
+    def test_recovery_uses_explicit_claude_pid(self):
+        breaker = CircuitBreaker(session_id="test-explicit-pid", max_recoveries=3)
+        breaker.reset()
+        try:
+            self._write_lines([json.dumps({"type": "user", "message": "hello"})])
+            recovery = OverflowRecovery(
+                self.session_path,
+                "test-explicit-pid",
+                self.tmpdir,
+                breaker,
+                danger_threshold_mb=100.0,
+                claude_pid=7777,
+            )
+
+            with (
+                patch.object(recovery, "detect_overflow", return_value=True),
+                patch("cozempic.guard.guard_prune_cycle", return_value={
+                    "saved_mb": 1.0,
+                    "original_tokens": 1000,
+                    "final_tokens": 500,
+                }),
+                patch("cozempic.guard._terminate_and_resume") as mock_reload,
+                patch("cozempic.session.find_claude_pid", return_value=None),
+            ):
+                recovery.recover()
+
+            mock_reload.assert_called_once_with(7777, self.tmpdir, session_id="test-explicit-pid")
+        finally:
+            breaker.reset()
+
 
 class TestJsonlWatcher(unittest.TestCase):
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 from pathlib import Path
 from unittest.mock import patch
 
-from cozempic.session import MAX_LINE_BYTES, get_claude_dir, get_claude_json_path, load_messages
+from cozempic.session import (
+    MAX_LINE_BYTES,
+    find_claude_pid,
+    get_claude_dir,
+    get_claude_json_path,
+    load_messages,
+)
 
 
 class TestGetClaudeDir:
@@ -58,3 +65,31 @@ class TestLoadMessagesLimits:
         assert len(messages) == 2
         assert messages[0][1]["content"] == "first"
         assert messages[1][1]["content"] == "second"
+
+
+class TestFindClaudePid:
+    def test_finds_claude_process_in_ancestor_chain(self):
+        with (
+            patch("cozempic.session.os.getpid", return_value=400),
+            patch(
+                "cozempic.session.subprocess.run",
+                side_effect=[
+                    SimpleNamespace(stdout="300 python\n"),
+                    SimpleNamespace(stdout="200 node\n"),
+                ],
+            ),
+        ):
+            assert find_claude_pid() == 300
+
+    def test_returns_none_when_detached_guard_parent_is_systemd(self):
+        with (
+            patch("cozempic.session.os.getpid", return_value=400),
+            patch(
+                "cozempic.session.subprocess.run",
+                side_effect=[
+                    SimpleNamespace(stdout="300 python\n"),
+                    SimpleNamespace(stdout="1 systemd\n"),
+                ],
+            ),
+        ):
+            assert find_claude_pid() is None


### PR DESCRIPTION
## What changed

- capture Claude's PID before the guard daemon detaches
- pass that PID into the detached `cozempic guard` process with an internal `--claude-pid` argument
- use the explicit PID for guard reload/watchdog and overflow recovery when available
- keep the existing process-tree discovery as a fallback when no explicit PID is available

## Why

This came out of debugging unexpected full session exits during guard-triggered reloads.

Tracing showed that, by the time the detached guard tried to reload, it was no longer necessarily parented by Claude. That means parent-process heuristics are unsafe in the daemon path: a detached guard can end up targeting the wrong process.

By capturing Claude's PID before daemonization and carrying it into the detached guard, reload behavior stays functional without depending on an ambiguous parent PID.

## Behavior

- normal detached guard reload keeps working when Claude's PID is known at startup
- overflow recovery uses the same explicit PID path
- if no explicit PID is available, the code still falls back to the existing Claude discovery logic
- if Claude still cannot be identified, the guard prunes without reloading rather than guessing an arbitrary process

## Tests

- add coverage that `start_guard_daemon()` passes `--claude-pid` into the child command
- add coverage that overflow recovery prefers the explicit Claude PID over rediscovery
- keep PID discovery coverage for the existing ancestor-walk behavior

Tested with:

```bash
env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_session.py tests/test_guard_robustness.py tests/test_overflow.py
```
