### PR TITLE
feat: add claude-opus-4-7 to model context window mapping

### DIFF
--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -703,7 +703,7 @@ def check_agent_model_mismatch() -> CheckResult:
     """Check for missing model config that breaks agent team inheritance.
 
     When Claude Code spawns subagents in agent teams, they may not inherit
-    the team lead's model, defaulting to claude-opus-4-6 and causing 403
+    the team lead's model, defaulting to claude-opus-4-7 and causing 403
     errors on custom or restricted endpoints.
 
     Ref: anthropics/claude-code#32368
@@ -738,7 +738,7 @@ def check_agent_model_mismatch() -> CheckResult:
             status="warning",
             message=(
                 f"Agent teams active ({len(team_dirs)} team(s)) but no ~/.claude/settings.json found. "
-                "Spawned subagents will default to claude-opus-4-6 regardless of ANTHROPIC_MODEL env var."
+                "Spawned subagents will default to claude-opus-4-7 regardless of ANTHROPIC_MODEL env var."
             ),
             fix_description='Create ~/.claude/settings.json with {"model": "your-model-id"} to ensure subagents inherit the correct model',
         )
@@ -759,9 +759,9 @@ def check_agent_model_mismatch() -> CheckResult:
             status="warning",
             message=(
                 f"Agent teams active ({len(team_dirs)} team(s)) but no model set in ~/.claude/settings.json. "
-                "Spawned subagents may default to claude-opus-4-6 causing 403 errors on restricted endpoints."
+                "Spawned subagents may default to claude-opus-4-7 causing 403 errors on restricted endpoints."
             ),
-            fix_description='Add "model": "claude-opus-4-6" to ~/.claude/settings.json to ensure subagents inherit the correct model',
+            fix_description='Add "model": "claude-opus-4-7" to ~/.claude/settings.json to ensure subagents inherit the correct model',
         )
 
     return CheckResult(

--- a/src/cozempic/tokens.py
+++ b/src/cozempic/tokens.py
@@ -69,11 +69,12 @@ def default_token_thresholds_4tier(context_window: int = DEFAULT_CONTEXT_WINDOW)
 
 # Model → context window mapping
 # Claude Code does NOT append "[1m]" to model IDs in the JSONL — the model
-# field always contains the base ID (e.g., "claude-opus-4-6"). 1M context is
+# field always contains the base ID (e.g., "claude-opus-4-7"). 1M context is
 # the standard for current models on Max plans, so we default 4.5/4.6 to 1M.
 # Users on Pro (200K) can override with COZEMPIC_CONTEXT_WINDOW=200000.
 MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     # Current models — default 1M (standard for Claude Code Max plans)
+    "claude-opus-4-7": 1_000_000,
     "claude-opus-4-6": 1_000_000,
     "claude-opus-4-5": 1_000_000,
     "claude-sonnet-4-6": 1_000_000,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -315,12 +315,12 @@ class TestAgentModelMismatch(unittest.TestCase):
     def test_teams_with_model_in_settings_is_ok(self):
         (self.claude_dir / "teams" / "my-team").mkdir(parents=True)
         (self.claude_dir / "settings.json").write_text(
-            json.dumps({"model": "claude-opus-4-6"})
+            json.dumps({"model": "claude-opus-4-7"})
         )
         with patch("cozempic.doctor.get_claude_dir", return_value=self.claude_dir):
             result = check_agent_model_mismatch()
         self.assertEqual(result.status, "ok")
-        self.assertIn("claude-opus-4-6", result.message)
+        self.assertIn("claude-opus-4-7", result.message)
 
     def test_teams_without_model_in_settings_is_warning(self):
         (self.claude_dir / "teams" / "my-team").mkdir(parents=True)

--- a/tests/test_model_detection.py
+++ b/tests/test_model_detection.py
@@ -79,6 +79,11 @@ class TestDetectModel(unittest.TestCase):
 
 class TestDetectContextWindow(unittest.TestCase):
 
+    def test_opus_47_is_1m(self):
+        """Current Opus 4.7 defaults to 1M (standard for Claude Code Max)."""
+        messages = [make_assistant_with_model(0, "claude-opus-4-7")]
+        self.assertEqual(detect_context_window(messages), 1_000_000)
+
     def test_opus_46_is_1m(self):
         """Current Opus 4.6 defaults to 1M (standard for Claude Code Max)."""
         messages = [make_assistant_with_model(0, "claude-opus-4-6")]
@@ -109,6 +114,11 @@ class TestDetectContextWindow(unittest.TestCase):
         self.assertEqual(detect_context_window(messages), DEFAULT_CONTEXT_WINDOW)
 
     def test_prefix_match_versioned(self):
+        """Versioned model IDs like claude-opus-4-7-20260401 should match."""
+        messages = [make_assistant_with_model(0, "claude-opus-4-7-20260401")]
+        self.assertEqual(detect_context_window(messages), 1_000_000)
+
+    def test_prefix_match_versioned_46(self):
         """Versioned model IDs like claude-opus-4-6-20260301 should match."""
         messages = [make_assistant_with_model(0, "claude-opus-4-6-20260301")]
         self.assertEqual(detect_context_window(messages), 1_000_000)


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-7` (1M context) to `MODEL_CONTEXT_WINDOWS` in `tokens.py`
- Update `doctor.py` diagnostic messages to reference Opus 4.7 as current default
- Add test coverage for Opus 4.7 detection and prefix matching

Opus 4.7 released 2026-04-16. Added alongside existing models — not replacing, since 4.6 is still served.

## Test plan
- [x] Existing tests pass (4 pre-existing failures unrelated to this change)
- [x] New `test_opus_47_is_1m` passes
- [x] New `test_prefix_match_versioned` for 4.7 passes
- [x] Doctor test updated for 4.7 model reference