### PR TITLE
feat: strategies — centralize config validation with helpful errors

### DIFF
--- a/src/cozempic/strategies/_config.py
+++ b/src/cozempic/strategies/_config.py
@@ -1,0 +1,103 @@
+"""Shared config-validation helpers for strategy functions.
+
+Every strategy that reads tuning knobs from the per-session config dict goes
+through one of the helpers below so invalid values (wrong type, out-of-range,
+swapped ordering) surface a single well-formed ConfigError at invocation
+time rather than:
+
+  - a cryptic TypeError deep in a comparison loop
+    (e.g. `'>=' not supported between instances of 'int' and 'str'`)
+  - a silent no-op that nonetheless "runs successfully" and wastes a prune
+    cycle, or worse, produces destructive behavior (e.g. negative age
+    thresholds marking every tool result "old" and stubbing everything)
+
+Keeping validation in one module also avoids duplicating error strings
+across strategies and makes the user-facing message format consistent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ConfigError(ValueError):
+    """Raised when a strategy config value is missing a required invariant.
+
+    Subclasses ValueError so callers that already catch ValueError (e.g. the
+    executor's outer wrapper) keep working, but type-checking machinery and
+    humans reading tracebacks see the specific name.
+    """
+
+
+def _is_strict_int(value: Any) -> bool:
+    """Strict int check: rejects bool (True/False are ints in Python) and float.
+
+    YAML parsers in particular will turn `yes`/`no` into booleans, and users
+    occasionally write `8192.0` in a JSON config. Both are almost never what
+    was meant when the field expects a byte/line count.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def coerce_non_negative_int(config: dict, key: str, default: int) -> int:
+    """Return `config[key]` as a non-negative int, or `default` if key absent.
+
+    Raises `ConfigError` if the value is present but the wrong type or sign.
+    """
+    if key not in config:
+        return default
+    value = config[key]
+    if not _is_strict_int(value):
+        raise ConfigError(
+            f"config[{key!r}] must be an int, got {type(value).__name__} {value!r}"
+        )
+    if value < 0:
+        raise ConfigError(
+            f"config[{key!r}] must be non-negative, got {value}"
+        )
+    return value
+
+
+def coerce_choice(config: dict, key: str, choices: tuple[str, ...], default: str) -> str:
+    """Return `config[key]` if it matches one of `choices`, else `default`.
+
+    Raises `ConfigError` when the value is present but not a recognized
+    choice. Error message lists the accepted values so the user can
+    self-correct without reading the source.
+    """
+    if key not in config:
+        return default
+    value = config[key]
+    if not isinstance(value, str):
+        raise ConfigError(
+            f"config[{key!r}] must be a string, got {type(value).__name__} {value!r}"
+        )
+    if value not in choices:
+        raise ConfigError(
+            f"config[{key!r}]={value!r} is not one of {list(choices)}"
+        )
+    return value
+
+
+def coerce_ordered_pair(
+    config: dict,
+    low_key: str,
+    high_key: str,
+    defaults: tuple[int, int],
+) -> tuple[int, int]:
+    """Return `(config[low_key], config[high_key])` with the invariant
+    `low < high` enforced. Missing keys fall back to `defaults`.
+
+    Raises `ConfigError` if either value is the wrong type, negative, or
+    if `low >= high`. Swapped pairs are the canonical source of silent
+    misconfiguration (e.g. `tool_result_mid_age=50, tool_result_old_age=30`
+    collapses the "recent" tier and marks every tool result as `old`).
+    """
+    low = coerce_non_negative_int(config, low_key, defaults[0])
+    high = coerce_non_negative_int(config, high_key, defaults[1])
+    if low >= high:
+        raise ConfigError(
+            f"config[{low_key!r}]={low} must be strictly less than "
+            f"config[{high_key!r}]={high}"
+        )
+    return low, high

--- a/src/cozempic/strategies/aggressive.py
+++ b/src/cozempic/strategies/aggressive.py
@@ -17,6 +17,7 @@ from ..helpers import (
 )
 from ..registry import strategy
 from ..types import Message, PruneAction, StrategyResult
+from ._config import coerce_non_negative_int
 
 
 @strategy("http-spam", "Collapse consecutive HTTP request/response messages", "aggressive", "0-2%")
@@ -248,7 +249,7 @@ def strategy_background_poll_collapse(messages: list[Message], config: dict) -> 
 @strategy("document-dedup", "Deduplicate large document blocks (CLAUDE.md injection)", "aggressive", "0-44%")
 def strategy_document_dedup(messages: list[Message], config: dict) -> StrategyResult:
     """Detect and deduplicate large text blocks that appear multiple times."""
-    min_block_size = config.get("document_dedup_min_bytes", 1024)
+    min_block_size = coerce_non_negative_int(config, "document_dedup_min_bytes", default=1024)
     actions: list[PruneAction] = []
     total_orig = sum(b for _, _, b in messages)
     total_pruned = 0
@@ -320,7 +321,7 @@ def strategy_document_dedup(messages: list[Message], config: dict) -> StrategyRe
 @strategy("mega-block-trim", "Trim any content block over 32KB", "aggressive", "safety net")
 def strategy_mega_block_trim(messages: list[Message], config: dict) -> StrategyResult:
     """Safety net: any single content block over 32KB gets truncated."""
-    max_block_bytes = config.get("mega_block_max_bytes", 32768)
+    max_block_bytes = coerce_non_negative_int(config, "mega_block_max_bytes", default=32768)
     actions: list[PruneAction] = []
     total_orig = sum(b for _, _, b in messages)
     total_pruned = 0

--- a/src/cozempic/strategies/standard.py
+++ b/src/cozempic/strategies/standard.py
@@ -9,6 +9,9 @@ import re
 from ..helpers import get_content_blocks, get_msg_type, is_protected, msg_bytes, set_content_blocks, text_of
 from ..registry import strategy
 from ..types import Message, PruneAction, StrategyResult
+from ._config import coerce_choice, coerce_non_negative_int, coerce_ordered_pair
+
+_THINKING_MODES: tuple[str, ...] = ("remove", "truncate", "signature-only")
 
 
 @strategy("thinking-blocks", "Truncate or remove thinking/signature blocks", "standard", "2-5%")
@@ -20,7 +23,7 @@ def strategy_thinking_blocks(messages: list[Message], config: dict) -> StrategyR
         'truncate'       - Keep first 200 chars of thinking
         'signature-only' - Only strip signature fields
     """
-    mode = config.get("thinking_mode", "remove")
+    mode = coerce_choice(config, "thinking_mode", _THINKING_MODES, default="remove")
     actions: list[PruneAction] = []
     total_orig = sum(b for _, _, b in messages)
     total_pruned = 0
@@ -92,8 +95,8 @@ def strategy_thinking_blocks(messages: list[Message], config: dict) -> StrategyR
 @strategy("tool-output-trim", "Trim large tool_result blocks (>8KB or >100 lines)", "standard", "1-8%")
 def strategy_tool_output_trim(messages: list[Message], config: dict) -> StrategyResult:
     """Trim oversized tool results while preserving structure."""
-    max_bytes = config.get("tool_output_max_bytes", 8192)
-    max_lines = config.get("tool_output_max_lines", 100)
+    max_bytes = coerce_non_negative_int(config, "tool_output_max_bytes", default=8192)
+    max_lines = coerce_non_negative_int(config, "tool_output_max_lines", default=100)
 
     actions: list[PruneAction] = []
     total_orig = sum(b for _, _, b in messages)
@@ -373,8 +376,9 @@ def strategy_tool_result_age(messages: list[Message], config: dict) -> StrategyR
     Research: JetBrains validated observation masking on SWE-bench — matched
     LLM summarization quality at zero compute cost.
     """
-    mid_age = config.get("tool_result_mid_age", 15)
-    old_age = config.get("tool_result_old_age", 40)
+    mid_age, old_age = coerce_ordered_pair(
+        config, "tool_result_mid_age", "tool_result_old_age", defaults=(15, 40)
+    )
 
     actions: list[PruneAction] = []
     total_orig = sum(b for _, _, b in messages)

--- a/tests/test_strategies_config.py
+++ b/tests/test_strategies_config.py
@@ -1,0 +1,195 @@
+"""Tests for strategies._config config-validation helpers + integration with strategies."""
+
+from __future__ import annotations
+
+import unittest
+
+from cozempic.strategies._config import (
+    coerce_choice,
+    coerce_non_negative_int,
+    coerce_ordered_pair,
+    ConfigError,
+)
+
+
+class TestCoerceNonNegativeInt(unittest.TestCase):
+    """Validation helper for integer-typed options like `tool_output_max_bytes`."""
+
+    def test_returns_default_when_key_absent(self):
+        result = coerce_non_negative_int({}, "max_bytes", default=8192)
+        self.assertEqual(result, 8192)
+
+    def test_returns_value_when_valid_int(self):
+        result = coerce_non_negative_int({"max_bytes": 4096}, "max_bytes", default=8192)
+        self.assertEqual(result, 4096)
+
+    def test_accepts_zero(self):
+        result = coerce_non_negative_int({"max_bytes": 0}, "max_bytes", default=10)
+        self.assertEqual(result, 0)
+
+    def test_rejects_negative(self):
+        with self.assertRaises(ConfigError) as ctx:
+            coerce_non_negative_int({"max_bytes": -1}, "max_bytes", default=10)
+        self.assertIn("max_bytes", str(ctx.exception))
+        self.assertIn("non-negative", str(ctx.exception))
+
+    def test_rejects_string(self):
+        with self.assertRaises(ConfigError) as ctx:
+            coerce_non_negative_int({"max_bytes": "4096"}, "max_bytes", default=10)
+        self.assertIn("max_bytes", str(ctx.exception))
+        self.assertIn("int", str(ctx.exception))
+
+    def test_rejects_float(self):
+        """4096.5 is not a valid integer — reject to surface config typos early."""
+        with self.assertRaises(ConfigError):
+            coerce_non_negative_int({"max_bytes": 4096.5}, "max_bytes", default=10)
+
+    def test_rejects_bool(self):
+        """Python-ism: True is an int. We reject bool to prevent accidental
+        YAML `max_bytes: yes` (parsed as True) from being treated as max_bytes=1."""
+        with self.assertRaises(ConfigError):
+            coerce_non_negative_int({"max_bytes": True}, "max_bytes", default=10)
+
+
+class TestCoerceChoice(unittest.TestCase):
+    """Validation helper for string-enum options like `thinking_mode`."""
+
+    _CHOICES = ("remove", "truncate", "signature-only")
+
+    def test_returns_default_when_key_absent(self):
+        result = coerce_choice({}, "mode", self._CHOICES, default="remove")
+        self.assertEqual(result, "remove")
+
+    def test_returns_value_when_in_choices(self):
+        result = coerce_choice({"mode": "truncate"}, "mode", self._CHOICES, default="remove")
+        self.assertEqual(result, "truncate")
+
+    def test_rejects_value_not_in_choices(self):
+        with self.assertRaises(ConfigError) as ctx:
+            coerce_choice({"mode": "bogus"}, "mode", self._CHOICES, default="remove")
+        msg = str(ctx.exception)
+        self.assertIn("mode", msg)
+        self.assertIn("bogus", msg)
+        # Error should list the valid choices so user can self-correct
+        self.assertIn("remove", msg)
+        self.assertIn("truncate", msg)
+
+    def test_rejects_non_string(self):
+        with self.assertRaises(ConfigError):
+            coerce_choice({"mode": 42}, "mode", self._CHOICES, default="remove")
+
+
+class TestCoerceOrderedPair(unittest.TestCase):
+    """Helper enforcing `min < max` invariants on related options
+    (e.g. `tool_result_mid_age` must be strictly less than `tool_result_old_age`)."""
+
+    def test_returns_defaults_when_both_absent(self):
+        lo, hi = coerce_ordered_pair({}, "mid", "old", defaults=(15, 40))
+        self.assertEqual((lo, hi), (15, 40))
+
+    def test_returns_values_when_valid(self):
+        lo, hi = coerce_ordered_pair({"mid": 10, "old": 30}, "mid", "old", defaults=(15, 40))
+        self.assertEqual((lo, hi), (10, 30))
+
+    def test_rejects_inverted(self):
+        """The canonical bug: user swaps values by mistake."""
+        with self.assertRaises(ConfigError) as ctx:
+            coerce_ordered_pair({"mid": 50, "old": 30}, "mid", "old", defaults=(15, 40))
+        msg = str(ctx.exception)
+        self.assertIn("mid", msg)
+        self.assertIn("old", msg)
+        self.assertIn("50", msg)
+        self.assertIn("30", msg)
+
+    def test_rejects_equal(self):
+        """Edge: equal values collapse the mid-age tier to nothing."""
+        with self.assertRaises(ConfigError):
+            coerce_ordered_pair({"mid": 20, "old": 20}, "mid", "old", defaults=(15, 40))
+
+    def test_rejects_negative(self):
+        with self.assertRaises(ConfigError):
+            coerce_ordered_pair({"mid": -1, "old": 10}, "mid", "old", defaults=(15, 40))
+
+    def test_rejects_non_int(self):
+        with self.assertRaises(ConfigError):
+            coerce_ordered_pair({"mid": "15", "old": 40}, "mid", "old", defaults=(15, 40))
+
+
+# ── Integration: strategies must raise ConfigError on bad input, not TypeError ──
+
+class TestStrategyConfigIntegration(unittest.TestCase):
+    """Each strategy using config must surface a helpful ConfigError on bad
+    values rather than a cryptic TypeError or silent no-op that destroys data."""
+
+    _SINGLE_USER_MSG = [(0, {"type": "user", "message": {"content": "hi"}}, 100)]
+
+    def _run(self, strategy_name: str, config: dict):
+        from cozempic.registry import STRATEGIES
+        import cozempic.strategies  # noqa: F401 — ensure registry populated
+        return STRATEGIES[strategy_name].func(self._SINGLE_USER_MSG, config)
+
+    # tool-output-trim
+    def test_tool_output_trim_rejects_string_max_bytes(self):
+        with self.assertRaises(ConfigError):
+            self._run("tool-output-trim", {"tool_output_max_bytes": "8192"})
+
+    def test_tool_output_trim_rejects_negative_max_bytes(self):
+        with self.assertRaises(ConfigError):
+            self._run("tool-output-trim", {"tool_output_max_bytes": -1})
+
+    # tool-result-age
+    def test_tool_result_age_rejects_inverted_ages(self):
+        with self.assertRaises(ConfigError):
+            self._run("tool-result-age", {"tool_result_mid_age": 50, "tool_result_old_age": 30})
+
+    def test_tool_result_age_rejects_string_mid_age(self):
+        with self.assertRaises(ConfigError):
+            self._run("tool-result-age", {"tool_result_mid_age": "15", "tool_result_old_age": 40})
+
+    def test_tool_result_age_rejects_negative_values(self):
+        with self.assertRaises(ConfigError):
+            self._run("tool-result-age", {"tool_result_mid_age": -5, "tool_result_old_age": -1})
+
+    # thinking-blocks
+    def test_thinking_blocks_rejects_unknown_mode(self):
+        with self.assertRaises(ConfigError):
+            self._run("thinking-blocks", {"thinking_mode": "bogus-mode"})
+
+    def test_thinking_blocks_rejects_non_string_mode(self):
+        with self.assertRaises(ConfigError):
+            self._run("thinking-blocks", {"thinking_mode": 42})
+
+    # document-dedup
+    def test_document_dedup_rejects_string_min_bytes(self):
+        with self.assertRaises(ConfigError):
+            self._run("document-dedup", {"document_dedup_min_bytes": "1024"})
+
+    # mega-block-trim
+    def test_mega_block_trim_rejects_string_max_bytes(self):
+        with self.assertRaises(ConfigError):
+            self._run("mega-block-trim", {"mega_block_max_bytes": "32768"})
+
+    def test_mega_block_trim_rejects_negative(self):
+        with self.assertRaises(ConfigError):
+            self._run("mega-block-trim", {"mega_block_max_bytes": -1})
+
+    # ── Backwards compatibility: valid configs still behave unchanged ──
+
+    def test_valid_tool_result_age_defaults_still_work(self):
+        """Default config (no keys set) must not regress — production uses this path."""
+        result = self._run("tool-result-age", {})
+        self.assertEqual(result.strategy_name, "tool-result-age")
+
+    def test_valid_thinking_blocks_default_mode(self):
+        result = self._run("thinking-blocks", {})
+        self.assertEqual(result.strategy_name, "thinking-blocks")
+
+    def test_valid_thinking_blocks_all_modes(self):
+        for mode in ("remove", "truncate", "signature-only"):
+            with self.subTest(mode=mode):
+                result = self._run("thinking-blocks", {"thinking_mode": mode})
+                self.assertEqual(result.strategy_name, "thinking-blocks")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a shared `strategies/_config.py` module with three small validation helpers, applied across the 5 config-reading pruning strategies. Surfaces misconfiguration as a clear `ConfigError` rather than a cryptic `TypeError`, a silent no-op, or — in the worst case — destructive behavior that looks like success.

Addresses the "strategy improvements / refinements" contribution area from #76.

## Problem — three silent pathologies today

Every config-driven strategy currently reads its knobs with bare `config.get(key, default)`. I audited every call site against real malformed configs and reproduced three failure modes:

### 1. Cryptic `TypeError` deep in a loop

`mega-block-trim` / `document-dedup` with a string value for a byte count:

```python
>>> STRATEGIES[\"mega-block-trim\"].func(msgs, {\"mega_block_max_bytes\": \"32768\"})
TypeError: '>' not supported between instances of 'int' and 'str'
    at src/cozempic/strategies/aggressive.py:343
```

The user has to read the strategy source to figure out that the config key was wrong.

### 2. Silent no-op that burns a prune cycle

`thinking-blocks` with a typo'd mode: `{\"thinking_mode\": \"truncateee\"}` → none of the three `if mode == ...` branches match → strategy runs to completion, reports 0B pruned. User never learns why their config had no effect.

### 3. Destructive behavior masquerading as success

`tool-result-age` with swapped values — `{\"tool_result_mid_age\": 50, \"tool_result_old_age\": 30}`:

- Current code: `if turns_ago < mid_age: skip; if turns_ago >= old_age: stub`
- With the swap: every tool result where `turns_ago >= 0` hits the `>= old_age=30` branch → gets replaced by a compact stub
- Output: \"Compacted N tool results\" — user thinks it worked. Actually, the session was just gutted.

Same pattern with negative values (reproduced locally: `mid=-5, old=-1` → every tool result marked old → session content destroyed).

## The fix

Three helpers in `cozempic/strategies/_config.py` (new file, 103 LOC):

| Helper | Guarantees |
|---|---|
| `coerce_non_negative_int(config, key, default)` | `int >= 0`, rejects `bool` (YAML `yes` → `True` → `1` would silently mean \"max_bytes=1\") and `float` |
| `coerce_choice(config, key, choices, default)` | `str in choices`, error message lists valid values |
| `coerce_ordered_pair(config, low_key, high_key, defaults)` | both non-negative ints, **enforces `low < high`** |

`ConfigError` subclasses `ValueError` — any existing `except ValueError` keeps catching it.

Applied to all 5 config-reading strategies:

| Strategy | File:Line | Change |
|---|---|---|
| thinking-blocks | standard.py:26 | `coerce_choice` with `(\"remove\", \"truncate\", \"signature-only\")` |
| tool-output-trim | standard.py:98-99 | `coerce_non_negative_int` × 2 |
| tool-result-age | standard.py:379-381 | `coerce_ordered_pair` |
| document-dedup | aggressive.py:252 | `coerce_non_negative_int` |
| mega-block-trim | aggressive.py:324 | `coerce_non_negative_int` |

## Safety & scope

- **No behavior change on valid configs** — identical path for everything that was already correct. The existing 360+ tests still pass unchanged.
- **No new dependencies.**
- **No public API change** — `ConfigError` is in `strategies/_config.py` (private module), strategies still have the same signature.
- Helper module is prefixed `_` (convention for internal modules in this codebase).

## Tests

30 new tests in `tests/test_strategies_config.py`, 3 classes:

**`TestCoerceNonNegativeInt`** (7 tests)
- returns default when key absent / returns value when valid / accepts zero
- rejects negative / string / float / bool (with explanatory test docstring about YAML `yes`)

**`TestCoerceChoice`** (4 tests)
- returns default / returns valid / rejects unknown value (message must list valid choices) / rejects non-string

**`TestCoerceOrderedPair`** (6 tests)
- defaults / valid / rejects inverted / rejects equal / rejects negative / rejects non-int

**`TestStrategyConfigIntegration`** (13 tests including 3 subtests)
- One ConfigError test per \"bad config\" scenario for each of the 5 strategies (tool-output-trim×2, tool-result-age×3, thinking-blocks×2, document-dedup×1, mega-block-trim×2)
- \"Backwards compat\" tests: default config still runs, every valid `thinking_mode` still runs

Suite status:
- New: **30/30 green + 3 subtests green**
- Existing doctor + strategies: **390/390 green**
- The 6 pre-existing `test_tokens.py` / `test_model_detection.py` failures on `main` are unchanged and not related to this PR.

## Live smoke test on real session

Ran against a 29K-message session in `~/.claude/projects/`:

```
[OK]   inverted ages: ConfigError raised
[OK]   string byte limit: ConfigError raised
[OK]   unknown thinking_mode: ConfigError raised
[OK]   string min_bytes: ConfigError raised
[OK]   tool-result-age default config: pruned=0B replaced=0
[OK]   tool-output-trim default config: pruned=23B replaced=23
[OK]   thinking-blocks default config: pruned=0B replaced=0
[OK]   document-dedup default config: pruned=0B replaced=0
[OK]   mega-block-trim default config: pruned=0B replaced=0
```

Bad configs fail loud, defaults work unchanged. `tool-output-trim` actually found 23 things to trim (the strategies are still active).

## Files changed

- `src/cozempic/strategies/_config.py` (new, 103 LOC)
- `src/cozempic/strategies/standard.py` (+8 -5 LOC — imports + 3 helper calls)
- `src/cozempic/strategies/aggressive.py` (+2 -2 LOC — imports + 2 helper calls)
- `tests/test_strategies_config.py` (new, 195 LOC)

## Test plan

- [x] 30 new unit + integration tests green
- [x] Full strategies + doctor suite unchanged (390 green)
- [x] Live smoke test on a real session JSONL: bad configs → ConfigError, valid configs behave exactly as before
- [x] No new dependencies
- [x] No public API change
- [x] `_config.py` is a prefixed private module (convention-consistent)