### PR TITLE
feat: harden numeric input validation across CLI flags + env vars

### DIFF
--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -1,0 +1,208 @@
+"""Shared validation helpers for user-supplied numeric input.
+
+Collects the cross-cutting helpers used by:
+  - strategy `config` dicts (originally introduced in strategies/_config.py,
+    PR #79) — now re-exported from here to avoid duplicating error strings,
+  - argparse CLI argument validators (via small wrappers in cli.py),
+  - environment-variable parsing in tokens.py.
+
+Design goals:
+
+  1. A single source of truth for the error-message shape, so the user sees
+     the same phrasing whether the bad value came from a config dict, a CLI
+     flag, or an env var.
+
+  2. ConfigError subclasses ValueError — callers that already catch
+     ValueError keep working; new code can catch the narrower exception.
+
+  3. Env-var helpers WARN rather than RAISE: an env var is ambient config
+     (often set once in a shell profile), and we don't want a daemon that
+     was running fine to crash on the next reload just because `$HOME`
+     carries a stale override. CLI args and in-process config dicts, in
+     contrast, raise — the call site is intentional and the user is there.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+
+class ConfigError(ValueError):
+    """Raised when a config value violates a required invariant.
+
+    Subclasses ValueError so callers that already catch ValueError (e.g.
+    the executor's outer wrapper) keep working, but type-checking
+    machinery and humans reading tracebacks see the specific name.
+    """
+
+
+# ── Type guards ────────────────────────────────────────────────────────────
+
+
+def _is_strict_int(value: Any) -> bool:
+    """Strict int check: rejects bool (True/False are ints in Python) and float.
+
+    YAML parsers in particular will turn `yes`/`no` into booleans, and users
+    occasionally write `8192.0` in a JSON config. Both are almost never what
+    was meant when the field expects a byte/line count.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_strict_number(value: Any) -> bool:
+    """Accept int or float for float-typed fields (e.g. MB thresholds).
+
+    Reject bool — same YAML concern as `_is_strict_int` — and reject anything
+    non-numeric. Users legitimately write `threshold=50` (int) expecting 50.0 MB,
+    so int is fine; but `True` or `"50"` are not.
+    """
+    if isinstance(value, bool):
+        return False
+    return isinstance(value, (int, float))
+
+
+# ── Config-dict helpers (shared across strategies + guard) ─────────────────
+
+
+def coerce_non_negative_int(config: dict, key: str, default: int) -> int:
+    """Return `config[key]` as a non-negative int, or `default` if key absent.
+
+    Raises `ConfigError` if the value is present but the wrong type or sign.
+    """
+    if key not in config:
+        return default
+    value = config[key]
+    if not _is_strict_int(value):
+        raise ConfigError(
+            f"config[{key!r}] must be an int, got {type(value).__name__} {value!r}"
+        )
+    if value < 0:
+        raise ConfigError(
+            f"config[{key!r}] must be non-negative, got {value}"
+        )
+    return value
+
+
+def coerce_positive_int(config: dict, key: str, default: int) -> int:
+    """Like `coerce_non_negative_int` but strict `> 0`.
+
+    Separate helper because zero is nonsensical for values like polling
+    intervals (would produce a spin loop) and context-window sizes
+    (would divide by zero downstream), whereas zero IS valid for values
+    like `system_overhead_tokens` (a session with no rules file).
+    """
+    if key not in config:
+        return default
+    value = config[key]
+    if not _is_strict_int(value):
+        raise ConfigError(
+            f"config[{key!r}] must be an int, got {type(value).__name__} {value!r}"
+        )
+    if value <= 0:
+        raise ConfigError(
+            f"config[{key!r}] must be positive, got {value}"
+        )
+    return value
+
+
+def coerce_positive_float(config: dict, key: str, default: float) -> float:
+    """Return `config[key]` as a strictly-positive float, or `default` if absent.
+
+    Accepts int in addition to float (users write `threshold=50`). Rejects
+    bool, str, None, negative, and zero.
+    """
+    if key not in config:
+        return default
+    value = config[key]
+    if not _is_strict_number(value):
+        raise ConfigError(
+            f"config[{key!r}] must be a number, got {type(value).__name__} {value!r}"
+        )
+    if value <= 0:
+        raise ConfigError(
+            f"config[{key!r}] must be positive, got {value}"
+        )
+    return float(value)
+
+
+def coerce_choice(config: dict, key: str, choices: tuple[str, ...], default: str) -> str:
+    """Return `config[key]` if it matches one of `choices`, else `default`.
+
+    Raises `ConfigError` when the value is present but not a recognized
+    choice. Error message lists the accepted values so the user can
+    self-correct without reading the source.
+    """
+    if key not in config:
+        return default
+    value = config[key]
+    if not isinstance(value, str):
+        raise ConfigError(
+            f"config[{key!r}] must be a string, got {type(value).__name__} {value!r}"
+        )
+    if value not in choices:
+        raise ConfigError(
+            f"config[{key!r}]={value!r} is not one of {list(choices)}"
+        )
+    return value
+
+
+# ── Environment-variable helpers (warn + fall back, never raise) ───────────
+
+
+def _env_warn(name: str, value: str, reason: str) -> None:
+    """Emit a single consistent warning line to stderr and continue.
+
+    Using bare stderr (not `logging`) matches the convention already used by
+    `cli._prescan_argv` for the same class of warning — users running
+    `cozempic ...` see the warning immediately above the command output
+    without having to configure a logging handler."""
+    print(
+        f"Warning: ignoring {name}={value!r} — {reason}",
+        file=sys.stderr,
+    )
+
+
+def parse_env_positive_int(name: str) -> int | None:
+    """Read env var `name`, parse as strictly-positive int, return None if
+    absent or invalid (after emitting a warning on stderr).
+
+    Used by `tokens.get_context_window_override` — a context window of 0 or
+    negative is nonsensical and would propagate into `pct = total / cw`
+    producing negative or divide-by-zero errors deep in diagnostics output.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        _env_warn(name, raw, "must be an integer")
+        return None
+    if value <= 0:
+        _env_warn(name, raw, "must be a positive integer")
+        return None
+    return value
+
+
+def parse_env_non_negative_int(name: str) -> int | None:
+    """Read env var, parse as non-negative int (0 OK), warn-and-fallback on
+    failure.
+
+    Used by `tokens.get_system_overhead_tokens` — `0` is a legitimate value
+    meaning "no system overhead in this session" (e.g. a user with no CLAUDE.md
+    and no MCP servers). Negatives and non-numerics are still rejected.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        _env_warn(name, raw, "must be an integer")
+        return None
+    if value < 0:
+        _env_warn(name, raw, "must be non-negative")
+        return None
+    return value

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -24,6 +24,38 @@ from .types import PrescriptionResult, StrategyResult
 # Ensure all strategies are registered
 import cozempic.strategies  # noqa: F401
 
+
+# ─── argparse type= validators ────────────────────────────────────────────
+# Kept inline (not a separate module) because they're tiny and argparse-specific.
+# Raise argparse.ArgumentTypeError so the error surfaces as a standard
+# argparse validation error — user sees "error: argument --threshold:
+# must be positive, got -1" with correct exit code 2.
+
+
+def _positive_int(val: str) -> int:
+    """argparse type= for strictly-positive ints. Used for --interval,
+    --threshold-tokens, and --soft-threshold-tokens where zero is
+    nonsensical (spin loops, always-trigger thresholds)."""
+    try:
+        n = int(val)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{val!r} is not a valid integer")
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"must be positive, got {n}")
+    return n
+
+
+def _positive_float(val: str) -> float:
+    """argparse type= for strictly-positive floats. Used for --threshold
+    and --soft-threshold (MB thresholds)."""
+    try:
+        f = float(val)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{val!r} is not a valid number")
+    if f <= 0:
+        raise argparse.ArgumentTypeError(f"must be positive, got {f}")
+    return f
+
 # Fix Windows stdout/stderr encoding for Unicode characters (box-drawing, emoji)
 if sys.platform == "win32":
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -1047,11 +1079,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_guard = sub.add_parser("guard", help="Background sentinel — auto-prune before compaction triggers")
     p_guard.add_argument("--cwd", help="Working directory (default: current)")
     p_guard.add_argument("-rx", help="Prescription to apply (default: standard)")
-    p_guard.add_argument("--threshold", type=float, default=50.0, help="Hard threshold in MB — full prune + reload (default: 50)")
-    p_guard.add_argument("--soft-threshold", type=float, default=None, help="Soft threshold in MB — gentle prune, no reload (default: 60%% of --threshold)")
-    p_guard.add_argument("--interval", type=int, default=30, help="Check interval in seconds (default: 30)")
-    p_guard.add_argument("--threshold-tokens", type=int, default=None, help="Hard threshold in tokens (default: 75%% of context window)")
-    p_guard.add_argument("--soft-threshold-tokens", type=int, default=None, help="Soft threshold in tokens (default: 45%% of context window)")
+    p_guard.add_argument("--threshold", type=_positive_float, default=50.0, help="Hard threshold in MB — full prune + reload (default: 50)")
+    p_guard.add_argument("--soft-threshold", type=_positive_float, default=None, help="Soft threshold in MB — gentle prune, no reload (default: 60%% of --threshold)")
+    p_guard.add_argument("--interval", type=_positive_int, default=30, help="Check interval in seconds (default: 30)")
+    p_guard.add_argument("--threshold-tokens", type=_positive_int, default=None, help="Hard threshold in tokens (default: 75%% of context window)")
+    p_guard.add_argument("--soft-threshold-tokens", type=_positive_int, default=None, help="Soft threshold in tokens (default: 45%% of context window)")
     p_guard.add_argument("--no-reload", action="store_true", help="Prune without auto-reload at hard threshold")
     p_guard.add_argument("--no-reactive", action="store_true", help="Disable reactive overflow recovery (kqueue/polling watcher)")
     p_guard.add_argument("--daemon", action="store_true", help="Run in background (PID file prevents double-starts)")
@@ -1083,7 +1115,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # remind
     p_remind = sub.add_parser("remind", help="Output active behavioral rules (for PostToolUse hook)")
-    p_remind.add_argument("--interval", type=int, default=25, help="Output every N tool calls (default: 25)")
+    p_remind.add_argument("--interval", type=_positive_int, default=25, help="Output every N tool calls (default: 25)")
 
     # digest
     p_digest = sub.add_parser("digest", help="Manage behavioral correction rules")

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -24,6 +24,7 @@ import sys
 import time
 from pathlib import Path
 
+from ._validation import ConfigError
 from .executor import run_prescription
 from .helpers import is_ssh_session, shell_quote
 from .registry import PRESCRIPTIONS
@@ -246,6 +247,38 @@ def start_guard(
         soft_threshold_tokens: Soft threshold in tokens (optional, checked alongside bytes).
         session_id: Explicit session ID to monitor (bypasses auto-detection).
     """
+    # Validate ordering invariants FIRST — a reload storm caused by a
+    # swapped soft/hard threshold is much worse than a clean upfront error.
+    # Argparse already rejects non-positive values, but direct Python callers
+    # (guard.start_guard(...)) bypass argparse, so belt-and-braces check.
+    if threshold_mb <= 0:
+        raise ConfigError(f"threshold_mb must be positive, got {threshold_mb}")
+    if soft_threshold_mb is not None and soft_threshold_mb <= 0:
+        raise ConfigError(f"soft_threshold_mb must be positive, got {soft_threshold_mb}")
+    if (
+        soft_threshold_mb is not None
+        and soft_threshold_mb >= threshold_mb
+    ):
+        raise ConfigError(
+            f"soft_threshold_mb={soft_threshold_mb} must be strictly less than "
+            f"threshold_mb={threshold_mb}"
+        )
+    if interval <= 0:
+        raise ConfigError(f"interval must be positive, got {interval}")
+    if threshold_tokens is not None and threshold_tokens <= 0:
+        raise ConfigError(f"threshold_tokens must be positive, got {threshold_tokens}")
+    if soft_threshold_tokens is not None and soft_threshold_tokens <= 0:
+        raise ConfigError(f"soft_threshold_tokens must be positive, got {soft_threshold_tokens}")
+    if (
+        threshold_tokens is not None
+        and soft_threshold_tokens is not None
+        and soft_threshold_tokens >= threshold_tokens
+    ):
+        raise ConfigError(
+            f"soft_threshold_tokens={soft_threshold_tokens} must be strictly less than "
+            f"threshold_tokens={threshold_tokens}"
+        )
+
     hard_threshold_bytes = int(threshold_mb * 1024 * 1024)
 
     if soft_threshold_mb is None:

--- a/src/cozempic/strategies/_config.py
+++ b/src/cozempic/strategies/_config.py
@@ -1,82 +1,35 @@
-"""Shared config-validation helpers for strategy functions.
+"""Strategy-specific config validation.
 
-Every strategy that reads tuning knobs from the per-session config dict goes
-through one of the helpers below so invalid values (wrong type, out-of-range,
-swapped ordering) surface a single well-formed ConfigError at invocation
-time rather than:
+Thin module that re-exports the generic helpers from `cozempic._validation`
+and adds `coerce_ordered_pair`, which is specific to strategy config dicts
+holding related age thresholds (e.g. `tool_result_mid_age` and
+`tool_result_old_age`).
 
-  - a cryptic TypeError deep in a comparison loop
-    (e.g. `'>=' not supported between instances of 'int' and 'str'`)
-  - a silent no-op that nonetheless "runs successfully" and wastes a prune
-    cycle, or worse, produces destructive behavior (e.g. negative age
-    thresholds marking every tool result "old" and stubbing everything)
-
-Keeping validation in one module also avoids duplicating error strings
-across strategies and makes the user-facing message format consistent.
+The generic helpers (`coerce_non_negative_int`, `coerce_choice`, `ConfigError`)
+were originally introduced here in PR #79 and later lifted to the root module
+so argparse validators and env-var parsers can reuse the same error-message
+shape. Existing strategy imports (`from ._config import coerce_non_negative_int`)
+continue to work unchanged via the re-exports below.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from .._validation import (
+    ConfigError,
+    coerce_choice,
+    coerce_non_negative_int,
+    coerce_positive_float,
+    coerce_positive_int,
+)
 
-
-class ConfigError(ValueError):
-    """Raised when a strategy config value is missing a required invariant.
-
-    Subclasses ValueError so callers that already catch ValueError (e.g. the
-    executor's outer wrapper) keep working, but type-checking machinery and
-    humans reading tracebacks see the specific name.
-    """
-
-
-def _is_strict_int(value: Any) -> bool:
-    """Strict int check: rejects bool (True/False are ints in Python) and float.
-
-    YAML parsers in particular will turn `yes`/`no` into booleans, and users
-    occasionally write `8192.0` in a JSON config. Both are almost never what
-    was meant when the field expects a byte/line count.
-    """
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
-def coerce_non_negative_int(config: dict, key: str, default: int) -> int:
-    """Return `config[key]` as a non-negative int, or `default` if key absent.
-
-    Raises `ConfigError` if the value is present but the wrong type or sign.
-    """
-    if key not in config:
-        return default
-    value = config[key]
-    if not _is_strict_int(value):
-        raise ConfigError(
-            f"config[{key!r}] must be an int, got {type(value).__name__} {value!r}"
-        )
-    if value < 0:
-        raise ConfigError(
-            f"config[{key!r}] must be non-negative, got {value}"
-        )
-    return value
-
-
-def coerce_choice(config: dict, key: str, choices: tuple[str, ...], default: str) -> str:
-    """Return `config[key]` if it matches one of `choices`, else `default`.
-
-    Raises `ConfigError` when the value is present but not a recognized
-    choice. Error message lists the accepted values so the user can
-    self-correct without reading the source.
-    """
-    if key not in config:
-        return default
-    value = config[key]
-    if not isinstance(value, str):
-        raise ConfigError(
-            f"config[{key!r}] must be a string, got {type(value).__name__} {value!r}"
-        )
-    if value not in choices:
-        raise ConfigError(
-            f"config[{key!r}]={value!r} is not one of {list(choices)}"
-        )
-    return value
+__all__ = [
+    "ConfigError",
+    "coerce_choice",
+    "coerce_non_negative_int",
+    "coerce_ordered_pair",
+    "coerce_positive_float",
+    "coerce_positive_int",
+]
 
 
 def coerce_ordered_pair(

--- a/src/cozempic/tokens.py
+++ b/src/cozempic/tokens.py
@@ -33,13 +33,10 @@ def get_system_overhead_tokens() -> int:
     conservative for lightweight sessions. Override with
     COZEMPIC_SYSTEM_OVERHEAD_TOKENS env var or --system-overhead-tokens flag.
     """
-    import os
-    val = os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS")
-    if val:
-        try:
-            return int(val)
-        except ValueError:
-            pass
+    from ._validation import parse_env_non_negative_int
+    override = parse_env_non_negative_int("COZEMPIC_SYSTEM_OVERHEAD_TOKENS")
+    if override is not None:
+        return override
     return SYSTEM_OVERHEAD_TOKENS
 
 
@@ -91,15 +88,16 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
 
 
 def get_context_window_override() -> int | None:
-    """Check for user override via COZEMPIC_CONTEXT_WINDOW env var."""
-    import os
-    val = os.environ.get("COZEMPIC_CONTEXT_WINDOW")
-    if val:
-        try:
-            return int(val)
-        except ValueError:
-            pass
-    return None
+    """Check for user override via COZEMPIC_CONTEXT_WINDOW env var.
+
+    Requires a strictly-positive integer. Zero previously hit the
+    `if val:` falsy-trap and was silently ignored; negative values
+    propagated into `context_pct = total / cw` producing negative
+    percentages. Both now emit a stderr warning and fall back to None
+    (triggering model-based detection at detect_context_window).
+    """
+    from ._validation import parse_env_positive_int
+    return parse_env_positive_int("COZEMPIC_CONTEXT_WINDOW")
 
 # Chars-per-token defaults (conservative)
 CHARS_PER_TOKEN_CODE = 3.5

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -61,6 +61,144 @@ class TestPrescanArgvValidation:
             assert "COZEMPIC_CONTEXT_WINDOW" not in os.environ
 
 
+class TestGuardArgparseValidation:
+    """`cozempic guard` numeric flags must reject nonsensical values at
+    parse time rather than silently triggering a reload storm or crashing
+    deep in `time.sleep(interval)` on the first cycle."""
+
+    def _parse(self, argv):
+        parser = build_parser()
+        return parser.parse_args(argv)
+
+    def _assert_argparse_rejects(self, argv, match_stderr=None):
+        import io
+        import contextlib
+        parser = build_parser()
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            try:
+                parser.parse_args(argv)
+            except SystemExit as e:
+                assert e.code == 2, f"expected exit code 2, got {e.code}"
+                if match_stderr:
+                    assert match_stderr in buf.getvalue(), (
+                        f"expected {match_stderr!r} in stderr, got: {buf.getvalue()!r}"
+                    )
+                return
+        raise AssertionError(f"argparse accepted {argv!r} but should have rejected")
+
+    def test_threshold_rejects_zero(self):
+        self._assert_argparse_rejects(
+            ["guard", "--threshold", "0"], match_stderr="positive"
+        )
+
+    def test_threshold_rejects_negative(self):
+        self._assert_argparse_rejects(
+            ["guard", "--threshold", "-1"], match_stderr="positive"
+        )
+
+    def test_threshold_rejects_non_numeric(self):
+        self._assert_argparse_rejects(["guard", "--threshold", "abc"])
+
+    def test_threshold_accepts_valid_float(self):
+        args = self._parse(["guard", "--threshold", "50.5"])
+        assert args.threshold == 50.5
+
+    def test_threshold_accepts_int(self):
+        """User may write `--threshold 50` (int) — accept."""
+        args = self._parse(["guard", "--threshold", "50"])
+        assert args.threshold == 50.0
+
+    def test_soft_threshold_rejects_zero(self):
+        self._assert_argparse_rejects(["guard", "--soft-threshold", "0"])
+
+    def test_soft_threshold_rejects_negative(self):
+        self._assert_argparse_rejects(["guard", "--soft-threshold", "-1"])
+
+    def test_interval_rejects_zero(self):
+        """interval=0 → spin loop (guard cycles with no pause)."""
+        self._assert_argparse_rejects(
+            ["guard", "--interval", "0"], match_stderr="positive"
+        )
+
+    def test_interval_rejects_negative(self):
+        """interval=-1 → ValueError from time.sleep(-1) mid-daemon."""
+        self._assert_argparse_rejects(["guard", "--interval", "-1"])
+
+    def test_interval_accepts_valid(self):
+        args = self._parse(["guard", "--interval", "30"])
+        assert args.interval == 30
+
+    def test_threshold_tokens_rejects_zero(self):
+        self._assert_argparse_rejects(["guard", "--threshold-tokens", "0"])
+
+    def test_threshold_tokens_rejects_negative(self):
+        self._assert_argparse_rejects(["guard", "--threshold-tokens", "-100"])
+
+    def test_soft_threshold_tokens_rejects_zero(self):
+        self._assert_argparse_rejects(["guard", "--soft-threshold-tokens", "0"])
+
+    def test_soft_threshold_tokens_rejects_negative(self):
+        self._assert_argparse_rejects(["guard", "--soft-threshold-tokens", "-1"])
+
+    def test_remind_interval_rejects_zero(self):
+        """Separate `--interval` on `cozempic remind` — same validation."""
+        self._assert_argparse_rejects(["remind", "--interval", "0"])
+
+    def test_remind_interval_rejects_negative(self):
+        self._assert_argparse_rejects(["remind", "--interval", "-5"])
+
+
+class TestStartGuardOrderingValidation:
+    """After argparse, soft thresholds may be resolved from defaults
+    (60% of threshold). The soft < hard invariant must hold at that point
+    too — checked inside start_guard, not just at argparse."""
+
+    def _call_start_guard(self, **kwargs):
+        from cozempic.guard import start_guard
+        return start_guard(**kwargs)
+
+    def test_soft_mb_equal_hard_mb_rejected(self):
+        from cozempic._validation import ConfigError
+        with self.assertRaisesLike(ConfigError, "strictly less"):
+            self._call_start_guard(
+                threshold_mb=50.0,
+                soft_threshold_mb=50.0,
+                cwd="/tmp/_cozempic_test_nonexistent_session",
+            )
+
+    def test_soft_mb_greater_than_hard_mb_rejected(self):
+        from cozempic._validation import ConfigError
+        with self.assertRaisesLike(ConfigError, "strictly less"):
+            self._call_start_guard(
+                threshold_mb=50.0,
+                soft_threshold_mb=100.0,
+                cwd="/tmp/_cozempic_test_nonexistent_session",
+            )
+
+    def test_soft_tokens_greater_than_threshold_tokens_rejected(self):
+        from cozempic._validation import ConfigError
+        with self.assertRaisesLike(ConfigError, "strictly less"):
+            self._call_start_guard(
+                threshold_mb=50.0,
+                threshold_tokens=10_000,
+                soft_threshold_tokens=20_000,
+                cwd="/tmp/_cozempic_test_nonexistent_session",
+            )
+
+    # pytest-style: contextmanager mimic
+    from contextlib import contextmanager
+
+    @contextmanager
+    def assertRaisesLike(self, exc_type, substr):
+        try:
+            yield
+        except exc_type as e:
+            assert substr in str(e), f"expected {substr!r} in {e!r}"
+            return
+        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
+
+
 class TestReloadSessionFlag:
     """Reload must accept --session as an escape hatch when auto-detect fails."""
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -445,5 +445,54 @@ class TestCalibrateRatio(unittest.TestCase):
         self.assertIsNone(ratio)
 
 
+class TestEnvVarOverrideValidation(unittest.TestCase):
+    """Env var override parsing must reject nonsensical values instead of
+    silently ignoring (previous falsy-trap bug with `if val:`) or propagating
+    them into token-math divisions producing negative percentages."""
+
+    def _get_window(self):
+        from cozempic.tokens import get_context_window_override
+        return get_context_window_override()
+
+    def _get_overhead(self):
+        from cozempic.tokens import get_system_overhead_tokens
+        return get_system_overhead_tokens()
+
+    def test_zero_context_window_was_falsy_trap_now_rejected(self):
+        """COZEMPIC_CONTEXT_WINDOW=0 was silently swallowed by the old
+        `if val:` check. Now returns None (plus a warning) so the caller
+        falls back to model-based detection."""
+        import os
+        from unittest.mock import patch
+        with patch.dict(os.environ, {"COZEMPIC_CONTEXT_WINDOW": "0"}):
+            self.assertIsNone(self._get_window())
+
+    def test_negative_context_window_rejected(self):
+        """Previously returned -100, producing context_pct=-110%."""
+        import os
+        from unittest.mock import patch
+        with patch.dict(os.environ, {"COZEMPIC_CONTEXT_WINDOW": "-100"}):
+            self.assertIsNone(self._get_window())
+
+    def test_valid_context_window_override(self):
+        import os
+        from unittest.mock import patch
+        with patch.dict(os.environ, {"COZEMPIC_CONTEXT_WINDOW": "200000"}):
+            self.assertEqual(self._get_window(), 200000)
+
+    def test_system_overhead_accepts_zero(self):
+        """0 is valid here — a session with no rules/MCP has no overhead."""
+        import os
+        from unittest.mock import patch
+        with patch.dict(os.environ, {"COZEMPIC_SYSTEM_OVERHEAD_TOKENS": "0"}):
+            self.assertEqual(self._get_overhead(), 0)
+
+    def test_system_overhead_rejects_negative(self):
+        import os
+        from unittest.mock import patch
+        with patch.dict(os.environ, {"COZEMPIC_SYSTEM_OVERHEAD_TOKENS": "-50"}):
+            self.assertEqual(self._get_overhead(), SYSTEM_OVERHEAD_TOKENS)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,184 @@
+"""Tests for cozempic._validation — generic helpers used by strategies, CLI,
+and env-var parsing."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from cozempic._validation import (
+    ConfigError,
+    coerce_choice,
+    coerce_non_negative_int,
+    coerce_positive_float,
+    coerce_positive_int,
+    parse_env_non_negative_int,
+    parse_env_positive_int,
+)
+
+
+class TestCoercePositiveInt(unittest.TestCase):
+    """Strict > 0. Distinct from coerce_non_negative_int (which allows 0)."""
+
+    def test_returns_default_when_absent(self):
+        self.assertEqual(coerce_positive_int({}, "k", default=30), 30)
+
+    def test_returns_value_when_positive(self):
+        self.assertEqual(coerce_positive_int({"k": 5}, "k", default=30), 5)
+
+    def test_rejects_zero(self):
+        with self.assertRaises(ConfigError) as ctx:
+            coerce_positive_int({"k": 0}, "k", default=30)
+        self.assertIn("positive", str(ctx.exception))
+
+    def test_rejects_negative(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_int({"k": -1}, "k", default=30)
+
+    def test_rejects_float(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_int({"k": 5.5}, "k", default=30)
+
+    def test_rejects_string(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_int({"k": "5"}, "k", default=30)
+
+    def test_rejects_bool(self):
+        """True is an int in Python but almost never intended here."""
+        with self.assertRaises(ConfigError):
+            coerce_positive_int({"k": True}, "k", default=30)
+
+
+class TestCoercePositiveFloat(unittest.TestCase):
+    """Strict > 0 for MB thresholds. Accepts int in addition to float."""
+
+    def test_returns_default_when_absent(self):
+        self.assertEqual(coerce_positive_float({}, "mb", default=50.0), 50.0)
+
+    def test_accepts_int(self):
+        """User writes threshold=50 (int) expecting 50.0 MB — must not reject."""
+        result = coerce_positive_float({"mb": 50}, "mb", default=10.0)
+        self.assertEqual(result, 50.0)
+        self.assertIsInstance(result, float)
+
+    def test_accepts_float(self):
+        self.assertEqual(coerce_positive_float({"mb": 50.5}, "mb", default=10.0), 50.5)
+
+    def test_rejects_zero(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": 0}, "mb", default=10.0)
+
+    def test_rejects_zero_float(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": 0.0}, "mb", default=10.0)
+
+    def test_rejects_negative(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": -1.0}, "mb", default=10.0)
+
+    def test_rejects_string(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": "50"}, "mb", default=10.0)
+
+    def test_rejects_bool(self):
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": True}, "mb", default=10.0)
+
+
+class TestParseEnvPositiveInt(unittest.TestCase):
+    """Env var helper: warn+fallback (does NOT raise). Used for
+    COZEMPIC_CONTEXT_WINDOW — zero would cause divide-by-zero downstream."""
+
+    def test_returns_none_when_unset(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TEST_ENV_POSINT", None)
+            self.assertIsNone(parse_env_positive_int("TEST_ENV_POSINT"))
+
+    def test_returns_none_when_empty(self):
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": ""}):
+            self.assertIsNone(parse_env_positive_int("TEST_ENV_POSINT"))
+
+    def test_returns_value_when_valid(self):
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": "1000000"}):
+            self.assertEqual(parse_env_positive_int("TEST_ENV_POSINT"), 1000000)
+
+    def test_returns_none_on_zero(self):
+        """The falsy-trap bug: `0` currently passes `if val:` test in
+        tokens.py and silently ignores the override. We reject it loudly."""
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": "0"}):
+            self.assertIsNone(parse_env_positive_int("TEST_ENV_POSINT"))
+
+    def test_returns_none_on_negative(self):
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": "-100"}):
+            self.assertIsNone(parse_env_positive_int("TEST_ENV_POSINT"))
+
+    def test_returns_none_on_non_numeric(self):
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": "abc"}):
+            self.assertIsNone(parse_env_positive_int("TEST_ENV_POSINT"))
+
+    def test_warns_on_invalid(self):
+        """User should see a message on stderr — silent swallow is a UX bug."""
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": "-100"}):
+            with contextlib.redirect_stderr(buf):
+                parse_env_positive_int("TEST_ENV_POSINT")
+        self.assertIn("TEST_ENV_POSINT", buf.getvalue())
+        self.assertIn("-100", buf.getvalue())
+
+    def test_silent_when_unset(self):
+        """No warning when the var is simply not set — that's the normal path."""
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TEST_ENV_POSINT", None)
+            with contextlib.redirect_stderr(buf):
+                parse_env_positive_int("TEST_ENV_POSINT")
+        self.assertEqual(buf.getvalue(), "")
+
+
+class TestParseEnvNonNegativeInt(unittest.TestCase):
+    """Like positive-int but accepts 0 (valid for system_overhead_tokens —
+    a session with no rules file legitimately has zero overhead)."""
+
+    def test_accepts_zero(self):
+        with patch.dict(os.environ, {"TEST_ENV_NNINT": "0"}):
+            self.assertEqual(parse_env_non_negative_int("TEST_ENV_NNINT"), 0)
+
+    def test_returns_value_when_positive(self):
+        with patch.dict(os.environ, {"TEST_ENV_NNINT": "25000"}):
+            self.assertEqual(parse_env_non_negative_int("TEST_ENV_NNINT"), 25000)
+
+    def test_rejects_negative(self):
+        with patch.dict(os.environ, {"TEST_ENV_NNINT": "-1"}):
+            self.assertIsNone(parse_env_non_negative_int("TEST_ENV_NNINT"))
+
+    def test_rejects_non_numeric(self):
+        with patch.dict(os.environ, {"TEST_ENV_NNINT": "xyz"}):
+            self.assertIsNone(parse_env_non_negative_int("TEST_ENV_NNINT"))
+
+
+# ── Backwards compat: re-exports from strategies/_config still work ────────
+
+class TestBackwardsCompatReExport(unittest.TestCase):
+    """strategies/_config.py re-exports these — existing strategy imports
+    must continue to resolve after the refactor."""
+
+    def test_reexport_coerce_non_negative_int(self):
+        from cozempic.strategies._config import coerce_non_negative_int as reexported
+        self.assertIs(reexported, coerce_non_negative_int)
+
+    def test_reexport_coerce_choice(self):
+        from cozempic.strategies._config import coerce_choice as reexported
+        self.assertIs(reexported, coerce_choice)
+
+    def test_reexport_ConfigError(self):
+        from cozempic.strategies._config import ConfigError as reexported
+        self.assertIs(reexported, ConfigError)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Applies the config-validation approach from #79 to every remaining user-facing numeric input — guard CLI flags, remind interval, and the two cozempic env vars that were parsed with a bare `int()`.

Follows up on @junaidtitan's comment after PR #79 merge: *\"Other areas where your config-validation approach would help: guard daemon thresholds accept arbitrary values with zero validation today; COZEMPIC_CONTEXT_WINDOW is parsed with a bare int() — string/negative/zero values crash deep in the token math.\"*

Two commits for reviewability:

| Commit | Scope |
|---|---|
| `refactor: lift strategy config helpers to cozempic._validation` | Mechanical move of the generic helpers from `strategies/_config.py` to a root `_validation.py`; `strategies/_config.py` re-exports so existing imports keep working. Zero behavior change, 39 existing strategy tests untouched. |
| `feat: harden numeric input validation across CLI flags and env vars` | The actual fix: 9 surfaces validated, 50 new tests. |

## Problem: 4 pathologies reproduced live on v1.8.5

### 1. Silent propagation of nonsense values
```
$ COZEMPIC_CONTEXT_WINDOW=-100 cozempic diagnose <session>
# pct=-110%, thresholds=(-25, -55, -80) printed in diagnostic output
```

### 2. Silent override ignored (falsy trap)
```python
# tokens.py:96 (before)
val = os.environ.get(\"COZEMPIC_CONTEXT_WINDOW\")
if val:        # <-- 0 is falsy, override silently dropped
    return int(val)
```
Running `COZEMPIC_CONTEXT_WINDOW=0 cozempic diagnose` silently uses the built-in default 1M. The user never sees their override was ignored.

### 3. Reload storm
```
$ cozempic guard --threshold -1 --daemon
# daemon spawns. hard_bytes=-1048576. Every 30s cycle:
#   current_bytes >= -1048576  =>  TRUE  =>  prune+reload
```

### 4. Cryptic mid-daemon crash
```
$ cozempic guard --interval -1 --daemon
# argparse accepts, daemon spawns. 30s later:
#   File \"guard.py\", line 368, in start_guard
#     time.sleep(interval)
# ValueError: sleep length must be non-negative
```

## Fix — three complementary layers

### Layer 1 — argparse validators (cli.py)
Two small inline validator functions:

```python
def _positive_int(val: str) -> int: ...
def _positive_float(val: str) -> float: ...
```

Applied to `--threshold`, `--soft-threshold`, `--interval`, `--threshold-tokens`, `--soft-threshold-tokens` (guard) and `--interval` (remind). Produces standard argparse error output with exit code 2:

```
$ cozempic guard --threshold -1
usage: cozempic guard [-h] ...
cozempic guard: error: argument --threshold: must be positive, got -1.0
```

### Layer 2 — in-process validation in `start_guard()` (guard.py)
Defense-in-depth for Python callers that bypass argparse (e.g. `cozempic.guard.start_guard(threshold_mb=-1, ...)`). Also catches the one thing argparse can't: **soft < hard ordering**. When user passes both `--soft-threshold` and `--threshold`, each individually passes argparse but their ordering isn't checked there.

```python
# start_guard() now starts with:
if soft_threshold_mb is not None and soft_threshold_mb >= threshold_mb:
    raise ConfigError(
        f\"soft_threshold_mb={soft_threshold_mb} must be strictly less than \"
        f\"threshold_mb={threshold_mb}\"
    )
# + same for token thresholds + positivity belt-and-braces
```

### Layer 3 — env var parsing (tokens.py)
Routes both env vars through helpers in `cozempic._validation` that WARN to stderr (matching `_prescan_argv` pattern) rather than raise — an env var is ambient config, and raising would crash a daemon that had been running fine.

```python
# Old:
val = os.environ.get(\"COZEMPIC_CONTEXT_WINDOW\")
if val:
    try: return int(val)
    except ValueError: pass
return None

# New:
return parse_env_positive_int(\"COZEMPIC_CONTEXT_WINDOW\")
# → rejects 0, -100, \"abc\", empty with a clear stderr warning; falls back to default
```

`COZEMPIC_SYSTEM_OVERHEAD_TOKENS` uses `parse_env_non_negative_int` instead: 0 is a legitimate value there (a session with no rules file and no MCP has no overhead).

## New helpers in `cozempic/_validation.py`

Extending the module with four new functions beyond what the refactor commit added:

```python
def coerce_positive_int(config, key, default) -> int: ...      # strict > 0
def coerce_positive_float(config, key, default) -> float: ...  # strict > 0, accepts int
def parse_env_positive_int(name: str) -> int | None: ...       # warn + fallback
def parse_env_non_negative_int(name: str) -> int | None: ...   # warn + fallback
```

`coerce_positive_int` is distinct from `coerce_non_negative_int` (which allows 0). Separation is intentional: zero is valid for \"no overhead\" but nonsensical for \"polling interval\" or \"context window size\".

## Testing

**New tests: 50**

| File | New tests | Coverage |
|---|---|---|
| `tests/test_validation.py` (new) | 30 | Unit tests for all 4 new helpers + 2 existing, including bool-rejection, backwards-compat re-exports |
| `tests/test_cli_validation.py` (ext) | 15 | `TestGuardArgparseValidation` (16 argparse scenarios) + `TestStartGuardOrderingValidation` (3 ordering invariants) |
| `tests/test_tokens.py` (ext) | 5 | `TestEnvVarOverrideValidation` — integration: env var to return value |

**Suite status:**
- New tests: **50/50 green**
- Full suite: **461 passed**, 3 pre-existing failures in `test_model_detection.py` (unrelated to this PR — reduced from 6 on v1.8.3 after maintainer fix in v1.8.4)
- Strategies + doctor tests: unchanged (39 green)
- **Zero regression.**

## Live smoke test — 8/8 scenarios pass

```
Smoke 1: cozempic guard --threshold -1
  → error: argument --threshold: must be positive, got -1.0 ✓
Smoke 2: cozempic guard --threshold 0
  → error: argument --threshold: must be positive, got 0.0 ✓
Smoke 3: cozempic guard --interval 0
  → error: argument --interval: must be positive, got 0 ✓
Smoke 4: cozempic guard --interval -1
  → error: argument --interval: must be positive, got -1 ✓
Smoke 5: start_guard(threshold_mb=50, soft_threshold_mb=100, ...) (Python direct)
  → ConfigError: soft_threshold_mb=100 must be strictly less than threshold_mb=50 ✓
Smoke 6: COZEMPIC_CONTEXT_WINDOW=0
  → Warning: ignoring COZEMPIC_CONTEXT_WINDOW='0' — must be a positive integer
  → Returns None (falls back to model detection) ✓
Smoke 7: COZEMPIC_CONTEXT_WINDOW=-100
  → Warning: ignoring COZEMPIC_CONTEXT_WINDOW='-100' — must be a positive integer ✓
Smoke 8: Happy path — cozempic guard --threshold 50 --soft-threshold 30 --interval 30
  → threshold=50.0, soft=30.0, interval=30 (parse OK) ✓
```

## Safety & scope

- **No public API change.** `ConfigError` subclasses `ValueError`, so existing `except ValueError` handlers keep catching.
- **No new dependencies.**
- **No behavior change on valid inputs.** Every happy path is identical to v1.8.5.
- **Env var path warns rather than raises** — matches the existing `_prescan_argv` convention, won't crash a running daemon.
- **Not in scope:** Windows-specific code (macOS-only testing), `--claude-pid` (PIDs are always positive on POSIX, implicit in `os.kill`), new features.

## Files changed

| File | Δ |
|---|---|
| `src/cozempic/_validation.py` | +208 (new — shared helpers, refactor commit) |
| `src/cozempic/strategies/_config.py` | -47 (thin re-export, refactor commit) |
| `src/cozempic/cli.py` | +32 / -5 (2 validators + 6 argparse updates) |
| `src/cozempic/guard.py` | +33 (ordering + positivity in `start_guard`) |
| `src/cozempic/tokens.py` | +8 / -12 (route through helpers) |
| `tests/test_validation.py` | +180 (new) |
| `tests/test_cli_validation.py` | +138 |
| `tests/test_tokens.py` | +49 |

## Test plan

- [x] 50 new tests green
- [x] Full suite shows zero regression (461 passed, 3 pre-existing unchanged)
- [x] Live smoke test on all 9 pathological inputs
- [x] Happy path (valid args) unchanged
- [x] No new dependencies
- [x] No breaking API change (re-export preserves existing strategy imports)