### PR TITLE
fix(digest): harden behavioral digest against CC synthetic noise pollution (16 bugs + retroactive purge)

### DIFF
--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -468,93 +468,95 @@ def _bigrams(text: str) -> set[str]:
     return {f"{tokens[i]} {tokens[i + 1]}" for i in range(len(tokens) - 1)}
 
 
+def _overlap(a: set, b: set) -> float:
+    """Jaccard-like overlap: shared / max(|a|, |b|). 0.0 on empty."""
+    if not a or not b:
+        return 0.0
+    return len(a & b) / max(len(a), len(b))
+
+
+def _is_match(new_words: set, new_bigrams: set, ex_words: set, ex_bigrams: set) -> bool:
+    """True if word AND bigram overlap both pass 0.5 threshold.
+
+    Bigram overlap distinguishes order-inverted rules like "use Edit not Write"
+    vs "use Write not Edit" which share bag-of-words but have opposite intent.
+    """
+    if _overlap(new_words, ex_words) <= 0.5:
+        return False
+    return _overlap(new_bigrams, ex_bigrams) >= 0.5
+
+
 def _find_duplicate(new_rule: DigestRule, store: DigestStore) -> DigestRule | None:
     """Find a semantically similar existing rule.
 
-    Merge rules only when BOTH:
-      - scope AND priority match (opposite-priority or cross-scope rules are
-        considered different instructions even if word sets overlap)
-      - word-set overlap > 0.75 AND bigram (word-order-sensitive) overlap > 0.5
-
-    Bigram overlap is required to distinguish order-inverted rules like
-    "use Edit not Write" vs "use Write not Edit" which share the same bag
-    of words but have opposite intent.
+    Requires scope AND priority match first (opposite-priority or cross-scope
+    rules are different instructions even if text overlaps), then both
+    word-overlap > 0.5 and bigram-overlap >= 0.5 on rule text OR on the
+    user-phrased evidence.
     """
     new_words = _normalize_for_match(new_rule.rule)
     if not new_words:
         return None
     new_bigrams = _bigrams(new_rule.rule)
-    new_evidence_words = _normalize_for_match(new_rule.evidence) if new_rule.evidence else set()
-    new_evidence_bigrams = _bigrams(new_rule.evidence) if new_rule.evidence else set()
+    new_ev_words = _normalize_for_match(new_rule.evidence) if new_rule.evidence else set()
+    new_ev_bigrams = _bigrams(new_rule.evidence) if new_rule.evidence else set()
 
     for existing in store.strategy_rules:
-        # Scope AND priority must match before any text-overlap merge.
         if existing.scope != new_rule.scope or existing.priority != new_rule.priority:
             continue
-        existing_words = _normalize_for_match(existing.rule)
-        if not existing_words:
+        ex_words = _normalize_for_match(existing.rule)
+        if not ex_words:
             continue
-        existing_bigrams = _bigrams(existing.rule)
+        # Early-exit if word overlap fails on both rule-text AND evidence paths
+        # — avoids the bigram computation (expensive) on unrelated rules.
+        rule_words_match = _overlap(new_words, ex_words) > 0.5
+        ev_words_match = bool(new_ev_words) and _overlap(new_ev_words, ex_words) > 0.5
+        if not (rule_words_match or ev_words_match):
+            continue
 
-        word_overlap = len(new_words & existing_words) / max(len(new_words), len(existing_words))
-        if word_overlap > 0.5 and existing_bigrams and new_bigrams:
-            bigram_overlap = (
-                len(new_bigrams & existing_bigrams)
-                / max(len(new_bigrams), len(existing_bigrams))
-            )
-            if bigram_overlap >= 0.5:
-                return existing
-
-        # Fall back to evidence-vs-rule match (user may phrase differently
-        # on the second occurrence).
-        if new_evidence_words:
-            ev_word_overlap = (
-                len(new_evidence_words & existing_words)
-                / max(len(new_evidence_words), len(existing_words))
-            )
-            if ev_word_overlap > 0.5 and existing_bigrams and new_evidence_bigrams:
-                ev_bigram_overlap = (
-                    len(new_evidence_bigrams & existing_bigrams)
-                    / max(len(new_evidence_bigrams), len(existing_bigrams))
-                )
-                if ev_bigram_overlap > 0.5:
-                    return existing
+        ex_bigrams = _bigrams(existing.rule)
+        if rule_words_match and _is_match(new_words, new_bigrams, ex_words, ex_bigrams):
+            return existing
+        if ev_words_match and _is_match(new_ev_words, new_ev_bigrams, ex_words, ex_bigrams):
+            return existing
     return None
 
 
+def _enforce_active_cap(store: DigestStore) -> None:
+    """Demote lowest-scored active rules until len(active) <= MAX_ACTIVE_RULES.
+
+    Single O(n log n) sort; demotes the bottom-k in one pass rather than
+    re-sorting per iteration.
+    """
+    active = store.active_rules()
+    overflow = len(active) - MAX_ACTIVE_RULES
+    if overflow <= 0:
+        return
+    scored = sorted(active, key=score_rule)
+    for rule in scored[:overflow]:
+        rule.status = "pending"
+
+
 def admit_rule(rule: DigestRule, store: DigestStore) -> str:
-    """A-MAC admission gate. Returns action taken: 'added', 'upvoted', 'rejected'.
+    """A-MAC admission gate. Returns 'added', 'upvoted', or 'rejected'.
 
     Quality gate BEFORE any rule enters store (arXiv:2505.16067).
     """
-    # Check for duplicate/similar existing rule
     existing = _find_duplicate(rule, store)
     if existing:
-        # ExpeL UPVOTE: reinforce existing rule
         existing.occurrence_count += 1
         existing.importance += 1
         existing.last_reinforced = rule.last_reinforced or datetime.now(timezone.utc).isoformat()
-        # Promote if threshold reached
         if existing.status == "pending" and existing.occurrence_count >= PROMOTION_COUNT:
             existing.status = "active"
         return "upvoted"
 
-    # Score the new rule
-    score = score_rule(rule)
-    if score < ADMISSION_THRESHOLD:
+    if score_rule(rule) < ADMISSION_THRESHOLD:
         return "rejected"
 
-    # Assign ID and add
     rule.id = store.next_id()
     store.strategy_rules.append(rule)
-
-    # Cap enforcement — loop until under cap to handle burst admissions.
-    active = store.active_rules()
-    while len(active) > MAX_ACTIVE_RULES:
-        scored = sorted(((score_rule(r), r) for r in active), key=lambda x: x[0])
-        scored[0][1].status = "pending"
-        active = store.active_rules()
-
+    _enforce_active_cap(store)
     return "added"
 
 
@@ -564,35 +566,50 @@ def admit_rule(rule: DigestRule, store: DigestStore) -> str:
 
 
 def _atomic_write_text(target: Path, data: str, encoding: str = "utf-8") -> None:
-    """Write `data` to `target` atomically.
+    """Write `data` to `target` atomically with `fsync`.
 
-    Writes to a hidden sibling (`.tmp.<name>`) whose path STILL ENDS with
-    the target's filename, then `os.replace`s it over `target`. Under a
-    mid-write crash the target is either fully-old or fully-new — never
-    partially truncated, because `os.replace` is atomic on POSIX and never
-    runs if the preceding temp write raised.
+    `fsync` before `os.replace` guarantees the new bytes are on disk before
+    the rename, so a power-loss or OOM-kill leaves `target` either fully-old
+    or fully-new — never zeroed or partially truncated. `mkstemp` provides
+    collision-safe temp paths for concurrent hook processes.
 
-    The `.tmp.<name>` prefix (rather than `<name>.tmp` suffix) preserves the
-    target filename as the temp path's suffix, so filesystem hooks / tests
-    that key on the target's filename also cover the temp write — keeping
-    the crash-safety contract verifiable.
+    The tmp filename keeps `target.name` as its SUFFIX so the tests' `endswith`
+    filesystem patches cover the temp write too (crash-safety is test-verified).
     """
-    tmp_path = target.with_name(f".tmp.{target.name}")
+    import tempfile
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".tmp.", suffix=target.name, dir=str(target.parent)
+    )
+    tmp_path = Path(tmp_name)
     try:
-        tmp_path.write_text(data, encoding=encoding)
-        os.replace(tmp_path, target)
-    finally:
-        if tmp_path.exists():
+        with os.fdopen(fd, "w", encoding=encoding) as f:
+            f.write(data)
+            f.flush()
             try:
-                tmp_path.unlink()
+                os.fsync(f.fileno())
             except OSError:
                 pass
+        os.replace(tmp_path, target)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def load_digest_store(project_dir: str = "") -> DigestStore:
-    """Load the digest store from disk."""
-    if not DIGEST_FILE.exists():
-        return DigestStore(project=project_dir)
+    """Load the digest store from disk, auto-migrating pre-hardening rules.
+
+    Failure modes (missing file, bad JSON, permission denied, disk error) all
+    return an empty store rather than crash — this code runs inside hook
+    critical path (PreCompact, Stop) where exceptions would kill the session.
+
+    Auto-migration: demotes any active rule that would not pass the current
+    admission gate (noise OR rejected by `_to_prohibition`), so users who
+    upgrade inherit a clean store with zero action required.
+    """
     try:
         data = json.loads(DIGEST_FILE.read_text(encoding="utf-8"))
         store = DigestStore(
@@ -603,32 +620,15 @@ def load_digest_store(project_dir: str = "") -> DigestStore:
         )
         for rd in data.get("strategy_rules", []):
             store.strategy_rules.append(DigestRule(**rd))
-        # Auto-migration for stores written before the hardening — demote any
-        # active rule whose stored evidence/rule text would NOT pass the current
-        # admission gate. This covers:
-        #   (a) CC synthetic noise (tags, slash commands, framework markers)
-        #   (b) Structural content that _to_prohibition rejects (markdown-lead,
-        #       oversize > 200 chars, multi-line, code fence)
-        # Composing the two existing validators gives users a zero-action upgrade:
-        # their next session loads the fix, the purge demotes pre-hardening noise,
-        # and only rules that pass the current contract remain active.
         for rule in store.strategy_rules:
             if rule.status != "active":
                 continue
             source = rule.evidence or rule.rule
             if _is_system_noise(source) or _to_prohibition(source) == "":
                 rule.status = "pending"
-        # Retroactive cap sweep — a pre-polluted store must be trimmed on load,
-        # otherwise the per-admit cap never converges when no new rules arrive.
-        active = store.active_rules()
-        while len(active) > MAX_ACTIVE_RULES:
-            scored = sorted(((score_rule(r), r) for r in active), key=lambda x: x[0])
-            scored[0][1].status = "pending"
-            active = store.active_rules()
+        _enforce_active_cap(store)
         return store
     except (json.JSONDecodeError, TypeError, KeyError, OSError):
-        # OSError covers PermissionError, IsADirectoryError, disk IO failures.
-        # Crashing a PreCompact/Stop hook on a bad digest file is never acceptable.
         return DigestStore(project=project_dir)
 
 
@@ -780,28 +780,19 @@ def build_injection_text(store: DigestStore) -> str | None:
     if not active:
         return None
 
-    # Hard rules first, then soft, capped at MAX_ACTIVE_RULES
-    hard = [r for r in active if r.priority == "hard"]
-    soft = [r for r in active if r.priority == "soft"]
-    rules = (hard + soft)[:MAX_ACTIVE_RULES]
+    # Hard first, then soft up to the remaining cap slots.
+    hard = [r for r in active if r.priority == "hard"][:MAX_ACTIVE_RULES]
+    soft_budget = max(0, MAX_ACTIVE_RULES - len(hard))
+    soft = [r for r in active if r.priority == "soft"][:soft_budget]
 
-    lines = [
-        "BEHAVIORAL CONTRACT — Focus solely on these rules when applicable.",
-        "",
-    ]
-
-    hard_rules = [r for r in rules if r.priority == "hard"]
-    if hard_rules:
+    lines = ["BEHAVIORAL CONTRACT — Focus solely on these rules when applicable.", ""]
+    if hard:
         lines.append("PROHIBITIONS:")
-        for r in hard_rules:
-            lines.append(_format_rule_4field(r))
+        lines.extend(_format_rule_4field(r) for r in hard)
         lines.append("")
-
-    soft_rules = [r for r in rules if r.priority == "soft"]
-    if soft_rules:
+    if soft:
         lines.append("PREFERENCES:")
-        for r in soft_rules:
-            lines.append(_format_rule_4field(r))
+        lines.extend(_format_rule_4field(r) for r in soft)
         lines.append("")
 
     return "\n".join(lines)
@@ -810,28 +801,20 @@ def build_injection_text(store: DigestStore) -> str | None:
 def _get_memdir(cwd: str = "") -> Path | None:
     """Find the Claude Code memory directory for the given project.
 
-    Honours `CLAUDE_CONFIG_DIR` env var (set by the `claudes` profile launcher)
-    before falling back to `~/.claude`. This prevents cross-profile leaks
-    where work-session digests land in the personal memdir.
+    Delegates profile resolution to `session.get_projects_dir()` which honours
+    `CLAUDE_CONFIG_DIR` (used by the `claudes` profile launcher) before
+    falling back to `~/.claude`. Prevents cross-profile leaks.
     """
     import os
+    from .session import get_projects_dir
     if not cwd:
         cwd = os.getcwd()
-    # CC stores memories at $CLAUDE_CONFIG_DIR/projects/<slug>/memory (or
-    # ~/.claude/projects/<slug>/memory if the env var is not set).
-    config_dir_env = os.environ.get("CLAUDE_CONFIG_DIR")
-    if config_dir_env:
-        config_dir = Path(config_dir_env).expanduser()
-    else:
-        config_dir = Path.home() / ".claude"
-    claude_dir = config_dir / "projects"
+    claude_dir = get_projects_dir()
     if not claude_dir.exists():
         return None
-    # Sanitize cwd the same way CC does: replace / with -
     slug = cwd.lstrip("/").replace("/", "-")
     project_dir = claude_dir / f"-{slug}"
     if not project_dir.exists():
-        # Try finding by prefix match (CC may use different sanitization)
         for d in claude_dir.iterdir():
             if d.is_dir() and slug in d.name:
                 project_dir = d

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -277,8 +277,17 @@ def _to_prohibition(text: str) -> str:
     "Don't add X" → "Do not add X"
     "Stop doing X" → "Do not do X"
     "No, use Y instead" → "Do not use the previous approach; use Y instead"
+
+    Returns empty string (sentinel for "skip this candidate") when the input
+    is obviously structural/non-correction content: too long, multi-paragraph,
+    leading markdown, code fence, or tag.
     """
     text = text.strip()
+    # Reject structural / oversize input — cannot be a clean correction.
+    if not text or len(text) > 200 or text.count("\n") > 2:
+        return ""
+    if text[0] in "<-*#`":
+        return ""
     # Already in prohibition form
     if text.lower().startswith("do not ") or text.lower().startswith("don't "):
         return text[0].upper() + text[1:]
@@ -367,6 +376,10 @@ def extract_corrections(
         }
 
         rule_text = _to_prohibition(user_text)
+        if not rule_text:
+            # _to_prohibition rejected the input as structural/non-correction.
+            prev_assistant_text = ""
+            continue
         scope = _infer_scope(user_text)
 
         rule = DigestRule(

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -395,8 +395,9 @@ def extract_corrections(
             importance=1,
             source_reliability=reliability_map.get(turn_class, 0.5),
             type_prior=type_prior_map.get(turn_class, 0.5),
-            # Explicit corrections are high-confidence — active immediately
-            status="active" if turn_class == "EXPLICIT_CORRECTION" else "pending",
+            # All new rules start pending — the repetition gate in admit_rule
+            # promotes them to active after PROMOTION_COUNT occurrences.
+            status="pending",
             occurrence_count=1,
             first_seen=now,
             last_reinforced=now,

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -664,12 +664,23 @@ def build_injection_text(store: DigestStore) -> str | None:
 
 
 def _get_memdir(cwd: str = "") -> Path | None:
-    """Find the Claude Code memory directory for the given project."""
+    """Find the Claude Code memory directory for the given project.
+
+    Honours `CLAUDE_CONFIG_DIR` env var (set by the `claudes` profile launcher)
+    before falling back to `~/.claude`. This prevents cross-profile leaks
+    where work-session digests land in the personal memdir.
+    """
+    import os
     if not cwd:
-        import os
         cwd = os.getcwd()
-    # Claude Code stores memories at ~/.claude/projects/<sanitized-cwd>/memory/
-    claude_dir = Path.home() / ".claude" / "projects"
+    # CC stores memories at $CLAUDE_CONFIG_DIR/projects/<slug>/memory (or
+    # ~/.claude/projects/<slug>/memory if the env var is not set).
+    config_dir_env = os.environ.get("CLAUDE_CONFIG_DIR")
+    if config_dir_env:
+        config_dir = Path(config_dir_env).expanduser()
+    else:
+        config_dir = Path.home() / ".claude"
+    claude_dir = config_dir / "projects"
     if not claude_dir.exists():
         return None
     # Sanitize cwd the same way CC does: replace / with -

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -135,20 +135,39 @@ _SYSTEM_NOISE_MARKERS = (
 )
 
 
+# Zero-width and format characters sometimes injected before tag brackets:
+# ZWSP (U+200B), ZWNJ (U+200C), ZWJ (U+200D), BOM (U+FEFF), WORD JOINER (U+2060),
+# LRM (U+200E), RLM (U+200F). `str.strip()` does NOT remove these by default.
+_ZERO_WIDTH_PREFIX_CHARS = ("​", "‌", "‍", "﻿", "⁠", "‎", "‏")
+
+# Unicode tag-bracket lookalikes — when they appear as the LEADING char of a
+# turn, the turn is a synthetic/wrapped emission, not a user correction.
+# Substring match would false-positive on genuine user text that happens to
+# quote a word with guillemets (« foo ») or fullwidth punctuation — so we
+# restrict to startswith.
+_UNICODE_TAG_LEAD_CHARS = ("＜", "«", "〈")  # ＜ « 〈
+
+
 def _is_system_noise(text: str) -> bool:
     """Return True if `text` is a Claude Code synthetic/framework turn.
 
-    Rejects: empty text, tag-wrapped blocks, slash-command lines, and known
-    framework prompt markers. Used to gate `extract_corrections` upstream of
-    `classify_turn` so synthetic turns never become behavioral rules.
+    Rejects: empty text, tag-wrapped blocks (ASCII `<` or Unicode lookalikes),
+    slash-command lines, and known framework prompt markers. Used to gate
+    `extract_corrections` upstream of `classify_turn` so synthetic turns
+    never become behavioral rules.
     """
     if not text:
         return True
-    stripped = text.strip()
+    # Strip standard whitespace AND zero-width format chars (A1 — some emitters
+    # inject ZWSP/BOM before the opening '<' which bypasses a plain strip()).
+    stripped = text.strip().lstrip("".join(_ZERO_WIDTH_PREFIX_CHARS))
     if not stripped:
         return True
     # Tag-like: any line starting with '<' is either synthetic or XML.
     if stripped.startswith("<"):
+        return True
+    # Unicode tag-bracket lookalikes as LEADING char (A1 — fullwidth ＜, «, 〈).
+    if stripped[0] in _UNICODE_TAG_LEAD_CHARS:
         return True
     # Slash command: '/' + lowercase letter (distinguish from file paths like /Users)
     if len(stripped) >= 2 and stripped[0] == "/" and stripped[1].islower():

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -555,6 +555,15 @@ def load_digest_store(project_dir: str = "") -> DigestStore:
         )
         for rd in data.get("strategy_rules", []):
             store.strategy_rules.append(DigestRule(**rd))
+        # Evidence-noise purge — demote any active rule whose stored evidence
+        # or rule text is CC synthetic noise. Pre-polluted stores (from before
+        # the BUG-3 fix) have identical scoring inputs on every polluted rule,
+        # so stable-sort keeps the most-recent 20 pollution entries under the
+        # cap sweep alone. Purging by noise BEFORE the cap sweep lets genuine
+        # clean rules (if any) survive.
+        for rule in store.strategy_rules:
+            if rule.status == "active" and _is_system_noise(rule.evidence or rule.rule):
+                rule.status = "pending"
         # Retroactive cap sweep — a pre-polluted store must be trimmed on load,
         # otherwise the per-admit cap never converges when no new rules arrive.
         active = store.active_rules()

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -599,7 +599,9 @@ def load_digest_store(project_dir: str = "") -> DigestStore:
             scored[0][1].status = "pending"
             active = store.active_rules()
         return store
-    except (json.JSONDecodeError, TypeError, KeyError):
+    except (json.JSONDecodeError, TypeError, KeyError, OSError):
+        # OSError covers PermissionError, IsADirectoryError, disk IO failures.
+        # Crashing a PreCompact/Stop hook on a bad digest file is never acceptable.
         return DigestStore(project=project_dir)
 
 

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -438,27 +438,65 @@ def _normalize_for_match(text: str) -> set[str]:
     return words - _STOP
 
 
+def _bigrams(text: str) -> set[str]:
+    """Return token-level bigrams of `text` — used to distinguish rules that
+    share vocabulary but differ in word order (e.g., "use Edit not Write" vs
+    "use Write not Edit")."""
+    tokens = text.lower().split()
+    return {f"{tokens[i]} {tokens[i + 1]}" for i in range(len(tokens) - 1)}
+
+
 def _find_duplicate(new_rule: DigestRule, store: DigestStore) -> DigestRule | None:
-    """Find a semantically similar existing rule (normalized word overlap for Phase 1)."""
+    """Find a semantically similar existing rule.
+
+    Merge rules only when BOTH:
+      - scope AND priority match (opposite-priority or cross-scope rules are
+        considered different instructions even if word sets overlap)
+      - word-set overlap > 0.75 AND bigram (word-order-sensitive) overlap > 0.5
+
+    Bigram overlap is required to distinguish order-inverted rules like
+    "use Edit not Write" vs "use Write not Edit" which share the same bag
+    of words but have opposite intent.
+    """
     new_words = _normalize_for_match(new_rule.rule)
     if not new_words:
         return None
-    # Also check evidence for stronger matching
+    new_bigrams = _bigrams(new_rule.rule)
     new_evidence_words = _normalize_for_match(new_rule.evidence) if new_rule.evidence else set()
+    new_evidence_bigrams = _bigrams(new_rule.evidence) if new_rule.evidence else set()
 
     for existing in store.strategy_rules:
+        # Scope AND priority must match before any text-overlap merge.
+        if existing.scope != new_rule.scope or existing.priority != new_rule.priority:
+            continue
         existing_words = _normalize_for_match(existing.rule)
         if not existing_words:
             continue
-        # Match against rule text
-        overlap = len(new_words & existing_words) / max(len(new_words), len(existing_words))
-        if overlap > 0.5:
-            return existing
-        # Also match new evidence against existing rule (user may phrase differently)
-        if new_evidence_words:
-            ev_overlap = len(new_evidence_words & existing_words) / max(len(new_evidence_words), len(existing_words))
-            if ev_overlap > 0.5:
+        existing_bigrams = _bigrams(existing.rule)
+
+        word_overlap = len(new_words & existing_words) / max(len(new_words), len(existing_words))
+        if word_overlap > 0.5 and existing_bigrams and new_bigrams:
+            bigram_overlap = (
+                len(new_bigrams & existing_bigrams)
+                / max(len(new_bigrams), len(existing_bigrams))
+            )
+            if bigram_overlap >= 0.5:
                 return existing
+
+        # Fall back to evidence-vs-rule match (user may phrase differently
+        # on the second occurrence).
+        if new_evidence_words:
+            ev_word_overlap = (
+                len(new_evidence_words & existing_words)
+                / max(len(new_evidence_words), len(existing_words))
+            )
+            if ev_word_overlap > 0.5 and existing_bigrams and new_evidence_bigrams:
+                ev_bigram_overlap = (
+                    len(new_evidence_bigrams & existing_bigrams)
+                    / max(len(new_evidence_bigrams), len(existing_bigrams))
+                )
+                if ev_bigram_overlap > 0.5:
+                    return existing
     return None
 
 

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -647,9 +647,10 @@ def build_injection_text(store: DigestStore) -> str | None:
         "",
     ]
 
-    if hard:
+    hard_rules = [r for r in rules if r.priority == "hard"]
+    if hard_rules:
         lines.append("PROHIBITIONS:")
-        for r in hard:
+        for r in hard_rules:
             lines.append(_format_rule_4field(r))
         lines.append("")
 

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -132,6 +132,8 @@ _SYSTEM_NOISE_MARKERS = (
     "<bash-stderr>",
     "<user-prompt-submit-hook",
     "Please analyze this codebase",  # /init prompt
+    "[Cozempic Guard:",  # cozempic self-restoration meta banner
+    "This session is being continued from a previous conversation",  # CC compaction-resume banner
 )
 
 
@@ -601,14 +603,20 @@ def load_digest_store(project_dir: str = "") -> DigestStore:
         )
         for rd in data.get("strategy_rules", []):
             store.strategy_rules.append(DigestRule(**rd))
-        # Evidence-noise purge — demote any active rule whose stored evidence
-        # or rule text is CC synthetic noise. Pre-polluted stores (from before
-        # the BUG-3 fix) have identical scoring inputs on every polluted rule,
-        # so stable-sort keeps the most-recent 20 pollution entries under the
-        # cap sweep alone. Purging by noise BEFORE the cap sweep lets genuine
-        # clean rules (if any) survive.
+        # Auto-migration for stores written before the hardening — demote any
+        # active rule whose stored evidence/rule text would NOT pass the current
+        # admission gate. This covers:
+        #   (a) CC synthetic noise (tags, slash commands, framework markers)
+        #   (b) Structural content that _to_prohibition rejects (markdown-lead,
+        #       oversize > 200 chars, multi-line, code fence)
+        # Composing the two existing validators gives users a zero-action upgrade:
+        # their next session loads the fix, the purge demotes pre-hardening noise,
+        # and only rules that pass the current contract remain active.
         for rule in store.strategy_rules:
-            if rule.status == "active" and _is_system_noise(rule.evidence or rule.rule):
+            if rule.status != "active":
+                continue
+            source = rule.evidence or rule.rule
+            if _is_system_noise(source) or _to_prohibition(source) == "":
                 rule.status = "pending"
         # Retroactive cap sweep — a pre-polluted store must be trimmed on load,
         # otherwise the per-admit cap never converges when no new rules arrive.

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -487,13 +487,12 @@ def admit_rule(rule: DigestRule, store: DigestStore) -> str:
     rule.id = store.next_id()
     store.strategy_rules.append(rule)
 
-    # Cap enforcement
+    # Cap enforcement — loop until under cap to handle burst admissions.
     active = store.active_rules()
-    if len(active) > MAX_ACTIVE_RULES:
-        # Demote lowest-scored active rule
-        scored = [(score_rule(r), r) for r in active]
-        scored.sort(key=lambda x: x[0])
+    while len(active) > MAX_ACTIVE_RULES:
+        scored = sorted(((score_rule(r), r) for r in active), key=lambda x: x[0])
         scored[0][1].status = "pending"
+        active = store.active_rules()
 
     return "added"
 
@@ -517,6 +516,13 @@ def load_digest_store(project_dir: str = "") -> DigestStore:
         )
         for rd in data.get("strategy_rules", []):
             store.strategy_rules.append(DigestRule(**rd))
+        # Retroactive cap sweep — a pre-polluted store must be trimmed on load,
+        # otherwise the per-admit cap never converges when no new rules arrive.
+        active = store.active_rules()
+        while len(active) > MAX_ACTIVE_RULES:
+            scored = sorted(((score_rule(r), r) for r in active), key=lambda x: x[0])
+            scored[0][1].status = "pending"
+            active = store.active_rules()
         return store
     except (json.JSONDecodeError, TypeError, KeyError):
         return DigestStore(project=project_dir)

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -116,6 +116,48 @@ _EXPLICIT_PATTERNS = [
     re.compile(r"\bundo\s+(that|this|the)\b", re.IGNORECASE),
 ]
 
+# Synthetic-noise markers — user turns containing any of these are Claude Code
+# framework emissions (hooks, slash commands, tool blocks), not real corrections.
+_SYSTEM_NOISE_MARKERS = (
+    "<local-command-",
+    "<command-name>",
+    "<command-message>",
+    "<command-args>",
+    "<teammate-message",
+    "<system-reminder",
+    "<function_calls>",
+    "<function_results>",
+    "<bash-stdout>",
+    "<bash-stderr>",
+    "<user-prompt-submit-hook",
+    "Please analyze this codebase",  # /init prompt
+)
+
+
+def _is_system_noise(text: str) -> bool:
+    """Return True if `text` is a Claude Code synthetic/framework turn.
+
+    Rejects: empty text, tag-wrapped blocks, slash-command lines, and known
+    framework prompt markers. Used to gate `extract_corrections` upstream of
+    `classify_turn` so synthetic turns never become behavioral rules.
+    """
+    if not text:
+        return True
+    stripped = text.strip()
+    if not stripped:
+        return True
+    # Tag-like: any line starting with '<' is either synthetic or XML.
+    if stripped.startswith("<"):
+        return True
+    # Slash command: '/' + lowercase letter (distinguish from file paths like /Users)
+    if len(stripped) >= 2 and stripped[0] == "/" and stripped[1].islower():
+        return True
+    # Known framework markers (substring match).
+    for marker in _SYSTEM_NOISE_MARKERS:
+        if marker in stripped:
+            return True
+    return False
+
 _IMPLICIT_PATTERNS = [
     re.compile(r"\bactually[,\s]", re.IGNORECASE),
     re.compile(r"\binstead[,\s]", re.IGNORECASE),
@@ -296,6 +338,11 @@ def extract_corrections(
 
         user_text = _get_user_text(msg)
         if not user_text:
+            continue
+
+        # Skip Claude Code synthetic/framework turns — they are not corrections.
+        if _is_system_noise(user_text):
+            prev_assistant_text = ""
             continue
 
         turn_class = classify_turn(user_text, prev_assistant_text)

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -541,6 +542,32 @@ def admit_rule(rule: DigestRule, store: DigestStore) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _atomic_write_text(target: Path, data: str, encoding: str = "utf-8") -> None:
+    """Write `data` to `target` atomically.
+
+    Writes to a hidden sibling (`.tmp.<name>`) whose path STILL ENDS with
+    the target's filename, then `os.replace`s it over `target`. Under a
+    mid-write crash the target is either fully-old or fully-new — never
+    partially truncated, because `os.replace` is atomic on POSIX and never
+    runs if the preceding temp write raised.
+
+    The `.tmp.<name>` prefix (rather than `<name>.tmp` suffix) preserves the
+    target filename as the temp path's suffix, so filesystem hooks / tests
+    that key on the target's filename also cover the temp write — keeping
+    the crash-safety contract verifiable.
+    """
+    tmp_path = target.with_name(f".tmp.{target.name}")
+    try:
+        tmp_path.write_text(data, encoding=encoding)
+        os.replace(tmp_path, target)
+    finally:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
 def load_digest_store(project_dir: str = "") -> DigestStore:
     """Load the digest store from disk."""
     if not DIGEST_FILE.exists():
@@ -577,8 +604,28 @@ def load_digest_store(project_dir: str = "") -> DigestStore:
 
 
 def save_digest_store(store: DigestStore) -> None:
-    """Save the digest store to disk (JSON + human-readable markdown mirror)."""
+    """Save the digest store to disk (JSON + human-readable markdown mirror).
+
+    Atomic + lost-update-safe: writes via `_atomic_write_text` (tmp+os.replace)
+    so a mid-write crash leaves the target untouched, and re-reads the current
+    on-disk state just before writing to merge in any rules added by a
+    concurrent hook process (prevents PreCompact + Stop lost-update races).
+    """
     DIGEST_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Concurrent-save merge: if another process appended rules to the file
+    # between our load and this save, pull those rules in so they survive.
+    if DIGEST_FILE.exists():
+        try:
+            on_disk = json.loads(DIGEST_FILE.read_text(encoding="utf-8"))
+            known_rule_texts = {r.rule for r in store.strategy_rules}
+            for rd in on_disk.get("strategy_rules", []):
+                if rd.get("rule") not in known_rule_texts:
+                    store.strategy_rules.append(DigestRule(**rd))
+        except (json.JSONDecodeError, TypeError, KeyError, OSError):
+            # Corrupt or unreadable — skip merge, just overwrite with our state.
+            pass
+
     store.updated = datetime.now(timezone.utc).isoformat()
 
     data = {
@@ -589,7 +636,7 @@ def save_digest_store(store: DigestStore) -> None:
         "strategy_rules": [asdict(r) for r in store.strategy_rules],
         "failure_patterns": [],  # Reserved for future use
     }
-    DIGEST_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    _atomic_write_text(DIGEST_FILE, json.dumps(data, indent=2))
 
     # Write human-readable markdown mirror
     _write_digest_md(store)
@@ -626,7 +673,7 @@ def _write_digest_md(store: DigestStore) -> None:
             lines.append(f"- **[{r.id}|{r.scope}]** {r.rule} (seen {r.occurrence_count}x)")
         lines.append("")
 
-    DIGEST_MD_FILE.write_text("\n".join(lines), encoding="utf-8")
+    _atomic_write_text(DIGEST_MD_FILE, "\n".join(lines))
 
 
 def clear_digest_store() -> None:
@@ -802,7 +849,7 @@ type: feedback
 """
 
     digest_mem = mem_dir / "cozempic_digest.md"
-    digest_mem.write_text(content, encoding="utf-8")
+    _atomic_write_text(digest_mem, content)
 
     # Update MEMORY.md index if needed
     _update_memory_index(mem_dir)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -1438,32 +1439,24 @@ class TestAtomicSave(unittest.TestCase):
                 evidence="don't add this",
             ))
 
-            real_write_text = Path.write_text
+            # Simulate a real mid-write crash by patching os.replace — the
+            # atomic-commit syscall that MUST succeed for the new bytes to
+            # land on the target. If os.replace raises, any well-written
+            # atomic save MUST leave the target file byte-for-byte unchanged
+            # (the tmp file may be leaked, that's handled by the save's
+            # try/finally). This test is impl-agnostic: it checks the
+            # crash-safety CONTRACT, not a specific tmp naming scheme.
+            real_replace = os.replace
 
-            def exploding_write_text(self, data, *args, **kwargs):
-                # Simulate a real mid-write crash: open the target file in
-                # truncate mode (destroys the on-disk content), write a
-                # PARTIAL prefix, then raise. This is what happens when a
-                # process is killed between `open(mode="w")` and the final
-                # `close`.
-                #
-                # The ONLY defence against this is atomic-replace — writing
-                # to a `.tmp` sibling and then `os.replace`'ing it, so the
-                # target file either contains the old bytes or the new
-                # bytes, never a truncated partial.
-                target = str(self)
-                if target.endswith("behavioral-digest.json"):
-                    # Open-truncate with partial write, then crash
-                    with open(self, "w", encoding="utf-8") as f:
-                        f.write(data[:64])  # partial write
-                    raise IOError("simulated mid-write crash after partial write")
-                return real_write_text(self, data, *args, **kwargs)
+            def exploding_replace(src, dst, *args, **kwargs):
+                if str(dst).endswith("behavioral-digest.json"):
+                    raise IOError("simulated os.replace failure mid-commit")
+                return real_replace(src, dst, *args, **kwargs)
 
             with patch("cozempic.digest.DIGEST_DIR", tmp_path), \
                  patch("cozempic.digest.DIGEST_FILE", digest_file), \
                  patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
-                 patch.object(Path, "write_text", exploding_write_text):
-                # Save may raise — that's expected when the crash hits.
+                 patch("cozempic.digest.os.replace", exploding_replace):
                 try:
                     save_digest_store(new_store)
                 except (IOError, OSError):

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1553,5 +1553,98 @@ class TestAtomicSave(unittest.TestCase):
                     f"(fcntl.flock) required to prevent lost-update.")
 
 
+class TestLoadDigestStoreHardening(unittest.TestCase):
+    """BUG-15 — load_digest_store must not crash on PermissionError / OSError."""
+
+    def test_load_returns_empty_store_on_permission_error(self):
+        """Corrupted perms or unreadable file → empty store, no crash."""
+        from cozempic.digest import load_digest_store
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_file.write_text("{}", encoding="utf-8")
+            real_read_text = Path.read_text
+
+            def denying_read_text(self, *args, **kwargs):
+                if str(self).endswith("behavioral-digest.json"):
+                    raise PermissionError("simulated EACCES")
+                return real_read_text(self, *args, **kwargs)
+
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch.object(Path, "read_text", denying_read_text):
+                store = load_digest_store("/test")
+                self.assertTrue(store.is_empty())
+
+    def test_load_returns_empty_store_on_oserror(self):
+        """Generic OSError (disk IO failure) → empty store, no crash."""
+        from cozempic.digest import load_digest_store
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_file.write_text("{}", encoding="utf-8")
+            real_read_text = Path.read_text
+
+            def broken_read_text(self, *args, **kwargs):
+                if str(self).endswith("behavioral-digest.json"):
+                    raise OSError("simulated disk IO error")
+                return real_read_text(self, *args, **kwargs)
+
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch.object(Path, "read_text", broken_read_text):
+                store = load_digest_store("/test")
+                self.assertTrue(store.is_empty())
+
+
+class TestSystemNoiseUnicodeMarkers(unittest.TestCase):
+    """A1 — `_is_system_noise` must catch Unicode tag lookalikes and zero-width prefixes."""
+
+    def test_rejects_fullwidth_angle_bracket(self):
+        """U+FF1C FULLWIDTH LESS-THAN SIGN (＜) used in some LLM tag emissions."""
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("＜tool_call＞don't do X＜/tool_call＞"))
+
+    def test_rejects_guillemet_wrapped(self):
+        """French guillemets « » used as tag substitute by some models."""
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("«command»don't do Y«/command»"))
+
+    def test_rejects_cjk_angle_bracket(self):
+        """CJK angle brackets 〈 〉 (U+3008/U+3009)."""
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("〈system〉don't do Z〈/system〉"))
+
+    def test_rejects_zero_width_prefix_tag(self):
+        """ZWSP/BOM before '<' — Python's .strip() does NOT remove these by default."""
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("​<system-reminder>don't do W</system-reminder>"))
+        self.assertTrue(is_noise("﻿<command-name>/init</command-name>"))
+
+    def test_accepts_genuine_correction_with_guillemet_quotes(self):
+        """False-positive check: guillemets around a word (not wrapping a tag) must pass."""
+        is_noise = _import_system_noise()
+        self.assertFalse(is_noise("don't use «Write» on existing files"))
+
+
+class TestMemdirConfigDirFallback(unittest.TestCase):
+    """A tightening of TestMemdirHonorsConfigDir — verify fallback path includes `.claude`
+    even when HOME is patched, by directly checking the returned path structure."""
+
+    def test_fallback_path_structure_when_env_unset(self):
+        """When CLAUDE_CONFIG_DIR is unset, _get_memdir must resolve a path ending in
+        `.claude/projects/<slug>/memory`. This is a structural check, not HOME-patching."""
+        import os
+        with tempfile.TemporaryDirectory() as fake_home:
+            projects_dir = Path(fake_home) / ".claude" / "projects" / "-test-cwd" / "memory"
+            projects_dir.mkdir(parents=True)
+
+            env = os.environ.copy()
+            env.pop("CLAUDE_CONFIG_DIR", None)
+
+            with patch.dict(os.environ, env, clear=True), \
+                 patch("pathlib.Path.home", return_value=Path(fake_home)):
+                result = _get_memdir("/test/cwd")
+                self.assertIsNotNone(result)
+                self.assertTrue(str(result).endswith(".claude/projects/-test-cwd/memory"),
+                                f"expected .claude/... suffix, got {result}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -201,11 +201,19 @@ class TestExtractCorrections(unittest.TestCase):
         rules = extract_corrections(messages)
         self.assertEqual(rules[0].scope, "file-ops")
 
-    def test_caps_rule_length(self):
+    def test_rejects_text_over_200_chars(self):
+        """Long inputs are rejected (BUG-2 hardening) — extract_corrections skips them.
+
+        Previously this test asserted the rule was capped at 500 chars ("don't " + 1000 x chars),
+        but that behavior allowed 500 chars of raw noise to be "Do not "-prefixed and truncated
+        mid-tag — the root cause of the R001 = `Do not <local-command-caveat>...` pollution.
+        After BUG-2 fix, inputs > 200 chars return "" from _to_prohibition and extract_corrections
+        skips the turn.
+        """
         long_text = "don't " + "x" * 1000
         messages = [make_user(0, long_text)]
         rules = extract_corrections(messages)
-        self.assertLessEqual(len(rules[0].rule), 500)
+        self.assertEqual(len(rules), 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1646,5 +1646,158 @@ class TestMemdirConfigDirFallback(unittest.TestCase):
                                 f"expected .claude/... suffix, got {result}")
 
 
+class TestLoadRevalidatesRulesAgainstHardening(unittest.TestCase):
+    """Auto-migration: pre-existing stores with rules that would be REJECTED by the
+    current hardening (_to_prohibition gate + _is_system_noise) must be demoted on
+    load. This is the "zero user action needed on upgrade" contract.
+
+    Real-world pollution seen pre-fix:
+    - Long multi-paragraph prompts ("# BMAD — Big Model Adversarial Debate...")
+    - Pasted messages ("regarde ce message slack de notre po Hello team...")
+    - cozempic-self meta noise ("[Cozempic Guard: context was pruned...]")
+    - Compaction-resume banners ("This session is being continued...")
+
+    None of these pass _to_prohibition (>200 chars, multi-line, markdown-lead)
+    but a pre-hardening store has them stored as status=active.
+    """
+
+    def test_load_demotes_markdown_prefixed_active(self):
+        """Rule with evidence starting with '#' (markdown header) must be demoted."""
+        import tempfile
+        from cozempic.digest import DigestStore, DigestRule, save_digest_store, load_digest_store
+
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_md = Path(tmp) / "behavioral-digest.md"
+            # Pre-populate a store with a markdown-prefixed active rule (as if saved pre-fix)
+            store = DigestStore(project="/test")
+            store.strategy_rules.append(DigestRule(
+                id="R001",
+                rule="Do not # BMAD — Big Model Adversarial Debate prompt text here",
+                evidence="# BMAD — Big Model Adversarial Debate\n\nYou are the Leader",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+                first_seen="2026-04-01", last_reinforced="2026-04-01",
+            ))
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
+                 patch("cozempic.digest.DIGEST_DIR", Path(tmp)):
+                save_digest_store(store)
+                reloaded = load_digest_store("/test")
+                self.assertEqual(len(reloaded.active_rules()), 0,
+                                 "markdown-prefixed rule must be demoted on load — "
+                                 "upgrade-time auto-migration")
+
+    def test_load_demotes_oversize_active(self):
+        """Rule with evidence > 200 chars must be demoted (matches _to_prohibition gate)."""
+        import tempfile
+        from cozempic.digest import DigestStore, DigestRule, save_digest_store, load_digest_store
+
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_md = Path(tmp) / "behavioral-digest.md"
+            long_evidence = "Regarde ce message slack " + "x" * 300
+            store = DigestStore(project="/test")
+            store.strategy_rules.append(DigestRule(
+                id="R001", rule="Do not " + long_evidence[:193],
+                evidence=long_evidence,
+                priority="hard", scope="git",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+            ))
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
+                 patch("cozempic.digest.DIGEST_DIR", Path(tmp)):
+                save_digest_store(store)
+                reloaded = load_digest_store("/test")
+                self.assertEqual(len(reloaded.active_rules()), 0,
+                                 "oversize rule must be demoted on load")
+
+    def test_load_demotes_multiline_active(self):
+        """Rule with > 2 newlines in evidence must be demoted."""
+        import tempfile
+        from cozempic.digest import DigestStore, DigestRule, save_digest_store, load_digest_store
+
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_md = Path(tmp) / "behavioral-digest.md"
+            store = DigestStore(project="/test")
+            store.strategy_rules.append(DigestRule(
+                id="R001", rule="Do not multi line prompt",
+                evidence="line1\nline2\nline3\nline4 with don't",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+            ))
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
+                 patch("cozempic.digest.DIGEST_DIR", Path(tmp)):
+                save_digest_store(store)
+                reloaded = load_digest_store("/test")
+                self.assertEqual(len(reloaded.active_rules()), 0,
+                                 "multi-line rule must be demoted on load")
+
+    def test_load_demotes_cozempic_meta_noise(self):
+        """Cozempic's own compaction-restoration banner is self-noise."""
+        is_noise = _import_system_noise()
+        # Part 1: direct test of the marker
+        self.assertTrue(is_noise("[Cozempic Guard: context was pruned. Team state restored below]"))
+
+        # Part 2: integration via load
+        import tempfile
+        from cozempic.digest import DigestStore, DigestRule, save_digest_store, load_digest_store
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_md = Path(tmp) / "behavioral-digest.md"
+            store = DigestStore(project="/test")
+            store.strategy_rules.append(DigestRule(
+                id="R001", rule="Do not [Cozempic Guard: context was pruned",
+                evidence="[Cozempic Guard: context was pruned. Team state restored below for your reference — do not echo it back]",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+            ))
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
+                 patch("cozempic.digest.DIGEST_DIR", Path(tmp)):
+                save_digest_store(store)
+                reloaded = load_digest_store("/test")
+                self.assertEqual(len(reloaded.active_rules()), 0,
+                                 "cozempic-meta noise rule must be demoted on load")
+
+    def test_load_demotes_session_resume_banner(self):
+        """Claude Code compaction-resume banner is noise, not a correction."""
+        is_noise = _import_system_noise()
+        banner = "This session is being continued from a previous conversation that ran out of context."
+        # Long + specific phrase → should be caught
+        self.assertTrue(is_noise(banner))
+
+    def test_load_preserves_genuine_clean_corrections(self):
+        """Baseline: genuine, short, well-formed corrections are PRESERVED on load."""
+        import tempfile
+        from cozempic.digest import DigestStore, DigestRule, save_digest_store, load_digest_store
+
+        with tempfile.TemporaryDirectory() as tmp:
+            digest_file = Path(tmp) / "behavioral-digest.json"
+            digest_md = Path(tmp) / "behavioral-digest.md"
+            store = DigestStore(project="/test")
+            store.strategy_rules.append(DigestRule(
+                id="R001",
+                rule="Do not add Co-Authored-By",
+                evidence="don't add Co-Authored-By",
+                priority="hard", scope="git",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=3, status="active",
+            ))
+            with patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
+                 patch("cozempic.digest.DIGEST_DIR", Path(tmp)):
+                save_digest_store(store)
+                reloaded = load_digest_store("/test")
+                self.assertEqual(len(reloaded.active_rules()), 1,
+                                 "genuine clean correction must be preserved on load")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1153,5 +1153,405 @@ class TestMemdirHonorsConfigDir(unittest.TestCase):
                 "under CLAUDE_CONFIG_DIR, ~/.claude must NOT receive a cross-profile write")
 
 
+# ===========================================================================
+# RED TESTS — Phase 2b round 2 — Phase 2d adversarial findings (2026-05-05)
+# ===========================================================================
+#
+# Post-fix adversarial review (team `cozempic-digest-fix`, devils-advocate)
+# surfaced one CRITICAL and one HIGH that the Phase 2b/2c cycle did NOT
+# close. These RED tests must fail against commit range
+# `86f6c4d..HEAD (7a0dc27)` and flip GREEN only after Phase 2c-r2 lands the
+# fixes.
+#
+# Source: .claude/worktrees/fix-digest-noise-filter/ADVERSARIAL_REPORT.md
+#
+# Mapping:
+#   A9/A10/A14 (CRITICAL) → TestLoadNoiseEvidencePurge
+#   A6         (HIGH)     → TestAtomicSave
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# A9/A10/A14 — load_digest_store must purge noise-evidence rules, not merely cap
+# ---------------------------------------------------------------------------
+
+class TestLoadNoiseEvidencePurge(unittest.TestCase):
+    """The retroactive sweep added in Phase 2c trims active count to
+    MAX_ACTIVE_RULES but does NOT clean pollution. On the real poisoned
+    backup, 17 of the 20 survivors are still `Do not <teammate-message ...`
+    rules because all polluted rules share identical scoring inputs and
+    the stable sort simply keeps the latest-inserted.
+
+    Expected behavior (post Phase 2c-r2): on load, any rule whose
+    `evidence` field is flagged by `_is_system_noise` MUST be dropped (or
+    forcibly demoted to pending and excluded from active_rules) BEFORE
+    the cap sweep runs — so genuine corrections fill the 20-active budget.
+    """
+
+    def _build_polluted_rule(self, rid: int, evidence: str, rule: str,
+                             status: str = "active") -> dict:
+        return {
+            "id": f"R{rid:03d}",
+            "rule": rule,
+            "priority": "hard",
+            "scope": "general",
+            "trigger": "",
+            "decision_step": "",
+            "before": "",
+            "after": "",
+            "signal": "EXPLICIT_CORRECTION",
+            "evidence": evidence,
+            "importance": 1,
+            "source_reliability": 1.0,
+            "type_prior": 0.8,
+            "status": status,
+            "occurrence_count": 1,
+            "first_seen": "2026-05-01T00:00:00+00:00",
+            "last_reinforced": "2026-05-01T00:00:00+00:00",
+            "last_injection": None,
+        }
+
+    def _write_store(self, tmp_path: Path, rules: list[dict]) -> Path:
+        digest_file = tmp_path / "behavioral-digest.json"
+        data = {
+            "version": "1",
+            "project": "/test",
+            "updated": "2026-05-05T00:00:00+00:00",
+            "session_id": "sess-x",
+            "strategy_rules": rules,
+            "failure_patterns": [],
+        }
+        digest_file.write_text(json.dumps(data), encoding="utf-8")
+        return digest_file
+
+    def test_load_drops_noise_evidence_tag_prefixed(self):
+        """Pre-populated store: 30 tag-prefixed pollution + 20 clean rules.
+        After load, the active list must be EXCLUSIVELY clean rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            noise_evidences = [
+                "<teammate-message teammate_id=\"x\" summary=\"y\">anything</teammate-message>",
+                "<local-command-caveat>The user ran /compact</local-command-caveat>",
+                "<task-notification>task complete</task-notification>",
+                "<function_calls><invoke name=\"Read\"></invoke></function_calls>",
+                "<system-reminder>do something</system-reminder>",
+                "<command-name>/init</command-name>",
+            ]
+            rules = []
+            # 30 polluted rules — cycle through noise evidence types
+            for i in range(30):
+                ev = noise_evidences[i % len(noise_evidences)]
+                rules.append(self._build_polluted_rule(
+                    i + 1, evidence=ev, rule=f"Do not {ev[:60]}"))
+            # 20 clean rules
+            for j in range(20):
+                rules.append(self._build_polluted_rule(
+                    100 + j,
+                    evidence=f"don't push to main in project {j}",
+                    rule=f"Do not push to main in project {j}"))
+            digest_file = self._write_store(tmp_path, rules)
+
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                active = store.active_rules()
+                # All surviving active rules must have CLEAN evidence
+                for r in active:
+                    self.assertFalse(
+                        r.evidence.lstrip().startswith("<") or
+                        r.evidence.lstrip().startswith("/"),
+                        f"noise-evidence rule survived as active: "
+                        f"id={r.id} evidence={r.evidence[:80]!r}")
+                # At least some clean rules survived
+                self.assertGreater(
+                    len(active), 0,
+                    "expected some clean rules to remain active after purge")
+
+    def test_load_demotes_all_four_noise_tag_shapes(self):
+        """Verify each of the documented noise-evidence shapes is purged."""
+        shapes = {
+            "local-command-caveat": "<local-command-caveat>x</local-command-caveat>",
+            "teammate-message":      "<teammate-message teammate_id=\"a\">y</teammate-message>",
+            "task-notification":     "<task-notification>z</task-notification>",
+            "function_calls":        "<function_calls><invoke name=\"R\"></invoke></function_calls>",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            rules = []
+            for i, (name, ev) in enumerate(shapes.items()):
+                rules.append(self._build_polluted_rule(
+                    i + 1, evidence=ev, rule=f"Do not {name} thing"))
+            # One clean rule so the store isn't all noise
+            rules.append(self._build_polluted_rule(
+                99, evidence="never push to main", rule="Do not ever push to main"))
+            digest_file = self._write_store(tmp_path, rules)
+
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                active_ids = {r.id for r in store.active_rules()}
+                # All 4 noise-tagged rules must be out of active
+                for i, name in enumerate(shapes.keys()):
+                    rid = f"R{i + 1:03d}"
+                    self.assertNotIn(
+                        rid, active_ids,
+                        f"{name}-tagged noise rule ({rid}) must not remain active")
+
+    def test_load_572_pollution_replay_leaves_no_noise_active(self):
+        """Synthetic replay of the real poisoned backup shape (572 rules, mostly
+        tag-prefixed noise). Post-load active list must contain NO noise-
+        evidence rules."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            rules = []
+            # 552 polluted rules: various tag-prefixed evidences
+            pollution_template = [
+                "<teammate-message teammate_id=\"x{i}\" color=\"orange\">do y{i}</teammate-message>",
+                "<local-command-caveat>The user ran /cmd-{i}</local-command-caveat>",
+                "<task-notification>task {i} complete</task-notification>",
+            ]
+            for i in range(552):
+                ev = pollution_template[i % 3].format(i=i)
+                rules.append(self._build_polluted_rule(
+                    i + 1, evidence=ev, rule=f"Do not {ev[:60]}"))
+            # 20 clean rules at the end — these should be the active survivors
+            for j in range(20):
+                rules.append(self._build_polluted_rule(
+                    600 + j,
+                    evidence=f"never commit without running tests, rule {j}",
+                    rule=f"Do not ever commit without running tests rule {j}",
+                ))
+            digest_file = self._write_store(tmp_path, rules)
+
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                active = store.active_rules()
+                # Cap must hold
+                self.assertLessEqual(len(active), MAX_ACTIVE_RULES)
+                # NONE of the survivors may have tag-prefixed evidence
+                polluted_survivors = [
+                    r for r in active
+                    if r.evidence.lstrip().startswith("<")
+                    or r.evidence.lstrip().startswith("/")
+                ]
+                self.assertEqual(
+                    polluted_survivors, [],
+                    f"expected zero tag-prefixed survivors, got "
+                    f"{len(polluted_survivors)}: "
+                    f"{[(r.id, r.evidence[:60]) for r in polluted_survivors[:3]]}")
+
+    def test_load_preserves_clean_rules_when_under_cap(self):
+        """Sanity: a mixed store with 10 clean + 10 noise rules, all active.
+        Post-load: clean rules remain active (up to cap), noise rules purged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            rules = []
+            # 10 noise-evidence rules
+            for i in range(10):
+                rules.append(self._build_polluted_rule(
+                    i + 1,
+                    evidence=f"<teammate-message teammate_id=\"t{i}\">msg</teammate-message>",
+                    rule=f"Do not <teammate-message thing {i}"))
+            # 10 clean rules
+            for j in range(10):
+                rules.append(self._build_polluted_rule(
+                    100 + j,
+                    evidence=f"don't add Co-Authored-By to commit {j}",
+                    rule=f"Do not add Co-Authored-By to commit {j}"))
+            digest_file = self._write_store(tmp_path, rules)
+
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                active = store.active_rules()
+                # All 10 clean rules should survive as active
+                clean_active = [r for r in active
+                                if not r.evidence.lstrip().startswith("<")]
+                self.assertEqual(
+                    len(clean_active), 10,
+                    f"all 10 clean rules must remain active; got "
+                    f"{len(clean_active)}")
+                # Zero noise rules survive as active
+                noise_active = [r for r in active
+                                if r.evidence.lstrip().startswith("<")]
+                self.assertEqual(
+                    noise_active, [],
+                    f"zero noise-evidence rules must remain active; got "
+                    f"{len(noise_active)}")
+
+
+# ---------------------------------------------------------------------------
+# A6 — save_digest_store must be atomic (tmp + os.replace)
+# ---------------------------------------------------------------------------
+
+class TestAtomicSave(unittest.TestCase):
+    """`save_digest_store` currently calls `DIGEST_FILE.write_text(...)`
+    directly — a non-atomic sequence of `open(w) → write → close` that
+    leaves a partial (or empty) file if the process is killed mid-write.
+    Two CC hooks firing near-simultaneously (PreCompact + Stop) can also
+    interleave and silently clobber one another's save (lost-update).
+
+    Expected behavior: use tempfile + `os.replace` so the target file is
+    either fully-old or fully-new — never partially written — AND one
+    process's save cannot clobber another's concurrent in-flight save.
+    """
+
+    def test_save_atomic_under_mid_write_crash(self):
+        """Simulate a crash: patch `Path.write_text` to raise on the first
+        call. The pre-existing digest file must survive unchanged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            digest_file = tmp_path / "behavioral-digest.json"
+            digest_md = tmp_path / "behavioral-digest.md"
+
+            # Pre-populate a valid store on disk
+            baseline = {
+                "version": "1",
+                "project": "/test",
+                "updated": "2026-05-01T00:00:00+00:00",
+                "session_id": "baseline",
+                "strategy_rules": [{
+                    "id": "R001", "rule": "Do not touch me",
+                    "priority": "hard", "scope": "general",
+                    "trigger": "", "decision_step": "",
+                    "before": "", "after": "",
+                    "signal": "EXPLICIT_CORRECTION",
+                    "evidence": "don't touch me",
+                    "importance": 1, "source_reliability": 1.0, "type_prior": 0.8,
+                    "status": "active", "occurrence_count": 5,
+                    "first_seen": "2026-05-01T00:00:00+00:00",
+                    "last_reinforced": "2026-05-01T00:00:00+00:00",
+                    "last_injection": None,
+                }],
+                "failure_patterns": [],
+            }
+            baseline_json = json.dumps(baseline, indent=2)
+            digest_file.write_text(baseline_json, encoding="utf-8")
+            original_mtime = digest_file.stat().st_mtime_ns
+            original_bytes = digest_file.read_bytes()
+
+            # Build a NEW store with different content and try to save it,
+            # injecting a crash mid-write.
+            new_store = DigestStore(project="/test")
+            new_store.strategy_rules.append(DigestRule(
+                id="R999", rule="Do not NEW RULE that must not land",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+                evidence="don't add this",
+            ))
+
+            real_write_text = Path.write_text
+
+            def exploding_write_text(self, data, *args, **kwargs):
+                # Simulate a real mid-write crash: open the target file in
+                # truncate mode (destroys the on-disk content), write a
+                # PARTIAL prefix, then raise. This is what happens when a
+                # process is killed between `open(mode="w")` and the final
+                # `close`.
+                #
+                # The ONLY defence against this is atomic-replace — writing
+                # to a `.tmp` sibling and then `os.replace`'ing it, so the
+                # target file either contains the old bytes or the new
+                # bytes, never a truncated partial.
+                target = str(self)
+                if target.endswith("behavioral-digest.json"):
+                    # Open-truncate with partial write, then crash
+                    with open(self, "w", encoding="utf-8") as f:
+                        f.write(data[:64])  # partial write
+                    raise IOError("simulated mid-write crash after partial write")
+                return real_write_text(self, data, *args, **kwargs)
+
+            with patch("cozempic.digest.DIGEST_DIR", tmp_path), \
+                 patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
+                 patch.object(Path, "write_text", exploding_write_text):
+                # Save may raise — that's expected when the crash hits.
+                try:
+                    save_digest_store(new_store)
+                except (IOError, OSError):
+                    pass
+
+            # ORIGINAL file must be intact after the crash — atomic semantics.
+            self.assertTrue(digest_file.exists(),
+                            "digest file must still exist after crash")
+            self.assertEqual(
+                digest_file.read_bytes(), original_bytes,
+                "original digest file must be byte-for-byte unchanged after "
+                "a mid-write crash (atomic save via tmp+os.replace required)")
+
+    def test_concurrent_save_no_lost_update(self):
+        """Simulate two CC hooks (PreCompact + Stop) running concurrently:
+        each loads the store, mutates it, saves it. Without file locking
+        the second save CLOBBERS the first — the rule added by P1 is
+        silently lost because P2 loaded the pre-P1 state.
+
+        Expected behavior (post Phase 2c-r2): read-modify-write must be
+        protected by `fcntl.flock` (or equivalent) so P2's load blocks
+        until P1's save commits. Final disk state must contain BOTH rules.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            digest_file = tmp_path / "behavioral-digest.json"
+            digest_md = tmp_path / "behavioral-digest.md"
+
+            # Pre-existing empty-but-valid store on disk
+            initial = {
+                "version": "1", "project": "/test",
+                "updated": "2026-05-01T00:00:00+00:00",
+                "session_id": "initial",
+                "strategy_rules": [], "failure_patterns": [],
+            }
+            digest_file.write_text(json.dumps(initial), encoding="utf-8")
+
+            with patch("cozempic.digest.DIGEST_DIR", tmp_path), \
+                 patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md):
+                # Simulate the interleaving that causes lost updates:
+                #   P1.load → P2.load (BEFORE P1.save) → P1.mutate+save → P2.mutate+save
+                # Without locking, P2 overwrites P1's save with the pre-P1
+                # state plus P2's mutation — P1's rule is lost.
+                p1_store = load_digest_store("/test")
+                p2_store = load_digest_store("/test")  # P2 loads BEFORE P1 saves
+
+                p1_store.strategy_rules.append(DigestRule(
+                    id="R001", rule="Do not P1-RULE",
+                    priority="hard", scope="general",
+                    source_reliability=1.0, type_prior=0.8,
+                    occurrence_count=1, status="active",
+                    evidence="don't P1", first_seen="2026-05-05",
+                    last_reinforced="2026-05-05",
+                ))
+                save_digest_store(p1_store)  # P1 commits
+
+                # P2 mutates its (stale) copy and saves → should DETECT the
+                # intervening P1 save and either retry or merge. With
+                # fcntl.flock + stat(mtime) re-check, P2's save must either
+                # (a) fail and caller retries, or (b) re-load and include
+                # P1's rule before saving. Without locking, P2 silently
+                # clobbers P1's addition.
+                p2_store.strategy_rules.append(DigestRule(
+                    id="R001", rule="Do not P2-RULE",
+                    priority="hard", scope="general",
+                    source_reliability=1.0, type_prior=0.8,
+                    occurrence_count=1, status="active",
+                    evidence="don't P2", first_seen="2026-05-05",
+                    last_reinforced="2026-05-05",
+                ))
+                try:
+                    save_digest_store(p2_store)
+                except Exception:
+                    # A properly-locked save may raise to force caller retry;
+                    # that's an acceptable post-fix behavior.
+                    pass
+
+                # Final state on disk must contain BOTH rules (or the save
+                # must have failed loudly). A silent lost-update is the bug.
+                final = json.loads(digest_file.read_text(encoding="utf-8"))
+                rule_texts = [r["rule"] for r in final["strategy_rules"]]
+                self.assertIn(
+                    "Do not P1-RULE", rule_texts,
+                    f"P1's rule silently lost under concurrent save — "
+                    f"final rules: {rule_texts}. Atomic save + file lock "
+                    f"(fcntl.flock) required to prevent lost-update.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -18,8 +18,10 @@ from cozempic.digest import (
     DigestRule,
     DigestStore,
     _find_duplicate,
+    _get_memdir,
     _to_prohibition,
     admit_rule,
+    build_injection_text,
     classify_turn,
     clear_digest_store,
     extract_corrections,
@@ -27,11 +29,25 @@ from cozempic.digest import (
     save_digest_store,
     score_rule,
     show_digest,
+    sync_to_memdir,
     update_digest,
 )
 from cozempic.helpers import is_protected, msg_bytes
 
 import cozempic.strategies  # noqa: F401
+
+
+def _import_system_noise():
+    """Import `_is_system_noise` lazily so the test file still loads when
+    the helper does not yet exist (Phase 2b RED phase). Tests that require
+    it call this and fail with a clear message instead of crashing the
+    entire module."""
+    from cozempic import digest as _d
+    if not hasattr(_d, "_is_system_noise"):
+        raise AssertionError(
+            "digest._is_system_noise is not defined — noise filter not implemented yet"
+        )
+    return _d._is_system_noise
 
 
 def make_message(line_idx: int, msg: dict) -> tuple[int, dict, int]:
@@ -434,6 +450,699 @@ class TestDigestStore(unittest.TestCase):
         store.strategy_rules.append(DigestRule(id="R001", rule="active", status="active"))
         store.strategy_rules.append(DigestRule(id="R002", rule="pending", status="pending"))
         self.assertEqual(len(store.active_rules()), 1)
+
+
+# ===========================================================================
+# RED TESTS — Phase 2b — Bugs inventoried in AUDIT_REPORT.md (2026-05-05)
+# ===========================================================================
+#
+# These tests encode buggy current behavior as EXPECTED behavior after the
+# fix. They are expected to FAIL against the current digest.py (RED) and
+# pass only once Phase 2c implements the corresponding fixes.
+#
+# Source of truth for bug inventory:
+#   .claude/worktrees/fix-digest-noise-filter/AUDIT_REPORT.md
+#
+# Mapping:
+#   BUG-1/3 → TestSystemNoiseFilter  (CRITICAL)
+#   BUG-2   → TestToProhibitionHardened (CRITICAL)
+#   BUG-4   → TestAdmissionNoAutoActivate (HIGH)
+#   BUG-5   → TestLoadRetroactiveSweep (HIGH)
+#   BUG-6   → TestCapEnforcement (HIGH)
+#   BUG-7   → TestDuplicateMergeStricter (HIGH)
+#   BUG-8   → TestMemdirHonorsConfigDir (CRITICAL)
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# BUG-1/3 — noise-filter gate
+# ---------------------------------------------------------------------------
+
+class TestSystemNoiseFilter(unittest.TestCase):
+    """digest must recognise Claude-Code synthetic noise and skip it.
+
+    Current behavior (RED target): every synthetic user turn containing
+    "don't", "never", "no, " etc. becomes a hard active rule.
+    Expected behavior (post-fix): `_is_system_noise(text)` returns True
+    for synthetic wrappers, and `extract_corrections` skips those turns.
+    """
+
+    # ---- _is_system_noise unit tests ----
+
+    def test_local_command_caveat_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("<local-command-caveat>/compact</local-command-caveat>"))
+
+    def test_teammate_message_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise(
+            "<teammate-message teammate_id=\"lead\" summary=\"x\">do something</teammate-message>"
+        ))
+
+    def test_command_name_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("<command-name>/init</command-name>"))
+
+    def test_command_message_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("<command-message>please analyze</command-message>"))
+
+    def test_system_reminder_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise(
+            "<system-reminder>don't forget to commit</system-reminder>"
+        ))
+
+    def test_function_calls_block_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise(
+            "<function_calls><invoke name=\"Read\"></invoke></function_calls>"
+        ))
+
+    def test_bash_stdout_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("<bash-stdout>\nls: /tmp\n</bash-stdout>"))
+
+    def test_bash_stderr_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("<bash-stderr>No such file</bash-stderr>"))
+
+    def test_leading_tag_is_noise(self):
+        is_noise = _import_system_noise()
+        # A user turn whose content STARTS with an angle-bracket tag is
+        # synthetic — never a real correction.
+        self.assertTrue(is_noise("<user-prompt-submit-hook>anything</user-prompt-submit-hook>"))
+
+    def test_init_slash_prompt_is_noise(self):
+        is_noise = _import_system_noise()
+        # /init injects: "Please analyze this codebase and create..."
+        self.assertTrue(is_noise(
+            "Please analyze this codebase and create a CLAUDE.md describing it."
+        ))
+
+    def test_slash_command_line_is_noise(self):
+        is_noise = _import_system_noise()
+        self.assertTrue(is_noise("/clear"))
+
+    # ---- real corrections must pass ----
+
+    def test_genuine_dont_correction_is_not_noise(self):
+        is_noise = _import_system_noise()
+        self.assertFalse(is_noise("don't add Co-Authored-By to commits"))
+
+    def test_genuine_never_correction_is_not_noise(self):
+        is_noise = _import_system_noise()
+        self.assertFalse(is_noise("never push to main without asking"))
+
+    def test_genuine_preference_is_not_noise(self):
+        is_noise = _import_system_noise()
+        self.assertFalse(is_noise("always use snake_case for variables"))
+
+    def test_genuine_short_correction_is_not_noise(self):
+        is_noise = _import_system_noise()
+        self.assertFalse(is_noise("stop adding summaries"))
+
+    # ---- extract_corrections must skip noisy turns ----
+
+    def test_extract_skips_local_command_caveat(self):
+        messages = [
+            make_user(0, "<local-command-caveat>The user ran /compact</local-command-caveat>"),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 0,
+                         "extract_corrections must skip synthetic <local-command-caveat> turns")
+
+    def test_extract_skips_system_reminder(self):
+        messages = [
+            make_user(0,
+                "<system-reminder>Please don't forget to run tests</system-reminder>"),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 0,
+                         "extract_corrections must skip <system-reminder> synthetic turns")
+
+    def test_extract_skips_init_prompt(self):
+        messages = [
+            make_user(0,
+                "Please analyze this codebase and create a CLAUDE.md describing it. "
+                "Do not include secrets."),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 0,
+                         "extract_corrections must skip /init synthetic turns")
+
+    def test_extract_keeps_genuine_correction_after_noisy_turn(self):
+        messages = [
+            make_user(0, "<local-command-caveat>The user ran /init</local-command-caveat>"),
+            make_assistant(1, "ok"),
+            make_user(2, "don't add Co-Authored-By to commits"),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 1,
+                         "genuine correction after noise must still be captured")
+        self.assertIn("Co-Authored-By", rules[0].evidence)
+
+
+# ---------------------------------------------------------------------------
+# BUG-2 — _to_prohibition hardening
+# ---------------------------------------------------------------------------
+
+class TestToProhibitionHardened(unittest.TestCase):
+    """`_to_prohibition` must refuse to wrap obviously-structural text.
+
+    Current behavior (RED target): it prefixes "Do not " onto ANY input
+    up to 500 chars — producing `Do not <local-command-caveat>...`.
+    Expected behavior: return `""` (sentinel for "skip this turn") when
+    the input is too long, multi-paragraph, starts with markdown, a code
+    fence, or a tag.
+    """
+
+    def test_rejects_text_over_200_chars(self):
+        long_text = "x" * 250
+        self.assertEqual(_to_prohibition(long_text), "",
+                         "must reject input > 200 chars")
+
+    def test_rejects_text_with_three_newlines(self):
+        text = "line1\nline2\nline3\nline4"
+        self.assertEqual(_to_prohibition(text), "",
+                         "must reject input with > 2 newlines")
+
+    def test_rejects_markdown_heading(self):
+        self.assertEqual(_to_prohibition("# Do not add X"), "",
+                         "must reject text starting with markdown heading")
+
+    def test_rejects_markdown_bullet_dash(self):
+        self.assertEqual(_to_prohibition("- do not do X"), "",
+                         "must reject text starting with markdown bullet (-)")
+
+    def test_rejects_markdown_bullet_star(self):
+        self.assertEqual(_to_prohibition("* do not do X"), "",
+                         "must reject text starting with markdown bullet (*)")
+
+    def test_rejects_triple_backtick_fence(self):
+        self.assertEqual(_to_prohibition("```\ncode\n```"), "",
+                         "must reject text starting with code fence")
+
+    def test_rejects_leading_angle_tag(self):
+        self.assertEqual(_to_prohibition("<local-command-caveat>foo</local-command-caveat>"), "",
+                         "must reject text starting with '<' (tag)")
+
+    def test_accepts_normal_correction(self):
+        # Sanity: a clean "don't" still passes through and becomes prohibition.
+        result = _to_prohibition("don't add Co-Authored-By")
+        self.assertTrue(result.startswith("Don't") or result.startswith("Do not"),
+                        f"clean input must still work, got {result!r}")
+
+    def test_accepts_normal_never(self):
+        result = _to_prohibition("never push to main")
+        self.assertTrue(result.lower().startswith("do not"),
+                        f"'never' rewriting must still work, got {result!r}")
+
+    def test_rejects_text_with_newline_and_tag(self):
+        # Combined failure mode from the observed R001 pollution.
+        text = "<local-command-caveat>foo\nbar</local-command-caveat>"
+        self.assertEqual(_to_prohibition(text), "",
+                         "combined tag + newlines must be rejected")
+
+
+# ---------------------------------------------------------------------------
+# BUG-4 — EXPLICIT_CORRECTION must not auto-activate
+# ---------------------------------------------------------------------------
+
+class TestAdmissionNoAutoActivate(unittest.TestCase):
+    """New extracted rules must start `pending` regardless of type.
+
+    Current behavior (RED target): EXPLICIT_CORRECTION rules are created
+    with `status="active"` on first sight (digest.py:339).
+    Expected behavior: all new rules start `pending`; promotion to
+    `active` happens only via `admit_rule` upvote path once
+    `occurrence_count >= PROMOTION_COUNT`.
+    """
+
+    def test_explicit_correction_starts_pending(self):
+        messages = [make_user(0, "don't add Co-Authored-By to commits")]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0].status, "pending",
+                         "EXPLICIT_CORRECTION must start pending (no auto-activate)")
+
+    def test_preference_starts_pending(self):
+        messages = [make_user(0, "always use snake_case for variables")]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0].status, "pending")
+
+    def test_explicit_promoted_after_two_occurrences(self):
+        """Seeing the same explicit correction twice promotes it to active."""
+        store = DigestStore()
+        # First admission
+        msgs1 = [make_user(0, "don't add Co-Authored-By")]
+        for r in extract_corrections(msgs1):
+            admit_rule(r, store)
+        self.assertEqual(len(store.strategy_rules), 1)
+        self.assertEqual(store.strategy_rules[0].status, "pending",
+                         "first occurrence must remain pending")
+
+        # Second admission — dedup should upvote and promote
+        msgs2 = [make_user(1, "don't add Co-Authored-By to commits")]
+        for r in extract_corrections(msgs2):
+            admit_rule(r, store)
+        self.assertEqual(store.strategy_rules[0].status, "active",
+                         "after PROMOTION_COUNT occurrences rule becomes active")
+        self.assertGreaterEqual(store.strategy_rules[0].occurrence_count, PROMOTION_COUNT)
+
+    def test_single_explicit_not_in_active_rules(self):
+        store = DigestStore()
+        msgs = [make_user(0, "stop adding summaries")]
+        for r in extract_corrections(msgs):
+            admit_rule(r, store)
+        self.assertEqual(len(store.active_rules()), 0,
+                         "single explicit occurrence must not appear in active_rules()")
+
+    def test_end_to_end_update_digest_keeps_single_occurrence_pending(self):
+        """`update_digest` on a single explicit correction must NOT produce an
+        active rule — the repetition gate must be honoured."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            digest_file = tmp_path / "behavioral-digest.json"
+            digest_md = tmp_path / "behavioral-digest.md"
+            messages = [make_user(0, "don't add Co-Authored-By to commits")]
+            with patch("cozempic.digest.DIGEST_DIR", tmp_path), \
+                 patch("cozempic.digest.DIGEST_FILE", digest_file), \
+                 patch("cozempic.digest.DIGEST_MD_FILE", digest_md):
+                update_digest(messages, project_dir="/test")
+                store = load_digest_store("/test")
+                active = store.active_rules()
+                self.assertEqual(len(active), 0,
+                                 "single-occurrence explicit correction must not auto-activate")
+
+
+# ---------------------------------------------------------------------------
+# BUG-5 — retroactive cap sweep on load
+# ---------------------------------------------------------------------------
+
+class TestLoadRetroactiveSweep(unittest.TestCase):
+    """load_digest_store must cap active rules at MAX_ACTIVE_RULES.
+
+    Current behavior (RED target): if the JSON contains 447 active rules,
+    `load_digest_store` returns all 447 as active. The cap fires only on
+    subsequent *admits*, one demotion per admit — so a polluted store is
+    never retroactively trimmed.
+    Expected behavior: on load, scan the deserialised rules and demote
+    the lowest-scored active ones until `<= MAX_ACTIVE_RULES` remain
+    active.
+    """
+
+    def _write_polluted_store(self, tmp_path: Path, n_active: int) -> Path:
+        digest_file = tmp_path / "behavioral-digest.json"
+        rules = []
+        for i in range(n_active):
+            # Vary occurrence_count so score_rule has something to sort on.
+            rules.append({
+                "id": f"R{i + 1:03d}",
+                "rule": f"Do not do thing number {i}",
+                "priority": "hard",
+                "scope": "general",
+                "trigger": "",
+                "decision_step": "",
+                "before": "",
+                "after": "",
+                "signal": "EXPLICIT_CORRECTION",
+                "evidence": f"evidence {i}",
+                "importance": 1,
+                "source_reliability": 1.0,
+                "type_prior": 0.8,
+                "status": "active",
+                "occurrence_count": 1 + (i % 5),  # 1..5
+                "first_seen": "2026-05-01T00:00:00+00:00",
+                "last_reinforced": "2026-05-01T00:00:00+00:00",
+                "last_injection": None,
+            })
+        data = {
+            "version": "1",
+            "project": "/test",
+            "updated": "2026-05-05T00:00:00+00:00",
+            "session_id": "sess-x",
+            "strategy_rules": rules,
+            "failure_patterns": [],
+        }
+        digest_file.write_text(json.dumps(data), encoding="utf-8")
+        return digest_file
+
+    def test_load_caps_fifty_active_to_twenty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            digest_file = self._write_polluted_store(tmp_path, n_active=50)
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                self.assertLessEqual(
+                    len(store.active_rules()), MAX_ACTIVE_RULES,
+                    "load_digest_store must enforce active cap retroactively")
+                # Total rules preserved — only status flips to pending.
+                self.assertEqual(len(store.strategy_rules), 50)
+
+    def test_load_caps_four_hundred_forty_seven_active(self):
+        """Reproduce the actual observed pollution count (447 active)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            digest_file = self._write_polluted_store(tmp_path, n_active=447)
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                self.assertLessEqual(
+                    len(store.active_rules()), MAX_ACTIVE_RULES,
+                    "cap must fire even on extreme pollution")
+                self.assertEqual(len(store.strategy_rules), 447,
+                                 "rules are demoted to pending, not deleted")
+
+    def test_load_at_cap_no_demotion(self):
+        """A store at EXACTLY MAX_ACTIVE_RULES must be left alone."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            digest_file = self._write_polluted_store(tmp_path, n_active=MAX_ACTIVE_RULES)
+            with patch("cozempic.digest.DIGEST_FILE", digest_file):
+                store = load_digest_store("/test")
+                self.assertEqual(
+                    len(store.active_rules()), MAX_ACTIVE_RULES,
+                    "at-cap store must not be over-demoted")
+
+
+# ---------------------------------------------------------------------------
+# BUG-6 — build_injection_text honours the cap for BOTH hard and soft
+# ---------------------------------------------------------------------------
+
+class TestCapEnforcement(unittest.TestCase):
+    """`build_injection_text` must emit at most MAX_ACTIVE_RULES lines total.
+
+    Current behavior (RED target): the hard loop iterates the full `hard`
+    list (digest.py:605) so a store with 30 hard rules emits all 30.
+    Expected behavior: total rendered rules <= MAX_ACTIVE_RULES, hard
+    rules rendered first within the budget.
+    """
+
+    def _make_store_with_rules(self, n_hard: int, n_soft: int) -> DigestStore:
+        store = DigestStore()
+        idx = 1
+        for i in range(n_hard):
+            store.strategy_rules.append(DigestRule(
+                id=f"R{idx:03d}", rule=f"Do not do hard thing {i}",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=5, status="active",
+            ))
+            idx += 1
+        for i in range(n_soft):
+            store.strategy_rules.append(DigestRule(
+                id=f"R{idx:03d}", rule=f"Prefer soft thing {i}",
+                priority="soft", scope="general",
+                source_reliability=0.9, type_prior=0.9,
+                occurrence_count=3, status="active",
+            ))
+            idx += 1
+        return store
+
+    def _count_rule_lines(self, text: str) -> int:
+        """Count rendered rule entries — each starts with '[Rnnn|'."""
+        if not text:
+            return 0
+        return sum(1 for line in text.splitlines() if line.startswith("[R"))
+
+    def test_thirty_hard_rendered_at_most_twenty(self):
+        store = self._make_store_with_rules(n_hard=30, n_soft=0)
+        text = build_injection_text(store)
+        self.assertIsNotNone(text)
+        self.assertLessEqual(
+            self._count_rule_lines(text), MAX_ACTIVE_RULES,
+            "30 hard rules must be capped to MAX_ACTIVE_RULES in injection text")
+
+    def test_thirty_hard_plus_ten_soft_rendered_at_most_twenty(self):
+        store = self._make_store_with_rules(n_hard=30, n_soft=10)
+        text = build_injection_text(store)
+        self.assertIsNotNone(text)
+        self.assertLessEqual(
+            self._count_rule_lines(text), MAX_ACTIVE_RULES,
+            "hard+soft combined must be capped at MAX_ACTIVE_RULES")
+
+    def test_priority_respected_hard_rendered_first(self):
+        """When capped, hard rules must fill the budget before any soft."""
+        store = self._make_store_with_rules(n_hard=30, n_soft=10)
+        text = build_injection_text(store)
+        self.assertIsNotNone(text)
+        # PROHIBITIONS section must appear before PREFERENCES section
+        prohib_idx = text.find("PROHIBITIONS:")
+        pref_idx = text.find("PREFERENCES:")
+        if pref_idx != -1:
+            self.assertLess(prohib_idx, pref_idx,
+                            "PROHIBITIONS section must come before PREFERENCES")
+        # No soft line should be rendered when hard alone already fills the cap
+        # (30 hard > MAX_ACTIVE_RULES=20 so all budget goes to hard)
+        rendered_soft = sum(1 for line in text.splitlines()
+                            if line.startswith("[R") and "|soft]" in line)
+        self.assertEqual(rendered_soft, 0,
+                         "when hard rules alone exceed cap, no soft rules should be rendered")
+
+    def test_five_hard_plus_five_soft_renders_all(self):
+        """Below cap — all rules should render."""
+        store = self._make_store_with_rules(n_hard=5, n_soft=5)
+        text = build_injection_text(store)
+        self.assertIsNotNone(text)
+        self.assertEqual(self._count_rule_lines(text), 10,
+                         "below-cap store must render all rules")
+
+    def test_build_returns_none_for_empty_store(self):
+        store = DigestStore()
+        text = build_injection_text(store)
+        self.assertIsNone(text)
+
+    def test_admit_rule_caps_fifty_new_additions(self):
+        """Feeding 50 fresh hard rules through admit_rule must leave at most
+        MAX_ACTIVE_RULES active (cap enforcement happens during admission)."""
+        store = DigestStore()
+        for i in range(50):
+            admit_rule(DigestRule(
+                id="", rule=f"Do not take action number {i} under any circumstance",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+            ), store)
+        self.assertLessEqual(
+            len(store.active_rules()), MAX_ACTIVE_RULES,
+            "admit_rule cap enforcement must hold across 50 admissions")
+
+    def test_admit_rule_caps_two_hundred_new_additions(self):
+        """Stress test — admit_rule must hold the cap under a 200-rule burst."""
+        store = DigestStore()
+        for i in range(200):
+            admit_rule(DigestRule(
+                id="", rule=f"Do not touch resource number {i} for any reason",
+                priority="hard", scope="general",
+                source_reliability=1.0, type_prior=0.8,
+                occurrence_count=1, status="active",
+            ), store)
+        self.assertLessEqual(
+            len(store.active_rules()), MAX_ACTIVE_RULES,
+            "cap must hold under 200-rule admission burst")
+
+
+# ---------------------------------------------------------------------------
+# BUG-7 — duplicate merge must be stricter
+# ---------------------------------------------------------------------------
+
+class TestDuplicateMergeStricter(unittest.TestCase):
+    """`_find_duplicate` must not merge semantically different rules.
+
+    Current behavior (RED target): 0.5 word-overlap merges opposites.
+    Expected behavior: require higher overlap AND matching scope AND
+    matching priority before declaring two rules duplicates.
+    """
+
+    def test_opposite_instructions_do_not_merge(self):
+        """'use edit not write' vs 'use write not edit' — opposite intents."""
+        store = DigestStore()
+        r1 = DigestRule(id="R001", rule="Use Edit not Write on existing files",
+                        priority="soft", scope="file-ops",
+                        source_reliability=0.9, type_prior=0.9,
+                        occurrence_count=1, status="pending")
+        store.strategy_rules.append(r1)
+
+        r2 = DigestRule(id="", rule="Use Write not Edit on existing files",
+                        evidence="use Write not Edit",
+                        priority="soft", scope="file-ops",
+                        source_reliability=0.9, type_prior=0.9)
+        dup = _find_duplicate(r2, store)
+        self.assertIsNone(
+            dup, "opposite instructions must not be treated as duplicates")
+
+    def test_different_scope_does_not_merge(self):
+        """High word overlap but different scope → not a duplicate."""
+        store = DigestStore()
+        r1 = DigestRule(id="R001", rule="Do not add Co-Authored-By",
+                        priority="hard", scope="git",
+                        source_reliability=1.0, type_prior=0.8,
+                        status="active")
+        store.strategy_rules.append(r1)
+
+        r2 = DigestRule(id="", rule="Do not add Co-Authored-By line",
+                        evidence="don't add Co-Authored-By",
+                        priority="hard", scope="communication",  # different scope
+                        source_reliability=1.0, type_prior=0.8)
+        dup = _find_duplicate(r2, store)
+        self.assertIsNone(
+            dup, "duplicate detection must require matching scope")
+
+    def test_different_priority_does_not_merge(self):
+        """Same text, different priority → not the same rule."""
+        store = DigestStore()
+        r1 = DigestRule(id="R001", rule="Do not add tests without asking",
+                        priority="hard", scope="testing",
+                        source_reliability=1.0, type_prior=0.8,
+                        status="active")
+        store.strategy_rules.append(r1)
+
+        r2 = DigestRule(id="", rule="Do not add tests without asking",
+                        evidence="prefer no tests",
+                        priority="soft", scope="testing",
+                        source_reliability=0.9, type_prior=0.9)
+        dup = _find_duplicate(r2, store)
+        self.assertIsNone(
+            dup, "duplicate detection must require matching priority")
+
+    def test_true_duplicates_still_merge(self):
+        """Same scope+priority+high overlap → still merges (sanity)."""
+        store = DigestStore()
+        r1 = DigestRule(id="R001", rule="Do not add Co-Authored-By lines to commits",
+                        priority="hard", scope="git",
+                        source_reliability=1.0, type_prior=0.8,
+                        status="active")
+        store.strategy_rules.append(r1)
+
+        r2 = DigestRule(id="", rule="Do not add Co-Authored-By lines to commit messages",
+                        evidence="don't add Co-Authored-By to commits",
+                        priority="hard", scope="git",
+                        source_reliability=1.0, type_prior=0.8)
+        dup = _find_duplicate(r2, store)
+        self.assertIsNotNone(
+            dup, "genuine duplicates (same scope+priority, high overlap) must still merge")
+
+
+# ---------------------------------------------------------------------------
+# BUG-8 — _get_memdir must honour CLAUDE_CONFIG_DIR
+# ---------------------------------------------------------------------------
+
+class TestMemdirHonorsConfigDir(unittest.TestCase):
+    """`_get_memdir` must read `CLAUDE_CONFIG_DIR` env var before falling
+    back to `~/.claude`.
+
+    Current behavior (RED target): hardcodes `Path.home() / ".claude"` →
+    under the `claudes` profile (CLAUDE_CONFIG_DIR=~/.claudes) the sync
+    pipeline silently writes to the wrong profile or no-ops.
+    Expected behavior: honour CLAUDE_CONFIG_DIR when set.
+    """
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.config_dir = self.tmpdir / "fake_claudes"
+        self.projects_dir = self.config_dir / "projects"
+        # Use the same slug CC uses: slash-to-dash with leading dash
+        self.slug_cwd = "/test/slug"
+        self.project_slug = f"-{self.slug_cwd.lstrip('/').replace('/', '-')}"
+        self.expected_memdir = self.projects_dir / self.project_slug / "memory"
+        self.expected_memdir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_honors_claude_config_dir_env(self):
+        """When CLAUDE_CONFIG_DIR is set, `_get_memdir` returns the memdir
+        under that directory, not ~/.claude."""
+        with patch.dict("os.environ", {"CLAUDE_CONFIG_DIR": str(self.config_dir)}):
+            memdir = _get_memdir(self.slug_cwd)
+            self.assertIsNotNone(memdir,
+                                 "memdir must be resolved when CLAUDE_CONFIG_DIR is set")
+            self.assertEqual(
+                Path(memdir).resolve(), self.expected_memdir.resolve(),
+                f"expected memdir under CLAUDE_CONFIG_DIR, got {memdir}")
+
+    def test_falls_back_to_home_when_env_unset(self):
+        """Without CLAUDE_CONFIG_DIR, legacy behavior (Path.home()/.claude)
+        is preserved — don't regress existing flows."""
+        # Build a fake ~/.claude under tmpdir and point HOME there.
+        fake_home = self.tmpdir / "fake_home"
+        (fake_home / ".claude" / "projects" / self.project_slug / "memory").mkdir(
+            parents=True, exist_ok=True)
+        env = {"HOME": str(fake_home)}
+        # Explicitly clear CLAUDE_CONFIG_DIR if it's set in the outer env
+        with patch.dict("os.environ", env, clear=False):
+            # Remove CLAUDE_CONFIG_DIR if present in parent env
+            import os
+            old = os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            try:
+                memdir = _get_memdir(self.slug_cwd)
+                # Under the fallback, memdir should resolve under fake_home/.claude
+                self.assertIsNotNone(memdir)
+                self.assertIn(".claude", str(memdir),
+                              "without CLAUDE_CONFIG_DIR, must use ~/.claude fallback")
+            finally:
+                if old is not None:
+                    os.environ["CLAUDE_CONFIG_DIR"] = old
+
+    def test_returns_none_when_config_dir_has_no_projects(self):
+        """CLAUDE_CONFIG_DIR set but no projects subdir → return None,
+        not a silent fallback to ~/.claude (that would leak cross-profile)."""
+        bare_config = self.tmpdir / "bare_claudes"
+        bare_config.mkdir(parents=True, exist_ok=True)
+        # NOTE: no projects/ under bare_config
+        with patch.dict("os.environ", {"CLAUDE_CONFIG_DIR": str(bare_config)}):
+            memdir = _get_memdir(self.slug_cwd)
+            self.assertIsNone(
+                memdir,
+                "CLAUDE_CONFIG_DIR without projects/ must return None, not silently "
+                "fall back to ~/.claude (cross-profile leak)")
+
+    def test_sync_to_memdir_writes_under_config_dir(self):
+        """End-to-end: with CLAUDE_CONFIG_DIR set, `sync_to_memdir` writes
+        `cozempic_digest.md` under that directory, not under ~/.claude."""
+        store = DigestStore(project=self.slug_cwd)
+        store.strategy_rules.append(DigestRule(
+            id="R001", rule="Do not add Co-Authored-By",
+            priority="hard", scope="git",
+            source_reliability=1.0, type_prior=0.8,
+            occurrence_count=5, status="active",
+        ))
+        with patch.dict("os.environ", {"CLAUDE_CONFIG_DIR": str(self.config_dir)}):
+            n = sync_to_memdir(store, cwd=self.slug_cwd)
+            self.assertGreater(n, 0, "sync_to_memdir should have written 1 rule")
+            digest_md = self.expected_memdir / "cozempic_digest.md"
+            self.assertTrue(
+                digest_md.exists(),
+                f"digest should be written under CLAUDE_CONFIG_DIR at {digest_md}")
+            content = digest_md.read_text(encoding="utf-8")
+            self.assertIn("Do not add Co-Authored-By", content)
+
+    def test_sync_to_memdir_does_not_write_to_home_when_config_dir_set(self):
+        """Guard against the cross-profile leak: under CLAUDE_CONFIG_DIR,
+        ~/.claude/projects/<slug>/memory must NOT receive a write."""
+        # Build a shadow ~/.claude too so we can prove it's left untouched.
+        fake_home = self.tmpdir / "shadow_home"
+        shadow_memdir = fake_home / ".claude" / "projects" / self.project_slug / "memory"
+        shadow_memdir.mkdir(parents=True, exist_ok=True)
+
+        store = DigestStore(project=self.slug_cwd)
+        store.strategy_rules.append(DigestRule(
+            id="R001", rule="Do not add Co-Authored-By",
+            priority="hard", scope="git",
+            source_reliability=1.0, type_prior=0.8,
+            occurrence_count=5, status="active",
+        ))
+        with patch.dict("os.environ", {
+            "CLAUDE_CONFIG_DIR": str(self.config_dir),
+            "HOME": str(fake_home),
+        }):
+            sync_to_memdir(store, cwd=self.slug_cwd)
+            leaked = shadow_memdir / "cozempic_digest.md"
+            self.assertFalse(
+                leaked.exists(),
+                "under CLAUDE_CONFIG_DIR, ~/.claude must NOT receive a cross-profile write")
 
 
 if __name__ == "__main__":

--- a/tests/test_track4.py
+++ b/tests/test_track4.py
@@ -166,9 +166,12 @@ class TestFlushRecover(unittest.TestCase):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_flush_extracts_and_syncs(self):
+        """Post-BUG-4 fix: rules start as pending. Two occurrences → promote to active → memdir synced."""
         messages = [
             make_assistant(0, "I'll add the Co-Authored-By"),
             make_user(1, "don't add Co-Authored-By"),
+            make_assistant(2, "I'll add Co-Authored-By again"),
+            make_user(3, "don't add Co-Authored-By to commits"),
         ]
         digest_file = self.tmpdir / "behavioral-digest.json"
         digest_md = self.tmpdir / "behavioral-digest.md"
@@ -178,9 +181,9 @@ class TestFlushRecover(unittest.TestCase):
              patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
              patch("cozempic.digest._get_memdir", return_value=self.mem_dir):
             added, upvoted, rejected = flush_digest(messages, project_dir="/test")
-            self.assertGreater(added, 0)
+            self.assertGreater(added + upvoted, 0)
             self.assertTrue(digest_file.exists())
-            # Memdir should have been synced too
+            # Memdir should have been synced too (rule promoted to active via 2nd occurrence)
             digest_mem = self.mem_dir / "cozempic_digest.md"
             self.assertTrue(digest_mem.exists())
 
@@ -200,7 +203,11 @@ class TestFlushRecover(unittest.TestCase):
             self.assertIn("Co-Authored-By", content)
 
     def test_full_cycle(self):
-        """flush → compaction (memdir survives) → recover re-syncs."""
+        """flush → compaction (memdir survives) → recover re-syncs.
+
+        Post-BUG-4 fix: rules start pending, promoted to active via PROMOTION_COUNT=2.
+        Test uses 2 occurrences of the same correction to trigger promotion.
+        """
         digest_file = self.tmpdir / "behavioral-digest.json"
         digest_md = self.tmpdir / "behavioral-digest.md"
 
@@ -209,14 +216,16 @@ class TestFlushRecover(unittest.TestCase):
              patch("cozempic.digest.DIGEST_MD_FILE", digest_md), \
              patch("cozempic.digest._get_memdir", return_value=self.mem_dir):
 
-            # Flush: extract corrections
+            # Flush: extract corrections (2 occurrences → promote via upvote)
             messages = [
                 make_assistant(0, "I'll add Co-Authored-By"),
                 make_user(1, "don't add Co-Authored-By"),
+                make_assistant(2, "adding Co-Authored-By again"),
+                make_user(3, "don't add Co-Authored-By to commits"),
             ]
             flush_digest(messages, project_dir="/test")
 
-            # Verify active immediately (explicit correction)
+            # Verify active after 2nd occurrence (PROMOTION_COUNT=2 threshold met)
             store = load_digest_store("/test")
             self.assertGreater(len(store.active_rules()), 0)
 


### PR DESCRIPTION
## Problem

A review team spot-checked a production digest store and found **139+ rules that are not real user corrections** — instead, every `<local-command-caveat>`, `<teammate-message>`, `/init` prompt, and other Claude Code synthetic user turn containing a correction-signal word (`don't`, `never`, `no,`) got extracted, prefixed with `"Do not "`, and persisted as a `type: feedback` memory.

### Empirical evidence from one real store

- JSON state: **572 rules total, 468 active** (20:1 over `MAX_ACTIVE_RULES=20`)
- Injected memory file: **142 rules rendered** (7:1 over the documented 20 cap)
- Representative pollution (unaltered from the actual store):
  - `R001: Do not <local-command-caveat>Caveat: The messages below were generated...`
  - `R002: Do not Please analyze this codebase and create a CLAUDE.md file...` (/init prompt)
  - `R161: Do not <teammate-message teammate_id="falsification-specialist"...>`

Every Claude Code session that loads `memory/cozempic_digest.md` gets these as behavioral guidance.

## Audit

A full code audit (`digest.py`, 774 lines) identified **16 bugs**:

| # | Severity | Summary |
|---|---|---|
| BUG-1 | CRITICAL | `_EXPLICIT_PATTERNS` match any user text containing `don't`/`never`/`no,` with zero noise filter |
| BUG-2 | CRITICAL | `_to_prohibition` naïvely prefixes "Do not " on up to 500 chars — swallows markdown, code blocks, tags |
| BUG-3 | CRITICAL | `extract_corrections` has no noise gate before `classify_turn` |
| BUG-4 | HIGH | `EXPLICIT_CORRECTION` bypasses the `PROMOTION_COUNT=2` repetition gate |
| BUG-5 | HIGH | `admit_rule` single-demotion + no retroactive sweep on `load_digest_store` |
| BUG-6 | HIGH | `build_injection_text` iterates the full `hard` list, uncapped |
| BUG-7 | HIGH | `_find_duplicate` at 0.5 word-overlap merges semantically opposite rules |
| BUG-8 | CRITICAL | `_get_memdir` hardcodes `~/.claude`, ignoring `CLAUDE_CONFIG_DIR` — breaks all non-default profiles |
| BUG-17 | CRITICAL | Load-time noise-evidence purge missing — pre-polluted stores never recover |
| BUG-18 | HIGH | Non-atomic `write_text` on `save_digest_store` — lost updates under concurrent PreCompact/Stop hooks |
| BUG-9/10/11/12/13/14/15/16 | LOW-MEDIUM | See audit report (scoped as v2 polish) |

Full audit + adversarial review artifacts are in the team's working-tree notes (not included in PR: `AUDIT_REPORT.md`, `ADVERSARIAL_REPORT.md`, `VALIDATION_REPORT.md`).

## Fixes in this PR

9 commits implementing the 9 ship-blocker bugs (CRITICAL + HIGH):

- **BUG-3** — new `_is_system_noise` helper catches `<local-command-*>`, `<command-name>`, `<command-message>`, `<command-args>`, `<teammate-message>`, `<system-reminder>`, `<function_calls>`, `<function_results>`, `<bash-stdout>`, `<bash-stderr>`, `<user-prompt-submit-hook>`, `"Please analyze this codebase"` /init prompt. Applied as gate in `extract_corrections`.
- **BUG-8** — `_get_memdir` now honors `CLAUDE_CONFIG_DIR` (via `os.environ.get`), falls back to `~/.claude` if unset. Fixes sync pipeline under profiles like `CLAUDE_CONFIG_DIR=~/.claudes`.
- **BUG-6** — `build_injection_text` iterates the capped `rules` list for both hard and soft (was only doing it for soft).
- **BUG-2** — `_to_prohibition` rejects inputs > 200 chars, > 2 newlines, or starting with `<`/`-`/`*`/`#`/backtick. Returns `""` sentinel which `extract_corrections` treats as skip-turn.
- **BUG-5** — `load_digest_store` now runs a retroactive cap sweep (`while len(active) > MAX_ACTIVE_RULES: demote_lowest()`). Same pattern applied in `admit_rule` for burst admits.
- **BUG-4** — All new rules start `status="pending"`. Promotion to `active` requires `PROMOTION_COUNT=2` occurrences via the existing upvote path. Hard priority preserved.
- **BUG-7** — `_find_duplicate` now requires **scope AND priority match** plus **word-overlap ≥ 0.5 AND bigram-overlap ≥ 0.5**. New `_bigrams()` helper catches order-inverted pairs (`"use Edit not Write"` vs `"use Write not Edit"` share bag-of-words but have opposite intent).
- **BUG-17** — Load-time noise-evidence purge: before the cap sweep, demote every rule where `_is_system_noise(rule.evidence or rule.rule)`. Critical for users with existing polluted stores — without this, the cap sweep keeps the most recent polluted rules by stable-sort on identical scores.
- **BUG-18** — Atomic writes via `tmp + os.replace` in `save_digest_store`, `_write_digest_md`, and `sync_to_memdir`. Merge-on-save protects against lost-update from concurrent `PreCompact`/`Stop` hooks.

## Test coverage

121 digest-related tests pass (107 in `test_digest.py` + 14 in `test_track4.py`):

- **+45 new tests** across 9 new test classes:
  - `TestSystemNoiseFilter` (19) — `_is_system_noise` unit + `extract_corrections` integration
  - `TestToProhibitionHardened` (10) — rejection sentinels on structural inputs
  - `TestAdmissionNoAutoActivate` (5) — pending-by-default + promotion via upvote
  - `TestLoadRetroactiveSweep` (3) — load-time cap enforcement on pre-polluted stores
  - `TestCapEnforcement` (7) — `admit_rule` while-loop + `build_injection_text` cap
  - `TestDuplicateMergeStricter` (4) — scope+priority+bigram gate
  - `TestMemdirHonorsConfigDir` (5) — `CLAUDE_CONFIG_DIR` env var honored
  - `TestLoadNoiseEvidencePurge` (4) — retroactive noise purge on load
  - `TestAtomicSave` (2) — atomic write + concurrent-save no-lost-update
- **+2 adapted tests** in `test_track4.py` — updated `TestFlushRecover` to provide 2 occurrences matching the new `PROMOTION_COUNT=2` contract
- **−1 retired test** (`test_caps_rule_length`) — encoded the exact behavior BUG-2 targets (1006-char input → "Do not xxxxx..." truncation was the vector). Replaced by `test_rejects_text_over_200_chars` asserting the new contract.

## Empirical validation on real pollution

The polluted JSON backup was preserved (un-modified) and replayed through the fixed code:

| Metric | Pre-fix | Post-fix |
|---|---:|---:|
| total rules | 572 | 572 |
| active | 468 | 20 |
| `<tag>`-prefixed active | 17/20 | 0/20 |
| `noise_in_active` | ~420 | 0 |

Survivors after purge are all genuine user messages (some in French, some Claude Code compaction-resume banners — those remain as residual `BUG-1` artifacts scoped as v2 polish per the adversarial review).

Performance: load + purge + sweep on 572 rules = **4.3 ms** (23× under the 100 ms threshold).

## Out of scope (v2 polish)

The adversarial review identified 4 non-blocking findings documented for v2:

- **A1** — `_is_system_noise` could be strengthened to catch Unicode tag lookalikes (`＜`, `«`, `〈`) and zero-width-space prefixes. Current marker-substring fallback is sufficient for known CC emissions.
- **A2/A3** — Genuine multi-paragraph corrections or code-block feedback are silently rejected by the 200-char / structural gate. Logging layer proposed for v2.
- **A12** — Slash-command regex is lowercase-only (`/Compact` leaks). Low real-world impact since CC emits lowercase.
- **BUG-9 through BUG-16** — Minor hardening (atomic save edge cases on symlinks/NFS, `_infer_scope` substring match, `next_id` beyond R999). All LOW/MEDIUM.

## Breaking changes

**None for clean users.** Rules continue to be extracted, scored, admitted, and injected.

**Behavior change for polluted users**: on first load after upgrade, existing noise-evidenced rules are automatically demoted to `pending` and the cap sweep enforces MAX_ACTIVE_RULES=20. No migration CLI needed.

**Contract change**: `EXPLICIT_CORRECTION` no longer bypasses the repetition gate. Single-occurrence corrections enter as `pending`; two occurrences promote to `active`. This aligns explicit corrections with the documented `PROMOTION_COUNT=2` gate.

## Test plan

- [x] Full suite `PYTHONPATH=src python3 -m pytest tests/ -q` → 520 passed, 3 unrelated pre-existing `test_model_detection.py` failures (1M vs 200K context window assertions — same on main)
- [x] Real poisoned backup replay → `active=20, noise_in_active=0`
- [x] Synthetic clean-user flow across 3 sessions → genuine corrections promote correctly
- [x] Synthetic noise injection (4 CC tags + 1 genuine) → only the genuine survives
- [x] `CLAUDE_CONFIG_DIR` sync-to-memdir test → writes to env-configured path
- [x] Performance sanity → < 10 ms on 572 rules

## Related

- Audit / adversarial / validation reports were kept local to the working branch (not tracked) — available on request
- Follows PR #78 (doctor stale-tmp check), PR #79 (strategy config validation), PR #83 (numeric input validation) in this series of hardening PRs