### PR TITLE
feat: doctor — add stale-tmp-artifacts check + auto-fix

### DIFF
--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from .session import find_sessions, get_claude_dir, get_claude_json_path
 
 
+# Directory where cozempic writes runtime artifacts (.pid / .log / .lock files).
+# Exposed as a module-level constant so tests can redirect it to a tmpdir
+# without monkeypatching every glob call. Always points at POSIX /tmp today;
+# a future Windows port would swap this for tempfile.gettempdir().
+_TMP_DIR = Path("/tmp")
+
+
 @dataclass
 class CheckResult:
     """Result of a single health check."""
@@ -211,6 +218,224 @@ def check_disk_usage() -> CheckResult:
         message=f"{len(sessions)} sessions using {total / 1024 / 1024:.1f}MB total",
         fix_description="Run: cozempic treat <session> -rx standard --execute" if status != "ok" else None,
     )
+
+
+# ─── stale-tmp-artifacts ─────────────────────────────────────────────────────
+# When a guard daemon exits (crash, `kill -9`, reboot) without going through
+# its normal shutdown path, it leaves behind a /tmp/cozempic_guard_*.pid file,
+# a paired /tmp/cozempic_guard_*.log, and — if the crash happened while a
+# SessionStart hook was running — a /tmp/cozempic_hook_*.lock.
+#
+# Existing cleanup is lazy and per-session: `_is_guard_running_for_session`
+# (guard.py:947) only unlinks a stale .pid when a *new* guard for the SAME
+# session starts. Crashed sessions that never resume leave the artifact
+# forever. Across weeks this accumulates: a real user system was observed
+# with 20 .pid files (19 stale), 96 .log files, and 89 orphan .lock files.
+# This check surfaces and (with --fix) cleans them.
+
+# Files we must NEVER touch: intentionally-persistent global append logs
+# (guard.py:890,904 and cli.py:541,552) and the circuit-breaker state file
+# (overflow.py:41) which is designed to survive daemon restarts.
+_PROTECTED_TMP_NAMES = frozenset({
+    "cozempic_guard.log",
+    "cozempic_reload.log",
+})
+_PROTECTED_TMP_PREFIXES = ("cozempic_breaker_",)
+
+
+def _is_protected_tmp_artifact(name: str) -> bool:
+    """True if the file is an intentionally-persistent global artifact."""
+    if name in _PROTECTED_TMP_NAMES:
+        return True
+    return any(name.startswith(p) for p in _PROTECTED_TMP_PREFIXES)
+
+
+def _is_live_guard_pid(pid: int) -> bool:
+    """Return True when `pid` is both alive AND a cozempic guard process.
+
+    Delegates process-argv verification to the canonical helper in guard.py
+    (`_is_cozempic_guard_process`) so PID-reuse defense stays in one place.
+    """
+    import os as _os
+
+    try:
+        _os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    from .guard import _is_cozempic_guard_process
+    return _is_cozempic_guard_process(pid)
+
+
+def _is_lock_held(lock_path: Path) -> bool:
+    """Return True if a POSIX flock is currently held on `lock_path`.
+
+    Uses a non-blocking LOCK_EX trylock: if acquisition succeeds the lock
+    was orphaned (holder crashed or exited), so we release immediately and
+    report it as not-held. If the trylock fails with EAGAIN/EWOULDBLOCK
+    another process is still holding it and the file must be preserved.
+    On platforms without fcntl (e.g., Windows) conservatively report True
+    so we never delete a file whose lock status we cannot verify.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        return True
+    try:
+        fd = open(lock_path, "a+")
+    except OSError:
+        # Can't open — leave the file alone.
+        return True
+    try:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, OSError):
+            return True
+        # Acquired — lock was orphaned. Release before returning.
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        return False
+    finally:
+        fd.close()
+
+
+def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path]]:
+    """Scan `_TMP_DIR` and partition cozempic artifacts into three buckets:
+    stale .pid/.log files, orphan .lock files, and kept files (unused here
+    but isolates the pure-IO from the status/message logic).
+
+    Never returns a file listed in `_is_protected_tmp_artifact`.
+    """
+    stale_pids: list[Path] = []
+    orphan_logs: list[Path] = []
+    orphan_locks: list[Path] = []
+
+    live_slugs: set[str] = set()
+    pid_files: list[Path] = []
+
+    try:
+        entries = list(_TMP_DIR.glob("cozempic_guard_*.pid"))
+    except OSError:
+        entries = []
+
+    for pid_path in entries:
+        if _is_protected_tmp_artifact(pid_path.name):
+            continue
+        slug = pid_path.stem[len("cozempic_guard_"):]  # strip prefix, keep before .pid
+        try:
+            pid = int(pid_path.read_text().strip())
+        except (OSError, ValueError):
+            stale_pids.append(pid_path)
+            continue
+        if _is_live_guard_pid(pid):
+            live_slugs.add(slug)
+        else:
+            stale_pids.append(pid_path)
+        pid_files.append(pid_path)
+
+    pid_slugs = {p.stem[len("cozempic_guard_"):] for p in pid_files}
+
+    try:
+        log_entries = list(_TMP_DIR.glob("cozempic_guard_*.log"))
+    except OSError:
+        log_entries = []
+    for log_path in log_entries:
+        if _is_protected_tmp_artifact(log_path.name):
+            continue
+        slug = log_path.stem[len("cozempic_guard_"):]
+        if slug in live_slugs:
+            continue  # paired with a live guard
+        if slug in pid_slugs:
+            orphan_logs.append(log_path)  # paired with a stale .pid — delete together
+        else:
+            orphan_logs.append(log_path)  # no pid file at all — orphan
+
+    try:
+        lock_entries = list(_TMP_DIR.glob("cozempic_hook_*.lock"))
+    except OSError:
+        lock_entries = []
+    for lock_path in lock_entries:
+        if _is_protected_tmp_artifact(lock_path.name):
+            continue
+        if not _is_lock_held(lock_path):
+            orphan_locks.append(lock_path)
+
+    return stale_pids, orphan_logs, orphan_locks
+
+
+def check_stale_tmp_artifacts() -> CheckResult:
+    """Detect accumulated cozempic runtime artifacts left behind by crashed
+    or abnormally-terminated guard daemons.
+
+    Surfaces three classes of artifact:
+      - stale /tmp/cozempic_guard_*.pid files whose PID is dead or not a
+        cozempic guard (PID-reuse safe via `_is_cozempic_guard_process`)
+      - /tmp/cozempic_guard_*.log files with no matching live guard
+      - /tmp/cozempic_hook_*.lock files not currently held by any flock
+
+    Global append-only files (cozempic_guard.log, cozempic_reload.log) and
+    the circuit-breaker state file (cozempic_breaker_*.json) are ignored —
+    those are intentionally persistent.
+    """
+    stale_pids, orphan_logs, orphan_locks = _classify_tmp_artifacts()
+    total = len(stale_pids) + len(orphan_logs) + len(orphan_locks)
+
+    if total == 0:
+        return CheckResult(
+            name="stale-tmp-artifacts",
+            status="ok",
+            message="No stale cozempic artifacts in /tmp/",
+        )
+
+    # Size aggregate — helps surface the "96 log files" case.
+    size_bytes = 0
+    for path in (*stale_pids, *orphan_logs, *orphan_locks):
+        try:
+            size_bytes += path.stat().st_size
+        except OSError:
+            pass
+
+    # Graduated severity: a handful is usually a crashed session or two,
+    # ten or more points at a recurring failure mode worth surfacing.
+    status = "issue" if total >= 10 else "warning"
+    parts = []
+    if stale_pids:
+        parts.append(f"{len(stale_pids)} stale .pid file(s)")
+    if orphan_logs:
+        parts.append(f"{len(orphan_logs)} orphan .log file(s)")
+    if orphan_locks:
+        parts.append(f"{len(orphan_locks)} orphan .lock file(s)")
+    detail = ", ".join(parts)
+
+    return CheckResult(
+        name="stale-tmp-artifacts",
+        status=status,
+        message=f"{detail} ({size_bytes / 1024:.0f}KB)",
+        fix_description=(
+            "Delete artifacts whose owning guard/hook is no longer running "
+            "(preserves live PIDs and held locks)"
+        ),
+    )
+
+
+def fix_stale_tmp_artifacts() -> str:
+    """Delete stale .pid, orphan .log, and orphan .lock files.
+
+    Re-classifies artifacts at fix time (the set may have changed since the
+    check ran) so a guard that went live between check and fix is protected.
+    Every unlink uses `missing_ok=True` to tolerate races with concurrent
+    cleanup from `_is_guard_running_for_session`.
+    """
+    stale_pids, orphan_logs, orphan_locks = _classify_tmp_artifacts()
+    deleted = 0
+    for path in (*stale_pids, *orphan_logs, *orphan_locks):
+        try:
+            path.unlink(missing_ok=True)
+            deleted += 1
+        except OSError:
+            pass
+    return f"Deleted {deleted} stale artifact(s)"
 
 
 def check_corrupted_tool_use() -> CheckResult:
@@ -1046,6 +1271,7 @@ ALL_CHECKS: list[tuple[str, callable, callable | None]] = [
     ("agent-model-mismatch", check_agent_model_mismatch, None),
     ("oversized-sessions", check_oversized_sessions, None),
     ("stale-backups", check_stale_backups, fix_stale_backups),
+    ("stale-tmp-artifacts", check_stale_tmp_artifacts, fix_stale_tmp_artifacts),
     ("disk-usage", check_disk_usage, None),
 ]
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -15,9 +15,11 @@ from cozempic.doctor import (
     check_corrupted_tool_use,
     check_hooks_trust_flag,
     check_orphaned_tool_results,
+    check_stale_tmp_artifacts,
     check_zombie_teams,
     fix_claude_json_corruption,
     fix_hooks_trust_flag,
+    fix_stale_tmp_artifacts,
 )
 
 
@@ -334,6 +336,146 @@ class TestAgentModelMismatch(unittest.TestCase):
         with patch("cozempic.doctor.get_claude_dir", return_value=self.claude_dir):
             result = check_agent_model_mismatch()
         self.assertEqual(result.status, "warning")
+
+
+class TestStaleTmpArtifacts(unittest.TestCase):
+    """stale-tmp-artifacts check must detect dead-PID .pid files, their paired
+    .log files, and orphaned hook .lock files — without ever deleting anything
+    still in use (live guard PID or held flock)."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        # patch the /tmp directory used by the check so we stay isolated
+        self._patcher = patch("cozempic.doctor._TMP_DIR", self.tmpdir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_pid_file(self, slug: str, pid: int) -> Path:
+        p = self.tmpdir / f"cozempic_guard_{slug}.pid"
+        p.write_text(str(pid))
+        return p
+
+    def _make_log_file(self, slug: str, content: str = "log\n") -> Path:
+        p = self.tmpdir / f"cozempic_guard_{slug}.log"
+        p.write_text(content)
+        return p
+
+    def _make_lock_file(self, slug: str) -> Path:
+        p = self.tmpdir / f"cozempic_hook_{slug}.lock"
+        p.write_text("")
+        return p
+
+    # ── check: detection ──────────────────────────────────────────────────────
+    def test_no_artifacts_is_ok(self):
+        result = check_stale_tmp_artifacts()
+        self.assertEqual(result.status, "ok")
+
+    def test_live_guard_is_not_stale(self):
+        """A .pid file pointing to a live cozempic guard + its paired .log
+        must not be flagged."""
+        live_pid = 42
+        self._make_pid_file("livesess-12", live_pid)
+        self._make_log_file("livesess-12")
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=True):
+            result = check_stale_tmp_artifacts()
+        self.assertEqual(result.status, "ok")
+
+    def test_dead_pid_file_is_stale(self):
+        """A .pid file whose PID is no longer a running cozempic guard is stale."""
+        self._make_pid_file("deadsess-01", 999999)
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=False):
+            result = check_stale_tmp_artifacts()
+        self.assertIn(result.status, ("warning", "issue"))
+        self.assertIn("pid", result.message.lower())
+
+    def test_orphan_log_without_pid_is_stale(self):
+        """A .log file with no matching .pid file is an orphan."""
+        self._make_log_file("orphanlog-03")
+        result = check_stale_tmp_artifacts()
+        self.assertIn(result.status, ("warning", "issue"))
+        self.assertIn("log", result.message.lower())
+
+    def test_orphan_lock_is_stale_when_not_held(self):
+        """A .lock file that can be acquired with LOCK_EX|LOCK_NB is orphaned."""
+        self._make_lock_file("oldhook-05")
+        with patch("cozempic.doctor._is_lock_held", return_value=False):
+            result = check_stale_tmp_artifacts()
+        self.assertIn(result.status, ("warning", "issue"))
+        self.assertIn("lock", result.message.lower())
+
+    def test_held_lock_is_not_stale(self):
+        """A .lock file currently held by another process must be preserved."""
+        self._make_lock_file("activehook-06")
+        with patch("cozempic.doctor._is_lock_held", return_value=True):
+            result = check_stale_tmp_artifacts()
+        self.assertEqual(result.status, "ok")
+
+    def test_garbage_pid_content_is_treated_as_stale(self):
+        """Non-integer .pid file content must not crash — treat as stale."""
+        pid_path = self.tmpdir / "cozempic_guard_badcontent-07.pid"
+        pid_path.write_text("not-an-integer")
+        result = check_stale_tmp_artifacts()
+        self.assertIn(result.status, ("warning", "issue"))
+
+    def test_threshold_escalation_to_issue(self):
+        """Many stale artifacts escalate status from warning to issue."""
+        for i in range(15):
+            self._make_pid_file(f"stale{i:02d}-x", 999900 + i)
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=False):
+            result = check_stale_tmp_artifacts()
+        self.assertEqual(result.status, "issue")
+
+    def test_protected_globals_are_never_reported(self):
+        """Global append-only files (breaker state, cozempic_guard.log,
+        cozempic_reload.log) must NEVER be flagged — they are intentional."""
+        (self.tmpdir / "cozempic_guard.log").write_text("global log")
+        (self.tmpdir / "cozempic_reload.log").write_text("reload log")
+        (self.tmpdir / "cozempic_breaker_abc123.json").write_text("{}")
+        result = check_stale_tmp_artifacts()
+        self.assertEqual(result.status, "ok")
+
+    # ── fix: deletion safety ──────────────────────────────────────────────────
+    def test_fix_deletes_stale_pid_and_paired_log(self):
+        self._make_pid_file("deadsess-10", 999999)
+        log_path = self._make_log_file("deadsess-10")
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=False):
+            msg = fix_stale_tmp_artifacts()
+        self.assertFalse((self.tmpdir / "cozempic_guard_deadsess-10.pid").exists())
+        self.assertFalse(log_path.exists())
+        self.assertIn("2", msg)  # reports 2 files deleted
+
+    def test_fix_preserves_live_guard_files(self):
+        pid_path = self._make_pid_file("livesess-20", 42)
+        log_path = self._make_log_file("livesess-20")
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=True):
+            fix_stale_tmp_artifacts()
+        self.assertTrue(pid_path.exists())
+        self.assertTrue(log_path.exists())
+
+    def test_fix_preserves_held_locks(self):
+        lock_path = self._make_lock_file("activehook-21")
+        with patch("cozempic.doctor._is_lock_held", return_value=True):
+            fix_stale_tmp_artifacts()
+        self.assertTrue(lock_path.exists())
+
+    def test_fix_preserves_global_files(self):
+        guard_log = self.tmpdir / "cozempic_guard.log"
+        guard_log.write_text("global")
+        breaker = self.tmpdir / "cozempic_breaker_xyz.json"
+        breaker.write_text("{}")
+        fix_stale_tmp_artifacts()
+        self.assertTrue(guard_log.exists())
+        self.assertTrue(breaker.exists())
+
+    def test_fix_is_idempotent(self):
+        """Running fix twice on empty /tmp returns a sensible message."""
+        msg1 = fix_stale_tmp_artifacts()
+        msg2 = fix_stale_tmp_artifacts()
+        self.assertIn("0", msg1)
+        self.assertIn("0", msg2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a new `doctor` health check + auto-fix that surfaces and (with `--fix`) cleans accumulated cozempic runtime artifacts in `/tmp/`. Addresses the "more diagnostic checks" contribution area called out in #76 by @junaidtitan.

## Problem

Guard daemons that exit abnormally (crash, `kill -9`, reboot) leave behind:
- `/tmp/cozempic_guard_<slug>.pid` — dead PID file
- `/tmp/cozempic_guard_<slug>.log` — paired log
- `/tmp/cozempic_hook_<slug>.lock` — orphan flock from a SessionStart hook

Existing cleanup (`_is_guard_running_for_session` in `guard.py:947`) is lazy and per-session: it only unlinks a stale `.pid` when a **new** guard for the **same** session starts. Crashed sessions that never resume leave the artifact forever. Across weeks this accumulates.

**Real-world measurement on one user's Mac** (4 days uptime):

| Artifact | Count | Notes |
|---|---:|---|
| `.pid` files | 20 | 19 stale (PIDs dead) |
| `.log` files | 96 | 95 orphan (no matching live guard) |
| `.lock` files | 89 | 0 held, all orphan |
| **Total** | **205** | **~5.4 MB**, persisting for days |

## The check

`stale-tmp-artifacts` produces a single `CheckResult` aggregating:
- stale `.pid` files (dead PID OR PID reused by non-cozempic process — uses existing `_is_cozempic_guard_process` for PID-reuse defense)
- orphan `.log` files with no matching live guard
- `.lock` files not currently held (non-blocking `fcntl.LOCK_EX` trylock)

Severity: `ok` (0) → `warning` (1-9) → `issue` (10+).

**Never touches** protected global append-only artifacts:
- `/tmp/cozempic_guard.log` (guard.py:890, 904)
- `/tmp/cozempic_reload.log` (cli.py:541, 552)
- `/tmp/cozempic_breaker_*.json` (overflow.py:41 — circuit-breaker state, intentionally persistent)

## The fix

`fix_stale_tmp_artifacts()`:
- Re-classifies at fix time (a guard may have gone live since the check ran — always protected)
- Uses `missing_ok=True` for race-tolerance with concurrent `_is_guard_running_for_session` cleanup
- Returns a count of deleted files

## Safety invariants

- **PID reuse** → `_is_cozempic_guard_process(pid)` (strict argv match against `cozempic.cli guard`) prevents `kill`-ing or deleting the `.pid` of a stranger process that reused the PID.
- **Held locks** → non-blocking `LOCK_EX` trylock; if acquired, immediately `LOCK_UN` released and file reported as orphan; if fails, file preserved. On platforms without `fcntl` (hypothetical future Windows port) conservatively reports held.
- **Globals** → `_PROTECTED_TMP_NAMES` + `_PROTECTED_TMP_PREFIXES` allowlist filter runs before every consideration.

## Platform scope

POSIX only — matches current `/tmp/` hardcoding throughout `guard.py`, `cli.py`, and `hooks.json`. A `_TMP_DIR` module-level constant is introduced to make future Windows portability a one-line change (swap to `tempfile.gettempdir()`) without changing any call sites.

## Tests

14 new tests in `tests/test_doctor.py::TestStaleTmpArtifacts`:

**Detection:**
- `test_no_artifacts_is_ok`
- `test_live_guard_is_not_stale` — `.pid` + paired `.log` for a live guard ⇒ not flagged
- `test_dead_pid_file_is_stale`
- `test_orphan_log_without_pid_is_stale`
- `test_orphan_lock_is_stale_when_not_held`
- `test_held_lock_is_not_stale`
- `test_garbage_pid_content_is_treated_as_stale`
- `test_threshold_escalation_to_issue` — 10+ artifacts escalate
- `test_protected_globals_are_never_reported` — `cozempic_guard.log`, `cozempic_reload.log`, `cozempic_breaker_*.json` never flagged

**Fix safety:**
- `test_fix_deletes_stale_pid_and_paired_log`
- `test_fix_preserves_live_guard_files`
- `test_fix_preserves_held_locks`
- `test_fix_preserves_global_files`
- `test_fix_is_idempotent`

All 14 green; the 43 existing doctor tests still green; 6 unrelated pre-existing failures in `test_tokens.py` / `test_model_detection.py` are not touched by this PR.

## Live smoke test

On the system with 205 stale artifacts:

```
✗ stale-tmp-artifacts       [ISSUE]
  19 stale .pid file(s), 95 orphan .log file(s), 89 orphan .lock file(s) (5556KB)
  Fix: Delete artifacts whose owning guard/hook is no longer running (preserves live PIDs and held locks)
```

After `fix_stale_tmp_artifacts()`:
- 203 files deleted
- The one live guard's `.pid` and `.log` preserved (verified `ps -p 51461`, file still present)
- 0 orphan locks remain
- Global logs (if they had existed) untouched

## Files changed

- `src/cozempic/doctor.py` — +226 lines: `_TMP_DIR`, `_PROTECTED_TMP_NAMES`, `_PROTECTED_TMP_PREFIXES`, `_is_protected_tmp_artifact`, `_is_live_guard_pid`, `_is_lock_held`, `_classify_tmp_artifacts`, `check_stale_tmp_artifacts`, `fix_stale_tmp_artifacts`, registered in `ALL_CHECKS`
- `tests/test_doctor.py` — +142 lines: `TestStaleTmpArtifacts` (14 tests)

No changes to `guard.py`, `init.py`, `cli.py`. No new dependencies.

## Test plan

- [x] Unit tests (14 new, all green)
- [x] Existing doctor tests still green (43/43)
- [x] Live CLI smoke test: `cozempic doctor` shows the check
- [x] Live fix smoke test: 203 artifacts removed, live guard preserved
- [x] No new dependencies added
- [x] Protected globals never deleted (unit + live)
- [x] PID-reuse defense delegated to existing canonical helper