### PR TITLE
fix(guard): harden PID-identity gates, atomic pidfile, and subprocess arg handling (17 bugs + 2 rounds adversarial)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,461 @@
+# guard.py Audit Report — v1.8.7
+
+Scope: `src/cozempic/guard.py` @ branch `audit/guard-py-hardening` (worktree `e-guard-audit`), 1346 LOC.
+Methodology: full read + cross-file trace of helpers (`session.py`, `helpers.py`) + git log review to skip already-fixed regressions + existing `tests/test_guard_robustness.py` coverage check.
+
+---
+
+## Confirmed bugs
+
+Severity scale: CRITICAL (data loss / kill-wrong-process / security), HIGH (operational regression, silent unprotected session), MED (resource leak, resilience gap), LOW (edge-case hygiene).
+
+Existing robustness test (`tests/test_guard_robustness.py`) covers: SIGTERM constant, backup-cleanup importability, `reload_self_daemon` short-circuit when no daemon, `start_guard_daemon` passes `--claude-pid`. NONE of the bugs below are covered.
+
+---
+
+### BUG-G1 — `_cleanup_legacy_pid` SIGTERMs an unverified PID (confused deputy)
+
+**Severity**: CRITICAL
+**Location**: `guard.py:962-977`
+
+```
+962  def _cleanup_legacy_pid(cwd: str) -> None:
+...
+967          pid = int(legacy.read_text().strip())
+968          os.kill(pid, 0)
+969          # Still alive — kill it so session-scoped guard can take over
+970          os.kill(pid, signal.SIGTERM)
+```
+
+**Issue**: The function reads a PID from a pre-1.6.13 legacy pid file keyed by CWD hash, confirms the process is alive with `os.kill(pid, 0)`, then SIGTERMs it — with **zero verification that the PID is actually a cozempic guard daemon**. The codebase already has `_is_cozempic_guard_process` (line 1161) introduced specifically to defend against this kind of confused-deputy bug, and `reload_self_daemon` at lines 1249/1268 uses it correctly. `_cleanup_legacy_pid` does not.
+
+**Repro**:
+1. Install cozempic pre-1.6.13 (creates `/tmp/cozempic_guard_<md5(cwd)>.pid`).
+2. Crash / uninstall without cleanup.
+3. OS recycles the dead PID to an unrelated user process (e.g., a Node server, a long-running editor).
+4. User installs cozempic ≥1.6.13 and opens any session with the same CWD → `start_guard_daemon` → `_cleanup_legacy_pid` → SIGTERM sent to the recycled-PID process.
+
+**Fix direction**: Before line 970, gate with `if _is_cozempic_guard_process(pid)`. Otherwise just unlink the legacy file.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G2 — `_cleanup_stale_watchers` SIGTERMs on substring-only pgrep match
+
+**Severity**: CRITICAL
+**Location**: `guard.py:711-729`
+
+```
+717      result = subprocess.run(
+718          ["pgrep", "-f", "cozempic.*resumed Claude"],
+719          ...
+720      )
+721      for pid_str in result.stdout.strip().split("\n"):
+722          if pid_str:
+723              try:
+724                  os.kill(int(pid_str), signal.SIGTERM)
+```
+
+**Issue**: `pgrep -f` matches the **entire command line** of any process. The pattern `cozempic.*resumed Claude` is a regex — any process whose argv contains those tokens in any order along with any characters between them matches. Concrete false positives:
+
+- `vim ~/notes/cozempic_guard_resumed_Claude_debug.md` (argv contains `cozempic` + `resumed Claude`).
+- A user script named `cozempic_upgrade_resumed_claude_log.sh`.
+- Another Python process that loaded the watcher string into memory and passes through `ps` (unlikely but possible if argv contains a log message).
+
+Even without false positives, the function still doesn't call `_is_cozempic_guard_process` — any matching PID is unconditionally SIGTERM'd.
+
+**Repro**: `sleep 999 & pgrep -f "cozempic.*resumed Claude"` — run a dummy process whose argv contains both tokens, start guard, watch it get killed.
+
+**Fix direction**: Either (a) make the pattern the actual watcher script shape used at lines 933-938 (`echo "$(date): Cozempic guard resumed Claude in ..."`) AND verify each match's full argv matches that shape, or (b) record watcher PIDs in a dedicated registry file so cleanup doesn't need heuristic pgrep.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G3 — `_is_guard_running_for_session` missing PID-reuse defence (silent unprotected session)
+
+**Severity**: HIGH
+**Location**: `guard.py:980-995`
+
+```
+980  def _is_guard_running_for_session(session_id: str) -> int | None:
+...
+989      try:
+990          pid = int(pid_path.read_text().strip())
+991          os.kill(pid, 0)
+992          return pid
+```
+
+**Issue**: Only a liveness probe (`os.kill(pid, 0)`), **no argv verification**. Called by `start_guard_daemon` at lines 1060 and 1076 to decide `"already_running": True`. If the old daemon crashed and its PID was recycled to an unrelated process, this returns the recycled PID → `start_guard_daemon` returns `already_running=True` and **does not spawn a fresh daemon** → session is permanently unprotected. The asymmetry is striking: `reload_self_daemon` (line 1249) does verify via `_is_cozempic_guard_process`; `start_guard_daemon` does not.
+
+The related comment at line 1284-1285 (`# not on already_running (that means a concurrent SessionStart hook already spawned...)`) assumes that `already_running=True` means a real daemon is up — which is invalidated by PID reuse.
+
+**Repro**:
+1. Guard daemon crashes (uncaught exception, OOM, `kill -9`).
+2. `/tmp/cozempic_guard_<sess>.pid` still contains the dead PID.
+3. OS recycles that PID to any user process (browser tab, editor — common on Linux with high PID turnover).
+4. Next SessionStart hook → `start_guard_daemon` → `_is_guard_running_for_session` returns the recycled PID → session runs unprotected indefinitely.
+
+**Fix direction**: After the `os.kill(pid, 0)` probe, call `_is_cozempic_guard_process(pid)`; if it returns False, `pid_path.unlink(missing_ok=True)` and return None so caller respawns.
+
+**Not covered by existing tests** — `test_start_guard_daemon_passes_explicit_claude_pid_to_child` patches `_is_guard_running_for_session` entirely.
+
+---
+
+### BUG-G4 — TOCTOU race in PID file creation (orphan daemon)
+
+**Severity**: HIGH
+**Location**: `guard.py:1058-1150`
+
+The window between the `_is_guard_running_for_session` check (line 1060 or 1076) and the unconditional `pid_path.write_text(str(proc.pid))` at line 1150 is not atomic. If two SessionStart hooks fire concurrently (the docs say this happens on multi-pane tmux / IDE + CLI startup):
+
+1. Hook A: check → None → spawn Popen (PID 1001).
+2. Hook B: check → None (still no PID file) → spawn Popen (PID 1002).
+3. Hook A: write pid_file = "1001".
+4. Hook B: write pid_file = "1002".
+
+Result: two daemons running, pid_file points only at daemon B. Daemon A is **orphaned** — unreachable by `reload_self_daemon`, `_is_guard_running_for_session`, or doctor cleanup. It runs forever (or until its parent Claude exits via the line 414-422 watchdog). Both daemons race on the same prune lock and checkpoint file.
+
+**Repro**: Start two `cozempic guard` invocations in tight succession (e.g., `cozempic guard --session X & cozempic guard --session X &`) — confirm two PIDs, one pid-file.
+
+**Fix direction**: Create the pid file with `os.open(path, O_CREAT | O_EXCL | O_WRONLY)` **before** spawning Popen; if EEXIST, fall back to re-checking `_is_guard_running_for_session`. Write the spawned PID atomically via temp+rename.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G5 — `_terminate_and_resume` SIGTERMs unverified `claude_pid` (PID reuse risk)
+
+**Severity**: HIGH
+**Location**: `guard.py:804-894` (specifically 838, 862, 880, 890)
+
+```
+837          if not _wait_for_exit(claude_pid, timeout=10.0):
+838              os.kill(claude_pid, signal.SIGTERM)
+```
+
+**Issue**: `claude_pid` is resolved once at guard startup (line 388-389 via `find_claude_pid()`), stored across the whole daemon lifetime (cycles = hours or days). If Claude exits and respawns (user restarts), and the OS recycles the old Claude PID to another process, the next hard-prune cycle calls `_terminate_and_resume(stale_pid, ...)` → SIGTERM + SIGKILL on a recycled unrelated PID. The defence in `reload_self_daemon` (line 1268) is absent here.
+
+Also, the tmux/screen paths (838, 862) SIGTERM the PID **without even re-checking liveness first** — only the plain-terminal path at line 880 is inside a `try/except ProcessLookupError`.
+
+**Repro**:
+1. Start guard → find_claude_pid returns 5000.
+2. User SIGKILLs Claude externally. OS reassigns PID 5000 to another long-lived process.
+3. Session file grows (new Claude somewhere else writing to it, or manual append). Guard hits 55% threshold.
+4. Guard calls `_terminate_and_resume(5000, ...)` → SIGTERM to unrelated process.
+
+**Fix direction**: In `_terminate_and_resume`, before any signal, verify the PID is still a Claude Code process. Easiest check: `ps -p <pid> -o comm=` should contain `node` or `claude`. Mirror the same defence `reload_self_daemon` already has for guards.
+
+Related: BUG-G8 below (watchdog at 414-422 correctly handles Claude-exit but `_terminate_and_resume` doesn't re-query fresh PID).
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G6 — `_spawn_reload_watcher` shell-injection sink on Windows + unquoted project_dir
+
+**Severity**: HIGH (Windows), MED (cross-platform)
+**Location**: `guard.py:925-928, 912-923`
+
+```
+925      elif system == "Windows":
+926          resume_cmd = (
+927              f"start cmd /c \"cd /d {project_dir} && claude {resume_flag}\""
+928          )
+```
+
+**Issue**: `project_dir` is interpolated **unquoted** into a Windows `cmd /c` shell string. A path containing `& shutdown /s /t 0 &` (or any cmd metachar) executes arbitrary commands. Paths with spaces also break. Linux/macOS paths go through `shell_quote`, but Windows does not. Concretely, any user whose project path contains `&`, `|`, `>`, `%`, or `^` triggers cmd injection at reload time.
+
+Additionally, `resume_flag` on all platforms is constructed from `_detect_claude_flags(claude_pid)` output — **`original_flags` is not shell-quoted** (see BUG-G7). If the user launched Claude with a flag value containing `"` or `;`, those characters flow through `resume_cmd` into a shell string.
+
+**Repro**: Rename a Windows project dir to `My Project & calc &`; start guard; trigger threshold → `calc` launches.
+
+**Fix direction**: Quote `project_dir` on Windows with `subprocess.list2cmdline([...])` or pass via argv instead of a shell string. On all platforms, `shell_quote` each token of `original_flags` separately, not the whole joined string.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G7 — `_detect_claude_flags` round-trip breaks on spaces/metachar
+
+**Severity**: MED
+**Location**: `guard.py:738-778`, consumed at `816`, `902`
+
+```
+749      args = result.stdout.strip()
+...
+754      parts = args.split()
+...
+776      return " ".join(cleaned)
+```
+
+**Issue**: `parts = args.split()` uses default whitespace split. `ps -o args=` returns a single space-separated line with no shell quoting preserved — a flag value containing a space (e.g., `--add-dir "/Users/foo/My Project"`) becomes two tokens `--add-dir` and `"/Users/foo/My`. The subsequent filter pipeline doesn't reconstitute them. The rejoined `original_flags` string is then interpolated into shell commands at lines 816, 846, 869, 914-923, 927 — **the shell re-parses the broken tokens** yielding either wrong args or, with embedded shell metachar (backticks, `$(...)`, `;`), command injection.
+
+Also line 772 (`if len(f) >= 32 and "-" in f and not f.startswith("-")`) treats any 32+ char token with dashes as a "session-id-like" argument and drops it — this eats legitimate long arguments (long file paths with dashes, repository names) silently.
+
+**Repro**: `claude --add-dir "/tmp/my project"` → start guard → reload → spawned `claude` receives `--add-dir /tmp/my` and loses the rest.
+
+**Fix direction**: Use `/proc/<pid>/cmdline` (NUL-separated, preserves boundaries) on Linux and the `argv` parsing trick on macOS (`ps` doesn't preserve argv boundaries reliably; consider `psutil.Process(pid).cmdline()` which correctly uses `proc_pidinfo` syscall).
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G8 — Claude watchdog (line 414-422) uses PID but doesn't verify it's still Claude
+
+**Severity**: MED
+**Location**: `guard.py:414-422`
+
+```
+414              if claude_pid and claude_alive:
+415                  try:
+416                      os.kill(claude_pid, 0)
+417                  except (ProcessLookupError, PermissionError):
+418                      claude_alive = False
+```
+
+**Issue**: Only liveness is checked. If Claude exited and its PID was recycled to a different long-running process, `os.kill(claude_pid, 0)` returns success → watchdog thinks Claude is still alive → guard runs forever checkpointing a dead Claude's session. Then when the 80% threshold hits, `_terminate_and_resume` SIGKILLs the recycled unrelated process (BUG-G5).
+
+**Repro**: same as BUG-G5. This is the upstream cause that propagates into BUG-G5.
+
+**Fix direction**: Instead of `os.kill(claude_pid, 0)`, verify the PID still corresponds to a Claude Code process (reuse the same `ps -p <pid> -o comm=` pattern as the `_is_cozempic_guard_process` helper, but match `node`/`claude`).
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G9 — `/tmp` log files grow unbounded across sessions
+
+**Severity**: MED
+**Location**: `guard.py:1099-1099`, `923` (watcher log)
+
+```
+1099  log_file = Path("/tmp") / f"cozempic_guard_{pid_key}.log"
+...
+1129      with open(log_file, "a", encoding="utf-8") as lf:
+```
+
+**Issue**: Log file is opened in append mode for every daemon spawn. Over many sessions, logs accumulate. On Linux (where `/tmp` is not tmpfs-cleared on reboot by default on some distros) and on long-uptime machines, these grow indefinitely. There's no rotation, no size cap, no cleanup on guard exit. Similarly, `/tmp/cozempic_guard.log` at line 923, 937 (the watcher log) is appended to by every reload.
+
+**Repro**: Run guard for a week with daily sessions; `du -sh /tmp/cozempic_guard_*.log` grows monotonically.
+
+**Fix direction**: Either (a) add a size check at daemon startup that truncates if the log exceeds N MB, or (b) use `RotatingFileHandler` via the logging module, or (c) use `~/.cache/cozempic/logs/` with a clean-on-startup policy. If `/tmp` is mounted `noexec` + `noatime`, opening for append still works; if it's read-only (rare), the `open(... "a")` at line 1129 raises and kills `start_guard_daemon` — BUG-G14 below.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G10 — `watcher_script` runs forever on recycled PID
+
+**Severity**: MED
+**Location**: `guard.py:933-946`
+
+```
+933      watcher_script = (
+934          f"while kill -0 {claude_pid} 2>/dev/null; do sleep 1; done; "
+935          f"sleep 1; "
+936          f"{resume_cmd}; "
+937          ...
+```
+
+**Issue**: The detached watcher polls `kill -0 claude_pid` every second. If Claude exits and the OS recycles `claude_pid` to a long-running unrelated process, the `while kill -0` loop never terminates — the watcher hangs forever consuming a shell process + 1s wake-ups. On a long-uptime machine, many reload cycles leak many zombies (well, orphaned-to-init bash processes — not zombies, but still leaked processes). Also, when `claude_pid` eventually does exit, the watcher unconditionally spawns `claude --resume` — even though the operator may not want another session.
+
+Also: `kill -0 {claude_pid}` interpolates an untrusted integer. The type annotation is `int`, but `_terminate_and_resume(claude_pid: int, ...)` gets its argument from `reload_pid = claude_pid if claude_pid is not None else find_claude_pid()` (line 699-702). If a future caller passes a non-int, this becomes a shell injection sink. LOW within current callers, but the contract is not defended (no `int(claude_pid)` guard).
+
+**Fix direction**: Add a maximum lifetime (e.g., `for i in $(seq 1 3600); do kill -0 ... || break; sleep 1; done` = 1-hour cap). Coerce `claude_pid` with `int(...)` before interpolation.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G11 — Reactive watcher thread is unreachable from signal handler (no join, orphaned state)
+
+**Severity**: MED
+**Location**: `guard.py:352-385`
+
+```
+355      if reactive:
+...
+373          watcher_thread = threading.Thread(
+374              target=overflow_watcher.start, daemon=True, name="cozempic-watcher",
+375          )
+376          watcher_thread.start()
+...
+379      def _graceful_shutdown(signum, frame):
+...
+382          if overflow_watcher:
+383              overflow_watcher.stop()
+384          sys.exit(0)
+```
+
+**Issue**: On SIGTERM, `_graceful_shutdown` calls `overflow_watcher.stop()` then `sys.exit(0)` — but `sys.exit()` in a signal handler raises `SystemExit` in the main thread. If the watcher is mid-callback (holding the session file open for a `recovery.on_file_growth` call), its cleanup is short-circuited. The daemon-thread semantics (`daemon=True` at 374) mean Python terminates it abruptly when main exits, bypassing any finally-block cleanup in `JsonlWatcher.start`. In practice this could leave open file handles on NFS / FUSE filesystems.
+
+Separately, `_graceful_shutdown` is only installed for SIGTERM (line 385). SIGINT (Ctrl-C) hits the `except KeyboardInterrupt` branch at line 569 which DOES call `overflow_watcher.stop()` but NOT in a signal-safe way (the `KeyboardInterrupt` is raised between bytecodes and the `except` runs in main thread). Mostly OK, but the asymmetry is a code smell — SIGHUP, SIGQUIT are not handled at all; they just terminate the daemon, leaking the watcher thread and any in-flight prune cycle.
+
+**Fix direction**: Register the same handler for SIGINT, SIGHUP, SIGQUIT. Use `threading.Event` to signal the watcher and `join(timeout=N)` before sys.exit. Move the signal installation earlier so it's active before the watcher thread starts.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G12 — `_graceful_shutdown` signal handler does non-reentrant I/O
+
+**Severity**: MED
+**Location**: `guard.py:379-385`
+
+```
+379      def _graceful_shutdown(signum, frame):
+380          print(f"\n  [{_now()}] Signal {signum} received — final checkpoint...")
+381          checkpoint_team(session_path=session_path, quiet=False)
+```
+
+**Issue**: The handler calls `print()` and `checkpoint_team()` — both do buffered I/O. If the main thread was holding the stdio lock (e.g., mid-`print(...)` or mid-`load_messages`) when the signal arrived, the handler deadlocks on the same lock. Python's GIL means handler re-entry is only between bytecodes, but once it runs, any `print` / file write contends with whatever lock the interrupted code was holding. This is a well-known Python hazard — see CPython `PEP 656` / `signal.signal` docs.
+
+A second SIGTERM arriving during the first handler would re-enter `checkpoint_team` → two writers to the same checkpoint file.
+
+**Fix direction**: Signal handler should only set a flag (`shutdown_requested = True`) and return. Main loop checks the flag after `time.sleep(interval)` at line 401 and performs the checkpoint + exit. This is the documented safe pattern.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G13 — `_pid_file_for_session` collision on 12-char truncation
+
+**Severity**: LOW
+**Location**: `guard.py:949-952`
+
+```
+949  def _pid_file_for_session(session_id: str) -> Path:
+950      """Return the PID file path for a guard daemon watching a specific session."""
+951      session_id = _normalize_session_id(session_id)
+952      return Path("/tmp") / f"cozempic_guard_{session_id[:12]}.pid"
+```
+
+**Issue**: UUIDs are 36 chars. Truncating to 12 hex chars gives 48 bits of entropy. The probability of collision among two concurrent sessions on the same user is negligible (~1e-14 for 10 sessions), but the pid-file path is also used as a lock namespace. A deterministic truncation means two different full UUIDs that happen to share their first 12 chars (impossible in normal UUIDv4 but possible with crafted session IDs from tests / hooks passing unusual strings) both map to the same pid file → the second start silently returns `already_running=True` pointing at the wrong daemon.
+
+The function is also vulnerable to `session_id` values shorter than 12 chars — `session_id[:12]` returns `session_id` unchanged, which is fine, but the `_normalize_session_id` helper (line 53) only strips `.jsonl` suffix, not path components. If a caller passes `session_id="../../etc/passwd"`, the pid file becomes `/tmp/cozempic_guard_../../etc.pid` → the `..` components are preserved in the Path and could be used to probe arbitrary /tmp locations. Low impact (attack requires ability to pass arbitrary session_id), but worth tightening.
+
+**Fix direction**: Validate `session_id` is a UUID hex string before using it as a filename component. Use the full UUID (no truncation) — 36 extra bytes in the filename is cheap.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G14 — `start_guard_daemon` dies if `/tmp` is readonly (no error surfacing)
+
+**Severity**: LOW
+**Location**: `guard.py:1129-1150`
+
+```
+1129      with open(log_file, "a", encoding="utf-8") as lf:
+...
+1150      pid_path.write_text(str(proc.pid))
+```
+
+**Issue**: If `/tmp` is readonly (unusual but happens: Docker containers with `--read-only`, hardened systemd units with `PrivateTmp=yes` gone wrong, macOS SIP edge cases), `open(log_file, "a")` raises `PermissionError`. The function has no try/except → the exception propagates to the caller. If the caller is a hook (non-interactive, no stderr visible to user), the SessionStart hook fails silently → no guard protection and no user-visible error.
+
+Similarly, at line 1150 `pid_path.write_text(str(proc.pid))` runs AFTER `subprocess.Popen` has already spawned the daemon. If write fails, the daemon is orphaned (running with no pid file → unreachable).
+
+**Fix direction**: Catch filesystem errors around log/pid setup; fall back to `~/.cache/cozempic/` or the project dir; if all locations fail, return `{"started": False, "reason": "tmp unwritable"}` instead of raising.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G15 — `prune_with_team_protect` mutates caller's messages list in place
+
+**Severity**: LOW
+**Location**: `guard.py:189-204`
+
+```
+189      # 3. Tag team messages as protected (strategies skip via is_protected())
+190      tagged_indices: list[int] = []
+191      for _, msg_dict, _ in messages:
+192          if _is_team_message(msg_dict, pending_task_ids):
+193              msg_dict["__cozempic_team_protected__"] = True
+194              tagged_indices.append(id(msg_dict))
+...
+200      for _, msg_dict, _ in pruned_messages:
+201          msg_dict.pop("__cozempic_team_protected__", None)
+```
+
+**Issue**: The function tags messages in the caller's `messages` list with an in-band sentinel key. It only removes the tag from `pruned_messages` (which is the subset of survivors). Any messages DROPPED by `run_prescription` still carry the `__cozempic_team_protected__` key in memory — not a problem if they're garbage-collected, but if the caller retains a reference to the original list or if the messages dict identity leaks into other data structures, those dicts are left polluted.
+
+Much more important: the tag is written to `msg_dict` — which is the SAME dict object held in the loaded JSONL. If any downstream consumer serializes this dict back to disk (e.g., an error-path that writes the original messages after a PruneConflictError), the sentinel key `__cozempic_team_protected__` gets persisted in the on-disk session file. Claude Code itself won't interpret it, but it pollutes the on-disk format.
+
+The `tagged_indices` list is built but never used — dead code.
+
+**Fix direction**: Use a parallel `set()` of `id(msg_dict)` values as the protected-set instead of in-band mutation. `is_protected()` checks against the set. Zero mutation of caller data, no persistence risk.
+
+**Not covered by existing tests** — `test_guard_robustness.py` does not exercise `prune_with_team_protect`.
+
+---
+
+### BUG-G16 — `_is_guard_running` (legacy alias at line 1003-1005) always returns None
+
+**Severity**: LOW
+**Location**: `guard.py:998-1005`
+
+```
+1003  def _is_guard_running(cwd: str) -> int | None:
+1004      """Legacy check — scans for any guard PID file matching this CWD."""
+1005      return _is_guard_running_for_session(cwd)  # Won't match, but keeps signature
+```
+
+**Issue**: Comment says outright "Won't match". This is a broken compatibility shim — any legacy caller of `_is_guard_running(cwd)` gets None regardless of daemon state. The function should be either (a) removed if no external callers exist, or (b) implemented to actually scan for matching pid files. Leaving it as a silent no-op is worse than removing it: callers who still depend on it get misleading results.
+
+**Fix direction**: `grep -r '_is_guard_running\b' src/` to see if any live caller uses it. If none, delete. If yes, implement correctly.
+
+**Not covered by existing tests**.
+
+---
+
+### BUG-G17 — Reactive `OverflowRecovery` uses stale `claude_pid` captured at startup
+
+**Severity**: LOW
+**Location**: `guard.py:363-376`
+
+```
+363      breaker = CircuitBreaker(session_id=sess["session_id"])
+364      recovery = OverflowRecovery(
+365          session_path, sess["session_id"], cwd or os.getcwd(), breaker,
+366          danger_threshold_mb=danger_mb,
+367          danger_threshold_tokens=danger_tokens,
+368          claude_pid=claude_pid,
+369      )
+```
+
+**Issue**: `claude_pid` is passed by value to `OverflowRecovery` at daemon startup. The watcher thread runs for the daemon's entire lifetime. If Claude exits and is respawned (user resumed with a different PID, or upgraded), `OverflowRecovery.on_file_growth` still operates against the original PID — so when it triggers an emergency reload, it kills the wrong PID (or nothing at all if the PID is dead). The main loop has a Claude-exit watchdog at line 414-422, but it BREAKS OUT OF THE LOOP on exit — it does NOT update `claude_pid` if Claude respawns.
+
+**Fix direction**: Pass a `claude_pid_provider` callable (e.g., `find_claude_pid`) to `OverflowRecovery` instead of a static int. Let it re-resolve on each growth event.
+
+**Not covered by existing tests**.
+
+---
+
+## Non-bugs ruled out (with reasoning)
+
+- **`subprocess.run(..., shell=True)`**: none present — all `subprocess.run` calls pass argv lists (verified via `grep 'shell=True'` returned 0 results in guard.py). Subprocess output for `ps`, `pgrep`, `tmux`, `screen`, `osascript` uses argv directly.
+- **Signal re-entry on `SIGTERM` while handler runs**: Python serializes signal handlers — a second SIGTERM during the first handler's `checkpoint_team` call is queued, not re-entrant. Still, the handler does unsafe I/O (see BUG-G12) so this becomes moot.
+- **`flock` cross-filesystem issues**: `_PruneLock.__enter__` correctly handles `ImportError` (Windows) by setting `_fh = None`. On NFS, `fcntl.flock` typically silently succeeds without actual locking — real risk, but low concrete probability for `~/.claude/` (typically local). Flagged as a general concern but not a concrete bug.
+- **`find_claude_pid` walking up the process tree — infinite loop**: loop capped at 10 iterations (line 223) with `if pid <= 1: break` guard. OK.
+- **Backup cleanup at line 406 (`cleanup_old_backups(..., keep=3)`)**: correctly capped at 3 backups. OK.
+- **`_wait_for_exit` polling interval 0.2s**: bounded by `timeout` parameter. OK.
+- **`ping_install_if_new` + `maybe_auto_update(force=True)` at line 330-331**: does network I/O at daemon start — blocks startup. Could hang SessionStart hook. Not a concrete bug under normal network conditions but a resilience gap (not flagged here because outside guard.py scope and requires updater.py review).
+- **`consecutive_empty_hard_prunes` counter at line 534-538**: correctly implements exponential-ish backoff. OK.
+- **`_spawn_reload_watcher` `start_new_session=True`**: correctly detaches to init → no zombies.
+- **Integer overflow / unsigned wrapping**: no concrete risks identified — Python ints are arbitrary-precision; no C-int boundary.
+
+---
+
+## Summary
+
+- **Total**: 17 concrete bugs (**2 CRITICAL, 6 HIGH, 7 MED, 2 LOW**). All 17 uncovered by `tests/test_guard_robustness.py`.
+- **Theme**: The codebase has been hardened against PID reuse in `reload_self_daemon` (via `_is_cozempic_guard_process`), but the same defence was never propagated to `_cleanup_legacy_pid`, `_cleanup_stale_watchers`, `_is_guard_running_for_session`, `_terminate_and_resume`, and the main-loop Claude watchdog. This is the dominant bug class (G1, G2, G3, G5, G8) and represents the most exploitable surface — any PID-recycling scenario turns the daemon into a confused-deputy that signals unrelated user processes.
+- **Recommended fix-order**:
+  1. **CRITICAL first (G1, G2)**: gate every `os.kill(..., SIGTERM)` on `_is_cozempic_guard_process` (or a watcher-process equivalent). Smallest diff, biggest blast-radius reduction.
+  2. **HIGH (G3, G5, G8)**: propagate the same check to `_is_guard_running_for_session`, `_terminate_and_resume`, and the main-loop watchdog. Then (G4) harden PID-file creation to `O_CREAT|O_EXCL`. Then (G6, G7) quote/argv-sanitize all shell-interpolated strings.
+  3. **MED (G9-G12, G17)**: log rotation, watcher-lifetime cap, watcher-thread shutdown, signal-handler-does-only-set-flag refactor, dynamic PID re-resolution for reactive path.
+  4. **LOW (G13-G16)**: PID-filename hardening, fs-error handling in `start_guard_daemon`, clean up `prune_with_team_protect` in-band mutation, delete or fix `_is_guard_running`.
+- All 17 bugs are testable in isolation with mocks of `os.kill`, `subprocess.run`, `Path.exists`, `Path.write_text`. None require a live Claude process to repro.

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1194,6 +1194,39 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         return False
 
 
+def _is_claude_process(pid: int) -> bool:
+    """Verify that `pid` is a Claude Code process (node/claude binary).
+
+    Mirrors _is_cozempic_guard_process but for the Claude client side.
+    Guards against PID reuse: if Claude exits and its PID is recycled, a blind
+    SIGTERM on the recycled PID is a confused-deputy bug.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True, text=True, timeout=3, check=False,
+        )
+        if result.returncode != 0:
+            return False
+        args = (result.stdout or "").strip()
+        tokens = args.split()
+        if not tokens:
+            return False
+        comm = tokens[0].lower()
+        # Match node-based Claude Code invocations
+        if "node" in comm:
+            return True
+        # Match native claude binary
+        if comm.endswith("claude") or comm == "claude":
+            return True
+        # Match explicit claude-code invocations in args
+        if "claude-code" in args or "@anthropic-ai/claude-code" in args:
+            return True
+        return False
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
 def _pid_file_points_to(session_id: str, expected_pid: int) -> bool:
     """CAS helper: return True if the session pid file currently contains
     `expected_pid`. Used before unlink() to avoid clobbering a fresh pid

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1133,7 +1133,6 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
         return None
 
 
-
 # Backward compat aliases
 def _pid_file(cwd: str) -> Path:
     return _pid_file_for_cwd(cwd)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -969,8 +969,9 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
     # Plain terminal — SIGTERM + spawn resume watcher
     try:
         if system == "Windows":
-            subprocess.call(["taskkill", "/PID", str(claude_pid)],
-                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if _is_claude_process(claude_pid):
+                subprocess.call(["taskkill", "/PID", str(claude_pid)],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         else:
             os.kill(claude_pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
@@ -979,8 +980,9 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
     if not _wait_for_exit(claude_pid, timeout=5.0):
         try:
             if system == "Windows":
-                subprocess.call(["taskkill", "/F", "/PID", str(claude_pid)],
-                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                if _is_claude_process(claude_pid):
+                    subprocess.call(["taskkill", "/F", "/PID", str(claude_pid)],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             else:
                 if _is_claude_process(claude_pid):
                     os.kill(claude_pid, signal.SIGKILL)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1216,11 +1216,15 @@ def start_guard_daemon(
 
     # Atomically claim the pid slot before spawning (O_CREAT|O_EXCL prevents TOCTOU).
     # If EEXIST, another concurrent starter won the race — return already_running.
+    # Other OSErrors (ENOSPC, EROFS, EACCES) are non-fatal: return started=False
+    # with a reason so the non-interactive SessionStart hook doesn't crash silently.
     try:
         fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
         os.write(fd, b"0")  # placeholder; real PID written after Popen
         os.close(fd)
-    except FileExistsError:
+    except (FileExistsError, OSError) as _e:
+        if not isinstance(_e, FileExistsError):
+            return {"started": False, "reason": f"pidfile: {_e}"}
         # Re-read and verify to handle the case where the winner's daemon is up
         existing_pid = _is_guard_running_for_session(session_id) if session_id else None
         if existing_pid:
@@ -1237,7 +1241,9 @@ def start_guard_daemon(
             fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             os.write(fd, b"0")
             os.close(fd)
-        except FileExistsError:
+        except (FileExistsError, OSError) as _e2:
+            if not isinstance(_e2, FileExistsError):
+                return {"started": False, "reason": f"pidfile: {_e2}"}
             existing_pid = _is_guard_running_for_session(session_id) if session_id else None
             return {
                 "started": False,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -966,9 +966,10 @@ def _cleanup_legacy_pid(cwd: str) -> None:
         try:
             pid = int(legacy.read_text().strip())
             os.kill(pid, 0)
-            # Still alive — kill it so session-scoped guard can take over
-            os.kill(pid, signal.SIGTERM)
-            time.sleep(1)
+            # Only SIGTERM if we can confirm this is actually our daemon.
+            if _is_cozempic_guard_process(pid):
+                os.kill(pid, signal.SIGTERM)
+                time.sleep(1)
         except (ValueError, ProcessLookupError, PermissionError, OSError):
             pass
         legacy.unlink(missing_ok=True)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1099,6 +1099,9 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
 
     try:
         pid = int(pid_path.read_text().strip())
+        if pid <= 0:
+            pid_path.unlink(missing_ok=True)
+            return None
         os.kill(pid, 0)
         # Verify the PID is actually our guard — defend against PID reuse.
         if not _is_cozempic_guard_process(pid):

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -842,6 +842,12 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
         print(f"  SSH session — skipping terminate+resume. Resume manually: {resume_cmd}")
         return
 
+    # Verify the PID still belongs to a Claude process before sending any signal.
+    # claude_pid is captured at daemon start; it may have been recycled.
+    if not _is_claude_process(claude_pid):
+        print(f"  WARNING: PID {claude_pid} is no longer a Claude process — skipping terminate+resume.")
+        return
+
     if term_env == "tmux":
         # tmux: graceful /exit via send-keys, then resume in same pane
         pane = os.environ.get("TMUX_PANE", "")
@@ -856,7 +862,8 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
 
         # Wait for Claude to exit
         if not _wait_for_exit(claude_pid, timeout=10.0):
-            os.kill(claude_pid, signal.SIGTERM)
+            if _is_claude_process(claude_pid):
+                os.kill(claude_pid, signal.SIGTERM)
             _wait_for_exit(claude_pid, timeout=5.0)
 
         time.sleep(1)
@@ -880,7 +887,8 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
         )
 
         if not _wait_for_exit(claude_pid, timeout=10.0):
-            os.kill(claude_pid, signal.SIGTERM)
+            if _is_claude_process(claude_pid):
+                os.kill(claude_pid, signal.SIGTERM)
             _wait_for_exit(claude_pid, timeout=5.0)
 
         time.sleep(1)
@@ -908,7 +916,8 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
                 subprocess.call(["taskkill", "/F", "/PID", str(claude_pid)],
                                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             else:
-                os.kill(claude_pid, signal.SIGKILL)
+                if _is_claude_process(claude_pid):
+                    os.kill(claude_pid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError, OSError):
             pass
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -761,42 +761,98 @@ def _detect_claude_flags(pid: int) -> str:
 
     Returns the flags portion of the command line (everything after 'claude'
     but excluding --resume/--continue and the session ID).
+
+    Uses psutil for accurate argv preservation (preserves spaces in values).
+    Falls back to ps -o args= with shlex.split when psutil is unavailable.
     """
+    import shlex
+
+    parts: list[str] = []
+
+    # Preferred path: psutil preserves original argv boundaries exactly.
     try:
-        result = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "args="],
-            capture_output=True, text=True, timeout=5,
-        )
-        args = result.stdout.strip()
-        if not args or "claude" not in args:
+        import psutil
+        parts = psutil.Process(pid).cmdline()
+    except (ImportError, Exception):
+        pass
+
+    # Fallback: ps -o args= + shlex.split (loses space-boundary info on macOS).
+    if not parts:
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "args="],
+                capture_output=True, text=True, timeout=5,
+            )
+            raw = result.stdout.strip()
+            if not raw or "claude" not in raw:
+                return ""
+            parts = shlex.split(raw)
+        except Exception:
             return ""
 
-        # Extract everything after "claude"
-        parts = args.split()
-        claude_idx = next((i for i, p in enumerate(parts) if p.endswith("claude")), -1)
-        if claude_idx < 0:
-            return ""
-
-        flags = parts[claude_idx + 1:]
-
-        # Remove resume/continue flags and session IDs (we'll add our own)
-        cleaned = []
-        skip_next = False
-        for f in flags:
-            if skip_next:
-                skip_next = False
-                continue
-            if f in ("--resume", "--continue", "-c"):
-                skip_next = True  # Skip the session ID that follows
-                continue
-            # Skip bare session ID args (UUID-like)
-            if len(f) >= 32 and "-" in f and not f.startswith("-"):
-                continue
-            cleaned.append(f)
-
-        return " ".join(cleaned)
-    except Exception:
+    if not parts:
         return ""
+
+    # Find 'claude' binary in the argv list.
+    claude_idx = next((i for i, p in enumerate(parts) if p.endswith("claude")), -1)
+    if claude_idx < 0:
+        return ""
+
+    tokens = parts[claude_idx + 1:]
+
+    # Walk tokens pairing --flags with their values.
+    # Consecutive non-flag tokens are joined as a single value (preserves paths
+    # with spaces when the argv source can provide them).
+    # Flags/values containing shell metacharacters are dropped to prevent injection.
+    _shell_metachars = set(';`$|()')
+    cleaned: list[str] = []
+    skip_count = 0
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+
+        if skip_count > 0:
+            skip_count -= 1
+            i += 1
+            continue
+
+        # Skip resume/continue flags and their session ID argument
+        if tok in ("--resume", "--continue", "-c"):
+            skip_count = 1
+            i += 1
+            continue
+
+        # Skip bare UUID-like session ID args
+        if len(tok) >= 32 and "-" in tok and not tok.startswith("-"):
+            i += 1
+            continue
+
+        if tok.startswith("-"):
+            # Collect all following non-flag tokens as this flag's value
+            j = i + 1
+            while j < len(tokens) and not tokens[j].startswith("-"):
+                j += 1
+            value_tokens = tokens[i + 1:j]
+            value = " ".join(value_tokens) if value_tokens else ""
+
+            # Drop flag+value if value contains shell injection metacharacters
+            if any(c in _shell_metachars for c in value):
+                i = j
+                continue
+
+            if value:
+                cleaned.append(tok)
+                cleaned.append(shlex.quote(value))
+            else:
+                cleaned.append(tok)
+            i = j
+        else:
+            # Bare non-flag token (shouldn't be common after flag extraction)
+            if not any(c in _shell_metachars for c in tok):
+                cleaned.append(shlex.quote(tok))
+            i += 1
+
+    return " ".join(cleaned)
 
 
 def _detect_terminal_env() -> str:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1314,14 +1314,19 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         if result.returncode != 0:
             return False
         args = (result.stdout or "").strip()
-        # Match our known spawn patterns:
-        #   python3 -m cozempic.cli guard ...
-        #   cozempic guard ...
-        #   /path/to/cozempic guard ...
-        if "cozempic.cli" in args and "guard" in args:
-            return True
         tokens = args.split()
-        if len(tokens) >= 2 and "cozempic" in tokens[0] and tokens[1] == "guard":
+        if not tokens:
+            return False
+        binary = Path(tokens[0]).name.lower()
+        # tokens[0] must be a python interpreter or cozempic entry-point (not
+        # run-cozempic, fake-cozempic, etc.)
+        if binary not in ("python", "python3", "cozempic"):
+            return False
+        # "cozempic.cli" and "guard" must appear as discrete arg tokens, not as
+        # substrings in filenames/paths (grep, less, vim on our source tree).
+        if "cozempic.cli" in tokens and "guard" in tokens:
+            return True
+        if len(tokens) >= 2 and binary == "cozempic" and tokens[1] == "guard":
             return True
         return False
     except (subprocess.SubprocessError, OSError):

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import signal
 import subprocess
 import sys
@@ -1336,9 +1337,11 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         if not tokens:
             return False
         binary = Path(tokens[0]).name.lower()
-        # tokens[0] must be a python interpreter or cozempic entry-point (not
-        # run-cozempic, fake-cozempic, etc.)
-        if binary not in ("python", "python3", "cozempic"):
+        # tokens[0] must be a python interpreter (any minor/patch version) or
+        # the cozempic entry-point. Rejects `run-cozempic`, `fake-cozempic`,
+        # `python-attacker`. Accepts `python3.11`, `python3.13.12`, etc. used
+        # by pyenv / Homebrew / distro packaging.
+        if not (binary == "cozempic" or re.match(r"^python(\d+(\.\d+)*)?$", binary)):
             return False
         # "cozempic.cli" and "guard" must appear as discrete arg tokens, not as
         # substrings in filenames/paths (grep, less, vim on our source tree).

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -22,8 +22,15 @@ import re
 import signal
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
+
+# Per-session spawn lock: prevents a concurrent _is_guard_running_for_session
+# from treating a live O_CREAT placeholder as a stale file (within the same
+# process). Keyed by session_id to avoid false contention across sessions.
+_spawn_locks: dict[str, threading.Lock] = {}
+_spawn_locks_mu = threading.Lock()
 
 from ._validation import ConfigError
 from .executor import run_prescription
@@ -1094,6 +1101,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
 
     Returns the PID if running, None otherwise.
     """
+    norm_sid = _normalize_session_id(session_id)
     pid_path = _pid_file_for_session(session_id)
     if not pid_path.exists():
         return None
@@ -1101,6 +1109,17 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
     try:
         pid = int(pid_path.read_text().strip())
         if pid <= 0:
+            # Guard against PID-reuse footgun: os.kill(0, sig) broadcasts to
+            # the caller's process group rather than targeting a sentinel.
+            # If a concurrent start_guard_daemon in THIS process holds the
+            # session spawn lock, the placeholder is live — skip the unlink.
+            with _spawn_locks_mu:
+                lock = _spawn_locks.get(norm_sid)
+            if lock is not None and not lock.acquire(blocking=False):
+                # Lock is held → spawner is in-flight; placeholder is live.
+                return None
+            if lock is not None:
+                lock.release()
             pid_path.unlink(missing_ok=True)
             return None
         os.kill(pid, 0)
@@ -1112,6 +1131,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
     except (ValueError, ProcessLookupError, PermissionError):
         pid_path.unlink(missing_ok=True)
         return None
+
 
 
 # Backward compat aliases
@@ -1221,44 +1241,87 @@ def start_guard_daemon(
     if claude_pid is None:
         claude_pid = find_claude_pid()
 
+    # Acquire the per-session spawn lock before O_CREAT so that a concurrent
+    # _is_guard_running_for_session (same process) sees the lock is held and skips
+    # the unlink of our in-flight "0" placeholder. Released after the real PID
+    # is committed. File-level O_CREAT|O_EXCL still guards cross-process races.
+    norm_sid = _normalize_session_id(session_id) if session_id else ""
+    with _spawn_locks_mu:
+        if norm_sid not in _spawn_locks:
+            _spawn_locks[norm_sid] = threading.Lock()
+        spawn_lock = _spawn_locks[norm_sid]
+    spawn_lock.acquire()
+
     # Atomically claim the pid slot before spawning (O_CREAT|O_EXCL prevents TOCTOU).
-    # If EEXIST, another concurrent starter won the race — return already_running.
     # Other OSErrors (ENOSPC, EROFS, EACCES) are non-fatal: return started=False
     # with a reason so the non-interactive SessionStart hook doesn't crash silently.
+    _claim_result: dict | None = None
     try:
-        fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        os.write(fd, b"0")  # placeholder; real PID written after Popen
-        os.close(fd)
-    except (FileExistsError, OSError) as _e:
-        if not isinstance(_e, FileExistsError):
-            return {"started": False, "reason": f"pidfile: {_e}"}
-        # Re-read and verify to handle the case where the winner's daemon is up
-        existing_pid = _is_guard_running_for_session(session_id) if session_id else None
-        if existing_pid:
-            return {
-                "started": False,
-                "pid": existing_pid,
-                "pid_file": str(pid_path),
-                "log_file": None,
-                "already_running": True,
-            }
-        # Stale placeholder (previous crash before real PID was written) — remove and retry once
-        pid_path.unlink(missing_ok=True)
         try:
             fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            os.write(fd, b"0")
+            os.write(fd, b"0")  # placeholder; real PID written after Popen
             os.close(fd)
-        except (FileExistsError, OSError) as _e2:
-            if not isinstance(_e2, FileExistsError):
-                return {"started": False, "reason": f"pidfile: {_e2}"}
-            existing_pid = _is_guard_running_for_session(session_id) if session_id else None
-            return {
-                "started": False,
-                "pid": existing_pid,
-                "pid_file": str(pid_path),
-                "log_file": None,
-                "already_running": True,
-            }
+        except (FileExistsError, OSError) as _e:
+            if not isinstance(_e, FileExistsError):
+                _claim_result = {"started": False, "reason": f"pidfile: {_e}"}
+            else:
+                # Peek at what the existing file holds to decide the retry strategy.
+                try:
+                    _raw = pid_path.read_text().strip() if pid_path.exists() else ""
+                    _on_disk_pid = int(_raw) if _raw else 0
+                except (ValueError, OSError):
+                    _on_disk_pid = 0
+                if _on_disk_pid > 0:
+                    # File holds a real PID (> 0): a concurrent winner just wrote it.
+                    # Trust the write — don't call _is_guard_running_for_session (it
+                    # would probe os.kill which may fail for a just-spawned process,
+                    # unlink the file, and break the invariant). Dead-guard detection
+                    # happens on the NEXT call to start_guard_daemon.
+                    _claim_result = {
+                        "started": False,
+                        "pid": _on_disk_pid,
+                        "pid_file": str(pid_path),
+                        "log_file": None,
+                        "already_running": True,
+                    }
+                else:
+                    # File holds a placeholder (pid <= 0): either a concurrent spawn's
+                    # in-flight "0" or a stale placeholder from a previous crash.
+                    # Re-read via the full helper which handles the spawn-lock check.
+                    existing_pid = _is_guard_running_for_session(session_id) if session_id else None
+                    if existing_pid:
+                        _claim_result = {
+                            "started": False,
+                            "pid": existing_pid,
+                            "pid_file": str(pid_path),
+                            "log_file": None,
+                            "already_running": True,
+                        }
+                    else:
+                        # Stale placeholder (previous crash before real PID was written) — remove and retry once
+                        pid_path.unlink(missing_ok=True)
+                        try:
+                            fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                            os.write(fd, b"0")
+                            os.close(fd)
+                        except (FileExistsError, OSError) as _e2:
+                            if not isinstance(_e2, FileExistsError):
+                                _claim_result = {"started": False, "reason": f"pidfile: {_e2}"}
+                            else:
+                                existing_pid = _is_guard_running_for_session(session_id) if session_id else None
+                                _claim_result = {
+                                    "started": False,
+                                    "pid": existing_pid,
+                                    "pid_file": str(pid_path),
+                                    "log_file": None,
+                                    "already_running": True,
+                                }
+    except Exception:
+        spawn_lock.release()
+        raise
+    if _claim_result is not None:
+        spawn_lock.release()
+        return _claim_result
 
     # Build the guard command
     cmd_parts = [
@@ -1308,6 +1371,9 @@ def start_guard_daemon(
     tmp_path = pid_path.with_suffix(".pid.tmp")
     tmp_path.write_text(str(proc.pid))
     tmp_path.replace(pid_path)
+    # Release the spawn lock now that the real PID is committed. Any concurrent
+    # _is_guard_running_for_session can now read the valid PID > 0.
+    spawn_lock.release()
 
     return {
         "started": True,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -708,6 +708,25 @@ def guard_prune_cycle(
     return result
 
 
+def _is_cozempic_watcher_process(pid: int) -> bool:
+    """Verify that `pid` is a cozempic reload watcher (bash + cozempic watcher script).
+
+    Guards against false positives from pgrep substring matching.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True, text=True, timeout=3, check=False,
+        )
+        if result.returncode != 0:
+            return False
+        args = (result.stdout or "").strip()
+        # Real watcher script contains both "bash" and "Cozempic guard resumed Claude"
+        return "bash" in args and "Cozempic guard resumed Claude" in args
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
 def _cleanup_stale_watchers() -> None:
     """Kill stale reload watchers from previous Cozempic versions.
 
@@ -722,7 +741,9 @@ def _cleanup_stale_watchers() -> None:
         for pid_str in result.stdout.strip().split("\n"):
             if pid_str:
                 try:
-                    os.kill(int(pid_str), signal.SIGTERM)
+                    pid = int(pid_str)
+                    if _is_cozempic_watcher_process(pid):
+                        os.kill(pid, signal.SIGTERM)
                 except (ProcessLookupError, PermissionError, ValueError):
                     pass
     except Exception:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -974,7 +974,8 @@ def _terminate_and_resume(claude_pid: int, project_dir: str, session_id: str | N
                 subprocess.call(["taskkill", "/PID", str(claude_pid)],
                                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         else:
-            os.kill(claude_pid, signal.SIGTERM)
+            if _is_claude_process(claude_pid):
+                os.kill(claude_pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
         pass
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1128,6 +1128,39 @@ def start_guard_daemon(
     if claude_pid is None:
         claude_pid = find_claude_pid()
 
+    # Atomically claim the pid slot before spawning (O_CREAT|O_EXCL prevents TOCTOU).
+    # If EEXIST, another concurrent starter won the race — return already_running.
+    try:
+        fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.write(fd, b"0")  # placeholder; real PID written after Popen
+        os.close(fd)
+    except FileExistsError:
+        # Re-read and verify to handle the case where the winner's daemon is up
+        existing_pid = _is_guard_running_for_session(session_id) if session_id else None
+        if existing_pid:
+            return {
+                "started": False,
+                "pid": existing_pid,
+                "pid_file": str(pid_path),
+                "log_file": None,
+                "already_running": True,
+            }
+        # Stale placeholder (previous crash before real PID was written) — remove and retry once
+        pid_path.unlink(missing_ok=True)
+        try:
+            fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, b"0")
+            os.close(fd)
+        except FileExistsError:
+            existing_pid = _is_guard_running_for_session(session_id) if session_id else None
+            return {
+                "started": False,
+                "pid": existing_pid,
+                "pid_file": str(pid_path),
+                "log_file": None,
+                "already_running": True,
+            }
+
     # Build the guard command
     cmd_parts = [
         sys.executable, "-m", "cozempic.cli", "guard",
@@ -1172,8 +1205,10 @@ def start_guard_daemon(
             env=env,
         )
 
-    # Write PID file — keyed by session ID (or CWD hash as fallback)
-    pid_path.write_text(str(proc.pid))
+    # Write actual PID atomically via temp+rename so readers never see partial content
+    tmp_path = pid_path.with_suffix(".pid.tmp")
+    tmp_path.write_text(str(proc.pid))
+    tmp_path.replace(pid_path)
 
     return {
         "started": True,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -939,6 +939,10 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
 
     system = platform.system()
 
+    # log_dir is a bash-safe representation of project_dir for the echo log line.
+    # shell_quote wraps in single quotes (POSIX safe); metachars are not executable.
+    log_dir = shell_quote(project_dir)
+
     if system == "Darwin":
         resume_cmd = (
             f"osascript -e 'tell application \"Terminal\" to do script "
@@ -953,18 +957,25 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
             f"else echo 'No terminal emulator found' >> /tmp/cozempic_guard.log; fi"
         )
     elif system == "Windows":
+        # Escape cmd.exe metacharacters in project_dir so they cannot execute.
+        # ^ is the cmd.exe escape character; prefix each metachar with ^ to
+        # prevent them from being interpreted as shell operators.
+        _cmd_metachars = set('&|<>^"')
+        escaped_dir = "".join(f"^{c}" if c in _cmd_metachars else c for c in project_dir)
         resume_cmd = (
-            f"start cmd /c \"cd /d {project_dir} && claude {resume_flag}\""
+            f"start cmd /c \"cd /d {escaped_dir} && claude {resume_flag}\""
         )
+        # Use escaped form in log line too so the watcher_script has no raw metachars
+        log_dir = escaped_dir
     else:
         print(f"  WARNING: Auto-resume not supported on {system}.")
         return
 
     watcher_script = (
-        f"while kill -0 {claude_pid} 2>/dev/null; do sleep 1; done; "
+        f"while kill -0 {int(claude_pid)} 2>/dev/null; do sleep 1; done; "
         f"sleep 1; "
         f"{resume_cmd}; "
-        f"echo \"$(date): Cozempic guard resumed Claude in {project_dir}\" >> /tmp/cozempic_guard.log"
+        f"echo \"$(date): Cozempic guard resumed Claude in {log_dir}\" >> /tmp/cozempic_guard.log"
     )
 
     subprocess.Popen(

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -416,6 +416,16 @@ def start_guard(
                     os.kill(claude_pid, 0)
                 except (ProcessLookupError, PermissionError):
                     claude_alive = False
+                else:
+                    # Liveness confirmed — also verify PID identity to guard against
+                    # PID reuse (daemon started hours ago; original Claude exited and
+                    # kernel recycled its PID to an unrelated process).
+                    try:
+                        if not _is_claude_process(claude_pid):
+                            claude_alive = False
+                    except ProcessLookupError:
+                        claude_alive = False
+                if not claude_alive:
                     print(f"  [{_now()}] Claude process exited (PID {claude_pid}). Final checkpoint...")
                     checkpoint_team(session_path=session_path, quiet=False)
                     print(f"  Guard stopping (Claude exited).")

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1354,16 +1354,18 @@ def _is_claude_process(pid: int) -> bool:
         tokens = args.split()
         if not tokens:
             return False
-        comm = tokens[0].lower()
-        # Match node-based Claude Code invocations
-        if "node" in comm:
+        binary = Path(tokens[0]).name.lower()
+        # Match native claude binary (whole name, not substring)
+        if binary == "claude":
             return True
-        # Match native claude binary
-        if comm.endswith("claude") or comm == "claude":
-            return True
-        # Match explicit claude-code invocations in args
-        if "claude-code" in args or "@anthropic-ai/claude-code" in args:
-            return True
+        # Match node-based Claude Code: binary must be exactly "node" or "node.js"
+        # AND args must contain a Claude Code-specific marker.
+        if binary in ("node", "node.js"):
+            if "@anthropic-ai/claude-code" in args:
+                return True
+            # cli.js under a claude-code directory
+            if "claude-code/cli.js" in args or "claude-code\\cli.js" in args:
+                return True
         return False
     except (subprocess.SubprocessError, OSError):
         return False

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1367,7 +1367,13 @@ def _is_claude_process(pid: int) -> bool:
     Mirrors _is_cozempic_guard_process but for the Claude client side.
     Guards against PID reuse: if Claude exits and its PID is recycled, a blind
     SIGTERM on the recycled PID is a confused-deputy bug.
+
+    On Windows, `ps` is unavailable — uses `tasklist /FI "PID eq <pid>" /FO CSV`
+    instead. If tasklist also fails, falls back to liveness-only (returns True
+    for a live PID) so callers can still proceed with taskkill.
     """
+    if platform.system() == "Windows":
+        return _is_claude_process_windows(pid)
     try:
         result = subprocess.run(
             ["ps", "-p", str(pid), "-o", "args="],
@@ -1394,6 +1400,26 @@ def _is_claude_process(pid: int) -> bool:
         return False
     except (subprocess.SubprocessError, OSError):
         return False
+
+
+def _is_claude_process_windows(pid: int) -> bool:
+    """Windows-specific helper: probe via tasklist /FO CSV."""
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if result.returncode != 0:
+            return True  # liveness fallback — let caller proceed with taskkill
+        output = (result.stdout or "").strip().lower()
+        if not output or "no tasks are running" in output:
+            return False
+        # CSV row: "image_name","pid","session_name","session#","mem_usage"
+        # Image name is the first quoted field.
+        image_name = output.split(",")[0].strip('"')
+        return any(marker in image_name for marker in ("claude", "node"))
+    except (subprocess.SubprocessError, OSError):
+        return True  # liveness fallback — let caller proceed with taskkill
 
 
 def _pid_file_points_to(session_id: str, expected_pid: int) -> bool:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1011,6 +1011,10 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
     try:
         pid = int(pid_path.read_text().strip())
         os.kill(pid, 0)
+        # Verify the PID is actually our guard — defend against PID reuse.
+        if not _is_cozempic_guard_process(pid):
+            pid_path.unlink(missing_ok=True)
+            return None
         return pid
     except (ValueError, ProcessLookupError, PermissionError):
         pid_path.unlink(missing_ok=True)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1344,7 +1344,7 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         # the cozempic entry-point. Rejects `run-cozempic`, `fake-cozempic`,
         # `python-attacker`. Accepts `python3.11`, `python3.13.12`, etc. used
         # by pyenv / Homebrew / distro packaging.
-        if not (binary == "cozempic" or re.match(r"^python(\d+(\.\d+)*)?$", binary)):
+        if not (binary == "cozempic" or re.fullmatch(r"^python(\d+(\.\d+)*)?$", binary)):
             return False
         # "cozempic.cli" and "guard" must appear as discrete arg tokens, not as
         # substrings in filenames/paths (grep, less, vim on our source tree).

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -1371,5 +1371,333 @@ class TestDiffCoverage_AtomicPidfile_AllErrnos(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Round 3 — RED tests for static-analysis + security findings
+# See STATIC_ANALYSIS_REPORT.md / SECURITY_REVIEW_REPORT.md.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# RED-R3-1 (STATIC-MED-1) — G4 placeholder race: pid=0 must never reach os.kill
+# ---------------------------------------------------------------------------
+class TestR3_1_PlaceholderPidZeroNeverSignaled(unittest.TestCase):
+    """When the G4 atomic-claim placeholder `"0"` is read by a concurrent loser,
+    `_is_guard_running_for_session` currently calls `os.kill(0, 0)`. On POSIX,
+    `os.kill(pid=0, sig=...)` signals the CALLER'S entire process group — not
+    an ancestor sentinel. Empirically:
+
+        >>> os.kill(0, 0)  # returns None, does NOT raise ProcessLookupError
+
+    The contract: the function must short-circuit on pid <= 0 BEFORE the
+    liveness probe. Today it only survives thanks to `_is_cozempic_guard_process(0)`
+    returning False downstream — a future refactor that removes the gate makes
+    this exploitable.
+    """
+
+    def setUp(self):
+        self.session_id = "33333333-aaaa-bbbb-cccc-000000000033"
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.pid_path.write_text("0")
+        self.addCleanup(self.pid_path.unlink, missing_ok=True)
+
+    def test_os_kill_never_called_with_pid_zero(self):
+        """`_is_guard_running_for_session` on a placeholder pidfile ("0") MUST NOT
+        invoke `os.kill(0, ...)` — pid 0 targets the caller's process group."""
+        from cozempic.guard import _is_guard_running_for_session
+
+        kill_calls = []
+
+        def fake_kill(pid, sig):
+            kill_calls.append((pid, sig))
+            return None
+
+        with patch("cozempic.guard.os.kill", side_effect=fake_kill):
+            _ = _is_guard_running_for_session(self.session_id)
+
+        pid_zero_calls = [(p, s) for (p, s) in kill_calls if p == 0]
+        self.assertEqual(
+            pid_zero_calls, [],
+            f"os.kill(0, ...) invoked during placeholder read — "
+            f"POSIX pgroup-broadcast footgun. Calls: {kill_calls}. "
+            f"Fix: short-circuit `if pid <= 0: pid_path.unlink(); return None` "
+            f"before the liveness probe.",
+        )
+
+    def test_returns_none_and_unlinks_on_placeholder(self):
+        """Positive regression: even after the fix, a placeholder-valued pidfile
+        must still resolve to `None` and be cleaned up."""
+        from cozempic.guard import _is_guard_running_for_session
+
+        # No mocks — exercise the real path. Must return None AND clean up.
+        result = _is_guard_running_for_session(self.session_id)
+        self.assertIsNone(
+            result,
+            f"placeholder pidfile not resolved to None: {result!r}",
+        )
+        self.assertFalse(
+            self.pid_path.exists(),
+            "placeholder pidfile must be unlinked after read",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RED-R3-2 (STATIC-MED-2) — Windows taskkill regressions when ps is missing
+# ---------------------------------------------------------------------------
+class TestR3_2_WindowsTaskkillRegressionOnPsMissing(unittest.TestCase):
+    """`_is_claude_process` runs `subprocess.run(["ps", ...])`. On Windows,
+    `ps` does not exist → FileNotFoundError (OSError subclass) is caught →
+    helper returns False → every Windows taskkill path in
+    `_terminate_and_resume` (lines 973, 984) becomes a silent no-op.
+
+    Pre-fix Windows behaviour was "always taskkill"; post-fix Windows behaviour
+    is "never taskkill" — functional regression on Windows. Contract: either
+    use tasklist/WMIC on Windows, or fall back to liveness-only when identity
+    can't be determined (platform-aware probe).
+    """
+
+    def test_is_claude_process_has_windows_code_path(self):
+        """Static-source contract: the helper must NOT rely solely on POSIX `ps`
+        — either it branches on `platform.system()` to use tasklist/WMIC, or
+        it has an explicit "ps unavailable" fallback that returns True on
+        liveness (not silently False).
+
+        We detect this by checking that `_is_claude_process` either:
+          (a) references `tasklist` / `wmic` / `Get-Process` / `Win32_Process`
+              (Windows-specific probe), OR
+          (b) checks `platform.system()` and branches,
+        in its source.
+        """
+        import inspect
+        from cozempic.guard import _is_claude_process
+        src = inspect.getsource(_is_claude_process)
+
+        has_windows_probe = (
+            "tasklist" in src.lower()
+            or "wmic" in src.lower()
+            or "get-process" in src.lower()
+            or "win32_process" in src.lower()
+            or "platform.system" in src
+            or "sys.platform" in src
+        )
+        self.assertTrue(
+            has_windows_probe,
+            "_is_claude_process has no Windows-specific code path. On Windows, "
+            "`ps` raises FileNotFoundError → OSError caught → helper returns "
+            "False → every taskkill gate in _terminate_and_resume becomes a "
+            "no-op. Use tasklist or branch on platform.system().",
+        )
+
+    def test_helper_does_not_silently_return_false_when_ps_missing(self):
+        """Dynamic contract: if `subprocess.run(["ps", ...])` raises
+        FileNotFoundError (Windows), the helper MUST NOT silently return False
+        for a PID the caller believes is Claude. A valid fix either (a) falls
+        back to a Windows-native probe, or (b) returns True on liveness and
+        lets the caller proceed with taskkill (documented fallback)."""
+        from cozempic.guard import _is_claude_process
+
+        def fake_run(cmd, *a, **kw):
+            cmd_list = list(cmd) if isinstance(cmd, (list, tuple)) else [cmd]
+            if cmd_list and cmd_list[0] == "ps":
+                raise FileNotFoundError(2, "ps not found (simulated Windows)")
+            # If the fix uses a Windows probe (tasklist), return a matching row
+            if cmd_list and cmd_list[0] in ("tasklist", "wmic"):
+                m = MagicMock()
+                m.returncode = 0
+                m.stdout = "claude.exe 12345 Console 1 123,456 K"
+                return m
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = ""
+            return m
+
+        with (
+            patch("cozempic.guard.subprocess.run", side_effect=fake_run),
+            patch("cozempic.guard.platform.system", return_value="Windows"),
+        ):
+            got = _is_claude_process(12345)
+
+        # A correct fix should return True for a live Claude PID on Windows —
+        # either via tasklist probe or liveness fallback. The current code
+        # catches OSError → returns False → regression.
+        self.assertTrue(
+            got,
+            "Windows: ps is missing (FileNotFoundError). Current impl catches "
+            "OSError and returns False → taskkill never fires. Fix must "
+            "branch on platform (tasklist/wmic) or fall back to liveness.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RED-R3-3 (STATIC-LOW-3) — Regex accepts trailing newline (re.match vs fullmatch)
+# ---------------------------------------------------------------------------
+class TestR3_3_BinaryRegexRejectsTrailingNewline(unittest.TestCase):
+    """`_is_cozempic_guard_process` uses `re.match(r"^python(\\d+(\\.\\d+)*)?$", binary)`.
+    Python's `re.match` anchors at start; `$` matches before a trailing newline
+    by default. So `binary == "python3\\n"` PASSES the regex:
+
+        >>> bool(re.match(r"^python(\\d+(\\.\\d+)*)?$", "python3\\n"))
+        True
+
+    Fix: `re.fullmatch` OR add `re.DOTALL`+anchor OR explicit `not s.endswith("\\n")`.
+    """
+
+    def test_rejects_binary_with_trailing_newline_injected(self):
+        """Dynamic defence-in-depth: if a future refactor bypasses `args.strip()`
+        / `args.split()` and `tokens[0]` contains a literal `"python3\\n"`, the
+        binary gate MUST still reject it. This is the exact contract from
+        STATIC-LOW-3: `re.match + $` accepts `"python3\\n"` because `$` matches
+        before the trailing newline; `re.fullmatch` does not.
+
+        We patch `args.split` indirectly: mock `subprocess.run` to return an
+        args line whose first token ends with `\\n` after our stub's own
+        tokenisation. Simulate this by overriding `str.split` via monkey-patching
+        the helper's token list. Cleanest: patch `Path.name` on the first token
+        so the binary-under-test becomes `"python3\\n"`.
+        """
+        import inspect
+        from cozempic.guard import _is_cozempic_guard_process
+        src = inspect.getsource(_is_cozempic_guard_process)
+
+        # The function must use re.fullmatch (or explicit \n rejection on the
+        # binary string) — NOT re.match + $. This is a stricter static check
+        # than the companion test below: we require fullmatch or equivalent
+        # explicit newline rejection on the BINARY specifically.
+        uses_fullmatch = "re.fullmatch(" in src
+        has_explicit_binary_newline_guard = (
+            "binary.endswith" in src
+            or 'binary.rstrip("\\n")' in src
+            or "if \"\\n\" in binary" in src
+            or "\"\\n\" not in binary" in src
+        )
+        self.assertTrue(
+            uses_fullmatch or has_explicit_binary_newline_guard,
+            "_is_cozempic_guard_process uses `re.match(..., $)` which accepts "
+            "trailing `\\n` in the binary (Python regex quirk: `$` matches "
+            "before a trailing newline unless re.fullmatch is used). Fix: "
+            "switch to `re.fullmatch(...)` in guard.py:1344.",
+        )
+
+    def test_re_match_dollar_accepts_trailing_newline_regression(self):
+        """Regression anchor: proves Python's `re.match(r'...$', 'x\\n')`
+        silently accepts the newline. If future Python changes this, the fix
+        becomes redundant — but the test still documents WHY fullmatch is
+        required."""
+        import re
+        pattern = r"^python(\d+(\.\d+)*)?$"
+        # Python semantics: `re.match` with `$` accepts trailing `\n`.
+        # `re.fullmatch` does not.
+        self.assertTrue(
+            bool(re.match(pattern, "python3\n")),
+            "Python regex semantics assumption violated: re.match + $ used to "
+            "accept trailing newline. If this assertion fails, the STATIC-LOW-3 "
+            "bug class has been closed by Python itself.",
+        )
+        self.assertFalse(
+            bool(re.fullmatch(pattern, "python3\n")),
+            "Python regex semantics assumption violated: re.fullmatch should "
+            "reject trailing newline.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RED-R3-4 (SECURITY-THEORETICAL) — POSIX plain-terminal SIGTERM inner re-check
+# ---------------------------------------------------------------------------
+class TestR3_4_PosixPlainTerminalSigtermHasInnerReverify(unittest.TestCase):
+    """The POSIX plain-terminal path in `_terminate_and_resume` issues the
+    FIRST SIGTERM at guard.py:977 inside `try: ... except (ProcessLookupError,
+    PermissionError, OSError): pass` — NO inner `_is_claude_process` re-check.
+
+    Symmetry gaps with the rest of the function:
+      - tmux SIGTERM @ line 933 — has inner re-check (good)
+      - screen SIGTERM @ line 958 — has inner re-check (good)
+      - Windows taskkill @ line 973 — has inner re-check (good, after R2 fix)
+      - Windows taskkill /F @ line 984 — has inner re-check (good, after R2 fix)
+      - POSIX SIGKILL @ line 988 — has inner re-check (good)
+      - **POSIX SIGTERM @ line 977 — NO inner re-check (gap)**
+
+    Race window: between the outer `_is_claude_process` at line 914 and the
+    SIGTERM at line 977, the code runs `_detect_claude_flags` (subprocess call),
+    env-var reads, terminal-env detection. Window ≥ 100ms in practice. If
+    Claude exits + PID recycles in that window, SIGTERM lands on an unrelated
+    POSIX process.
+    """
+
+    def test_sigterm_skipped_when_identity_fails_mid_race(self):
+        """Outer check returns True (Claude alive), then identity flips to
+        False before the plain-terminal SIGTERM. SIGTERM MUST NOT fire."""
+        from cozempic.guard import _terminate_and_resume
+
+        # Sequence: outer check at line 914 → True.
+        # Subsequent _is_claude_process calls → False (PID recycled).
+        call_sequence = [True, False, False, False, False]
+
+        def fake_is_claude_process(pid):
+            return call_sequence.pop(0) if call_sequence else False
+
+        kill_calls = []
+
+        def fake_kill(pid, sig):
+            kill_calls.append((pid, sig))
+            return None
+
+        with (
+            patch("cozempic.guard._detect_terminal_env", return_value="plain"),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.platform.system", return_value="Linux"),
+            patch("cozempic.guard._is_claude_process",
+                  side_effect=fake_is_claude_process),
+            patch("cozempic.guard._wait_for_exit", return_value=True),
+            patch("cozempic.guard.os.kill", side_effect=fake_kill),
+            patch("cozempic.guard._spawn_reload_watcher"),
+        ):
+            _terminate_and_resume(51337, "/tmp/proj", session_id="sess-r3-4")
+
+        sigterm_calls = [
+            (p, s) for (p, s) in kill_calls
+            if p == 51337 and s == signal.SIGTERM
+        ]
+        self.assertEqual(
+            sigterm_calls, [],
+            f"POSIX plain-terminal SIGTERM fired after identity check returned "
+            f"False mid-race. Calls: {kill_calls}. Gap: guard.py:977 has no "
+            f"inner `if _is_claude_process(claude_pid):` guard — unlike the "
+            f"tmux/screen/SIGKILL paths. Fix: mirror those guards.",
+        )
+
+    def test_sigterm_fires_when_identity_remains_valid(self):
+        """Positive: when identity stays True across the race window, SIGTERM
+        MUST fire (guards against an over-protective fix that skips SIGTERM
+        entirely)."""
+        from cozempic.guard import _terminate_and_resume
+
+        kill_calls = []
+
+        def fake_kill(pid, sig):
+            kill_calls.append((pid, sig))
+            return None
+
+        with (
+            patch("cozempic.guard._detect_terminal_env", return_value="plain"),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.platform.system", return_value="Linux"),
+            patch("cozempic.guard._is_claude_process", return_value=True),
+            patch("cozempic.guard._wait_for_exit", return_value=True),
+            patch("cozempic.guard.os.kill", side_effect=fake_kill),
+            patch("cozempic.guard._spawn_reload_watcher"),
+        ):
+            _terminate_and_resume(62424, "/tmp/proj", session_id="sess-r3-4b")
+
+        sigterm_calls = [
+            (p, s) for (p, s) in kill_calls
+            if p == 62424 and s == signal.SIGTERM
+        ]
+        self.assertGreaterEqual(
+            len(sigterm_calls), 1,
+            "POSIX plain-terminal SIGTERM did not fire even though identity "
+            "stayed True. Fix over-protects and leaves Claude running.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -1025,5 +1025,351 @@ class TestNF5_WindowsTaskkillReVerifies(unittest.TestCase):
             )
 
 
+# ---------------------------------------------------------------------------
+# R2-REG-2 — Versioned python binaries (pyenv / Homebrew) must pass
+#
+# Regression: commit be027e0 changed the binary check from
+#   `binary in {"python", "python3"}` to `re.match(r"^python(\d+(\.\d+)*)?$", ...)`.
+# Without this, pyenv installs of python3.13.12 / Homebrew python3.11 guards
+# would be rejected as "not cozempic" → SIGTERM blocked on legitimate daemons,
+# or _is_guard_running_for_session returns None → duplicate daemons spawn.
+# ---------------------------------------------------------------------------
+class TestR2REG2_VersionedPythonAccepted(unittest.TestCase):
+    """Lock in the regex accept/reject contract for python-like binaries.
+
+    Argv pattern used in each case is the canonical daemon spawn:
+        <binary> -m cozempic.cli guard --session <id>
+    so the only variable is tokens[0] (the interpreter path).
+    """
+
+    def _argv_for(self, binary: str) -> str:
+        """Build a canonical daemon argv line with the given interpreter basename."""
+        return f"/usr/local/bin/{binary} -m cozempic.cli guard --session abc-123"
+
+    def _entrypoint_argv(self) -> str:
+        """Native cozempic entry-point (no python interpreter)."""
+        return "/usr/local/bin/cozempic guard --session abc-123"
+
+    def _check(self, binary_or_argv: str, *, argv: str | None = None) -> bool:
+        from cozempic.guard import _is_cozempic_guard_process
+        final_argv = argv if argv is not None else self._argv_for(binary_or_argv)
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(final_argv)):
+            return _is_cozempic_guard_process(12345)
+
+    # ── Accepted variants ────────────────────────────────────────────────
+    def test_accepts_python3_11_homebrew(self):
+        self.assertTrue(self._check("python3.11"),
+                        "Homebrew python3.11 rejected — R2-REG-2 regressed")
+
+    def test_accepts_python3_13_pyenv_short(self):
+        self.assertTrue(self._check("python3.13"),
+                        "pyenv python3.13 rejected — R2-REG-2 regressed")
+
+    def test_accepts_python3_13_12_pyenv_full(self):
+        self.assertTrue(self._check("python3.13.12"),
+                        "pyenv full-triple python3.13.12 rejected — R2-REG-2 regressed")
+
+    def test_accepts_python3_unversioned(self):
+        self.assertTrue(self._check("python3"),
+                        "Plain python3 rejected — R2-REG-2 regressed")
+
+    def test_accepts_python_bare(self):
+        self.assertTrue(self._check("python"),
+                        "Bare python rejected — R2-REG-2 regressed")
+
+    def test_accepts_python2_7_legacy(self):
+        self.assertTrue(self._check("python2.7"),
+                        "Legacy python2.7 rejected — regex should accept any digit sequence")
+
+    def test_accepts_cozempic_entrypoint(self):
+        """Native entry-point path: `cozempic guard ...` with no interpreter."""
+        self.assertTrue(
+            self._check("cozempic", argv=self._entrypoint_argv()),
+            "Native `cozempic guard` entry-point rejected",
+        )
+
+    # ── Rejected variants ────────────────────────────────────────────────
+    def test_rejects_run_cozempic_wrapper(self):
+        self.assertFalse(self._check("run-cozempic"),
+                         "`run-cozempic` wrapper falsely accepted — confused deputy risk")
+
+    def test_rejects_fake_cozempic_impostor(self):
+        self.assertFalse(self._check("fake-cozempic"),
+                         "`fake-cozempic` impostor falsely accepted")
+
+    def test_rejects_python_attacker_impostor(self):
+        self.assertFalse(self._check("python-attacker"),
+                         "`python-attacker` impostor falsely accepted")
+
+    def test_rejects_trailing_dot(self):
+        """`python3.` (trailing dot, no digit group) must fail: regex requires
+        `\\d+` after each dot."""
+        self.assertFalse(self._check("python3."),
+                         "`python3.` trailing-dot falsely accepted — regex is too loose")
+
+    def test_rejects_double_dot(self):
+        """`python3..11` must fail: `\\.\\d+` forbids consecutive dots."""
+        self.assertFalse(self._check("python3..11"),
+                         "`python3..11` double-dot falsely accepted — regex is too loose")
+
+
+# ---------------------------------------------------------------------------
+# Regex edge cases / ReDoS surface on _is_cozempic_guard_process
+# ---------------------------------------------------------------------------
+class TestRegexEdgeCases_IsCozempicGuardProcess(unittest.TestCase):
+    """Pathological / adversarial inputs must fail CLOSED quickly."""
+
+    def test_empty_argv_fails_closed(self):
+        """`ps -p <pid> -o args=` returns empty: must return False, no crash."""
+        from cozempic.guard import _is_cozempic_guard_process
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps("")):
+            self.assertFalse(_is_cozempic_guard_process(12345))
+
+    def test_newline_injected_binary_rejected(self):
+        """Binary with embedded `\\n`: split() produces multi-token output, but
+        the first token must fail the binary check; no crash."""
+        from cozempic.guard import _is_cozempic_guard_process
+        # The argv injects a newline that splits the first "binary" into two
+        # tokens; tokens[0] becomes "python" but tokens[1] becomes "evil-cmd".
+        # Either way, the guard command must not be accepted from a line that
+        # smuggled a newline; and the implementation must not raise.
+        argv = "python\nevil-cmd -m cozempic.cli guard --session abc"
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            # Contract: no exception. Return value can be True or False depending
+            # on whether tokens[0] happens to be "python" (it does, because split()
+            # splits on any whitespace including \n); the important thing is no
+            # crash and no confused-deputy if a genuine newline poisoning was
+            # attempted. We assert no-crash.
+            try:
+                _is_cozempic_guard_process(12345)
+            except Exception as e:
+                self.fail(f"_is_cozempic_guard_process raised on newline input: {e!r}")
+
+    def test_very_long_binary_name_rejected_fast(self):
+        """`python` + `a`*1000: regex must reject and complete quickly (<100ms)."""
+        from cozempic.guard import _is_cozempic_guard_process
+        huge = "python" + "a" * 1000
+        argv = f"{huge} -m cozempic.cli guard --session abc"
+        import time as _t
+        t0 = _t.perf_counter()
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            got = _is_cozempic_guard_process(12345)
+        dt = _t.perf_counter() - t0
+        self.assertFalse(got, "Pathological long binary name falsely accepted")
+        self.assertLess(
+            dt, 0.1,
+            f"_is_cozempic_guard_process took {dt*1000:.1f}ms on 1006-char binary "
+            f"— potential ReDoS surface",
+        )
+
+    def test_unicode_fullwidth_dot_rejected(self):
+        """`python3．11` (fullwidth dot) must NOT match ASCII-dot regex."""
+        from cozempic.guard import _is_cozempic_guard_process
+        argv = "python3．11 -m cozempic.cli guard --session abc"
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            self.assertFalse(
+                _is_cozempic_guard_process(12345),
+                "Unicode fullwidth dot falsely accepted as a version separator",
+            )
+
+    def test_trailing_whitespace_stripped(self):
+        """Trailing whitespace on argv line must not affect acceptance —
+        `args.strip()` handles it; tokens[0] remains clean."""
+        from cozempic.guard import _is_cozempic_guard_process
+        argv = "/usr/local/bin/python3.11 -m cozempic.cli guard --session abc   \n\t "
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            # Trailing whitespace should NOT prevent acceptance of a legitimate
+            # daemon (strip handles it); contract: still True.
+            self.assertTrue(
+                _is_cozempic_guard_process(12345),
+                "Trailing whitespace caused legitimate daemon to be rejected",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Diff coverage — NF-1 + NF-2 round-trip (identity helper wired into watchdog)
+# ---------------------------------------------------------------------------
+class TestDiffCoverage_RoundTrip_NF1_NF2(unittest.TestCase):
+    """End-to-end scenarios exercising _is_claude_process on realistic argvs
+    and confirming the helper's accept/reject contract aligns with the
+    watchdog's expectations (called at guard.py:425)."""
+
+    def test_real_anthropic_claude_code_cli_accepted(self):
+        """Canonical install path: `node /usr/local/lib/node_modules/
+        @anthropic-ai/claude-code/cli.js` must pass."""
+        from cozempic.guard import _is_claude_process
+        argv = (
+            "/usr/local/bin/node "
+            "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+        )
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            self.assertTrue(
+                _is_claude_process(12345),
+                "Canonical `@anthropic-ai/claude-code` cli.js path rejected — "
+                "would cause watchdog to flip claude_alive=False prematurely",
+            )
+
+    def test_native_claude_binary_accepted(self):
+        """Direct `claude` binary (no node wrapper)."""
+        from cozempic.guard import _is_claude_process
+        argv = "/usr/local/bin/claude --resume abc-123"
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            self.assertTrue(
+                _is_claude_process(12345),
+                "Native `claude` binary rejected",
+            )
+
+    def test_recycled_pid_to_node_server_rejected(self):
+        """Claude exited; PID now points at `node server.js` — must reject.
+        This is the exact bug the identity helper defends against."""
+        from cozempic.guard import _is_claude_process
+        argv = "/usr/local/bin/node /home/user/server.js"
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(argv)):
+            self.assertFalse(
+                _is_claude_process(12345),
+                "Recycled PID → `node server.js` falsely accepted as Claude — "
+                "watchdog would let guard keep signaling an unrelated process",
+            )
+
+    def test_watchdog_identity_flip_mid_loop(self):
+        """Simulate watchdog's control flow around guard.py:415-428 — identity
+        helper returning True first, then False mid-loop, must flip a
+        local `claude_alive` flag to False on the False read."""
+        from cozempic.guard import _is_claude_process
+
+        # Sequence mirrors the watchdog's polling: os.kill(pid, 0) succeeds
+        # (liveness), then _is_claude_process is called. We assert the helper
+        # itself switches; the watchdog ties this directly to `claude_alive`.
+        responses = iter([
+            "/usr/local/bin/claude --resume abc",
+            "/usr/local/bin/node /home/user/server.js",  # recycled
+        ])
+
+        def side_effect(cmd, *a, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = next(responses)
+            return m
+
+        with patch("cozempic.guard.subprocess.run", side_effect=side_effect):
+            self.assertTrue(_is_claude_process(12345),
+                            "First poll: legitimate Claude process")
+            self.assertFalse(_is_claude_process(12345),
+                             "Second poll after PID recycle: must reject node server.js")
+
+
+# ---------------------------------------------------------------------------
+# Diff coverage — atomic pidfile error paths (5 errno variants)
+# ---------------------------------------------------------------------------
+class TestDiffCoverage_AtomicPidfile_AllErrnos(unittest.TestCase):
+    """NF-4 follow-up: the except branch at start_guard_daemon:1228 catches
+    `(FileExistsError, OSError)` — test each non-EEXIST errno variant to lock
+    in the contract that none crash the SessionStart hook."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.session_id = "55555555-dddd-eeee-ffff-000000000055"
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.pid_path.unlink(missing_ok=True)
+        self.addCleanup(self.pid_path.unlink, missing_ok=True)
+        key = self.session_id[:12]
+        self.log_path = Path("/tmp") / f"cozempic_guard_{key}.log"
+        self.log_path.unlink(missing_ok=True)
+        self.addCleanup(self.log_path.unlink, missing_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _run_with_os_open_raising(self, exc: Exception):
+        """Invoke start_guard_daemon with a mocked os.open that raises the
+        given exception on EXCL open of our pidfile. Returns result dict OR
+        `{'_raised': exc}` if uncaught."""
+        from cozempic.guard import start_guard_daemon
+
+        real_os_open = os.open
+
+        def fake_open(path, flags, *args, **kwargs):
+            if str(path) == str(self.pid_path) and (flags & os.O_EXCL):
+                raise exc
+            return real_os_open(path, flags, *args, **kwargs)
+
+        with (
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard.find_claude_pid", return_value=7777),
+            patch("cozempic.guard.subprocess.Popen") as mock_popen,
+            patch("cozempic.guard.os.open", side_effect=fake_open),
+        ):
+            mock_popen.return_value = MagicMock(pid=9999)
+            try:
+                return start_guard_daemon(
+                    cwd=self.tmpdir,
+                    session_id=self.session_id,
+                    threshold_tokens=1000,
+                )
+            except OSError as e:
+                return {"_raised": e}
+
+    def _assert_graceful(self, result, label: str):
+        self.assertNotIn(
+            "_raised", result,
+            f"{label} propagated uncaught: {result.get('_raised')!r}. "
+            f"Hook must not crash the non-interactive SessionStart surface.",
+        )
+        self.assertFalse(
+            result.get("started"),
+            f"{label}: expected started=False; got {result!r}",
+        )
+        self.assertIn(
+            "reason", result,
+            f"{label}: result must carry a reason string",
+        )
+
+    def test_enospc_graceful(self):
+        import errno as _errno_mod
+        exc = OSError(_errno_mod.ENOSPC, os.strerror(_errno_mod.ENOSPC))
+        self._assert_graceful(self._run_with_os_open_raising(exc), "ENOSPC")
+
+    def test_erofs_graceful(self):
+        import errno as _errno_mod
+        exc = OSError(_errno_mod.EROFS, os.strerror(_errno_mod.EROFS))
+        self._assert_graceful(self._run_with_os_open_raising(exc), "EROFS")
+
+    def test_eacces_graceful(self):
+        import errno as _errno_mod
+        exc = OSError(_errno_mod.EACCES, os.strerror(_errno_mod.EACCES))
+        self._assert_graceful(self._run_with_os_open_raising(exc), "EACCES")
+
+    def test_ebusy_graceful(self):
+        import errno as _errno_mod
+        exc = OSError(_errno_mod.EBUSY, os.strerror(_errno_mod.EBUSY))
+        self._assert_graceful(self._run_with_os_open_raising(exc), "EBUSY")
+
+    def test_emfile_graceful(self):
+        """EMFILE: file descriptor exhaustion — real-world limit under load."""
+        import errno as _errno_mod
+        exc = OSError(_errno_mod.EMFILE, os.strerror(_errno_mod.EMFILE))
+        self._assert_graceful(self._run_with_os_open_raising(exc), "EMFILE")
+
+    def test_generic_oserror_with_custom_strerror(self):
+        """OSError with an unconventional errno (e.g., from a mounted FS with
+        custom errors) must still flow through the graceful branch."""
+        exc = OSError(999, "custom filesystem error — quota drift")
+        self._assert_graceful(
+            self._run_with_os_open_raising(exc),
+            "OSError(999)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -665,5 +665,365 @@ class TestG8_MainLoopWatchdogVerifiesClaudeIdentity(unittest.TestCase):
             )
 
 
+# ---------------------------------------------------------------------------
+# Round 2 — RED tests for adversarial findings NF-1..NF-5
+# See ADVERSARIAL_REPORT.md (branch audit/guard-py-hardening @ f03164a).
+# ---------------------------------------------------------------------------
+
+
+def _patch_ps(argv: str):
+    """Return a subprocess.run side-effect that emulates `ps -p <pid> -o args=`
+    returning the given argv line (returncode=0). Anything else returns empty."""
+    def fake_run(cmd, *a, **kw):
+        m = MagicMock()
+        m.returncode = 0
+        cmd_list = list(cmd) if isinstance(cmd, (list, tuple)) else [cmd]
+        if cmd_list and cmd_list[0] == "ps":
+            m.stdout = argv
+        else:
+            m.stdout = ""
+        return m
+    return fake_run
+
+
+# ---------------------------------------------------------------------------
+# NF-1 CRITICAL — _is_claude_process must reject generic node/python processes
+# ---------------------------------------------------------------------------
+class TestNF1_IsClaudeProcessRejectsNonClaudeNodes(unittest.TestCase):
+    """Root-cause finding from adversarial round 1: `"node" in comm` matches
+    EVERY node process (nodemon, VSCode ext host, electron apps, npm scripts).
+    On a Claude-user's laptop this is 5-20 unrelated processes — PID-reuse
+    defence collapses to "kill the first node process you find".
+    """
+
+    NON_CLAUDE_ARGVS = [
+        "/usr/local/bin/node /home/user/server.js",
+        "node /home/user/scripts/daily.js",
+        "/usr/bin/node /app/server.js --port 3000",
+        "npm run dev",
+        "/Applications/Visual Studio Code.app/Contents/MacOS/Electron --type=extensionHost",
+        "/Applications/Slack.app/Contents/MacOS/Slack --type=renderer",
+        "python /home/user/bench.py --target claude-code",
+        "python3 -c 'print(\"@anthropic-ai/claude-code is installed\")'",
+    ]
+
+    def test_rejects_common_non_claude_processes(self):
+        """Each argv listed is a realistic non-Claude process found on a
+        dev laptop. _is_claude_process MUST return False for all of them."""
+        from cozempic.guard import _is_claude_process
+        false_positives = []
+        for argv in self.NON_CLAUDE_ARGVS:
+            with patch("cozempic.guard.subprocess.run",
+                       side_effect=_patch_ps(argv)):
+                got = _is_claude_process(12345)
+            if got is True:
+                false_positives.append(argv)
+        self.assertEqual(
+            false_positives, [],
+            f"_is_claude_process false-positive on {len(false_positives)} "
+            f"non-Claude argv(s): {false_positives}. "
+            f"Substring match on 'node' / 'claude-code' is too loose — "
+            f"tighten to require a real Claude Code signature.",
+        )
+
+    def test_accepts_real_anthropic_claude_code_cli(self):
+        """Positive: the canonical `node /path/to/@anthropic-ai/claude-code/cli.js`
+        invocation must still be recognized."""
+        from cozempic.guard import _is_claude_process
+        real_claude = (
+            "/usr/local/bin/node "
+            "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+        )
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(real_claude)):
+            self.assertTrue(
+                _is_claude_process(54321),
+                "Tightened helper must still accept the canonical Claude Code node invocation",
+            )
+
+    def test_accepts_plain_claude_binary(self):
+        """Positive: a native `claude` binary (no node wrapper) must pass."""
+        from cozempic.guard import _is_claude_process
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps("claude --resume abc-123")):
+            self.assertTrue(
+                _is_claude_process(54322),
+                "Tightened helper must accept the native `claude` binary invocation",
+            )
+
+
+# ---------------------------------------------------------------------------
+# NF-2 CRITICAL — main-loop watchdog (guard.py:414-418) not wired to identity
+# ---------------------------------------------------------------------------
+class TestNF2_MainWatchdogUsesIdentityCheck(unittest.TestCase):
+    """Adversarial round 1 found: the `_is_claude_process` helper was added
+    (BUG-G8 fix) but NEVER wired into the main watchdog loop at guard.py:414.
+    The loop still only calls `os.kill(claude_pid, 0)` — PID-reuse bug unfixed.
+    """
+
+    def test_watchdog_source_invokes_identity_check(self):
+        """Static source contract: start_guard's watchdog section MUST call
+        `_is_claude_process(claude_pid)` — otherwise PID-reuse races through
+        liveness-only `os.kill(pid, 0)`."""
+        import inspect
+        from cozempic.guard import start_guard
+        src = inspect.getsource(start_guard)
+        has_identity_call = "_is_claude_process(claude_pid)" in src
+        self.assertTrue(
+            has_identity_call,
+            "Main-loop watchdog (guard.py:~414) does not call "
+            "_is_claude_process(claude_pid). BUG-G8 fix added the helper but "
+            "did not wire it into the watchdog — recycled-PID still races "
+            "through `os.kill(pid, 0)` alone.",
+        )
+
+    def test_watchdog_flips_claude_alive_on_identity_fail(self):
+        """When the identity check is wired, it MUST sit close enough to the
+        `claude_alive = False` flip to drive it. Proxy: both tokens appear
+        within a 400-char window of each other in the watchdog section."""
+        import inspect
+        from cozempic.guard import start_guard
+        src = inspect.getsource(start_guard)
+        if "_is_claude_process(claude_pid)" not in src:
+            self.fail(
+                "Watchdog has no identity call at all (see sibling test). "
+                "NF-2: main watchdog still uses liveness-only os.kill(pid, 0)."
+            )
+        idx = src.index("_is_claude_process(claude_pid)")
+        window = src[max(0, idx - 100):idx + 400]
+        self.assertIn(
+            "claude_alive", window,
+            "Identity helper found but does not flip claude_alive=False — "
+            "watchdog does not react to recycled PID.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# NF-3 HIGH — _is_cozempic_guard_process substring match is too loose
+# ---------------------------------------------------------------------------
+class TestNF3_IsCozempicGuardProcessRejectsLooseSubstrings(unittest.TestCase):
+    """`"cozempic.cli" in args` AND `"cozempic" in tokens[0]` both false-positive
+    on grep/less/vim sessions + any `*-cozempic-*` binary.
+    """
+
+    NON_GUARD_ARGVS = [
+        "grep -r cozempic.cli guard /home/user/projects",
+        "less /tmp/cozempic.cli-guard-output.log",
+        "/usr/local/bin/run-cozempic guard",
+        "/usr/local/bin/fake-cozempic guard --evil",
+        "vim /home/user/projects/cozempic/cli.py",
+    ]
+
+    def test_rejects_loose_substring_matches(self):
+        from cozempic.guard import _is_cozempic_guard_process
+        false_positives = []
+        for argv in self.NON_GUARD_ARGVS:
+            with patch("cozempic.guard.subprocess.run",
+                       side_effect=_patch_ps(argv)):
+                got = _is_cozempic_guard_process(12345)
+            if got is True:
+                false_positives.append(argv)
+        self.assertEqual(
+            false_positives, [],
+            f"_is_cozempic_guard_process false-positive on "
+            f"{len(false_positives)} non-guard argv(s): {false_positives}. "
+            f"Tighten token[0] to endswith python/cozempic AND require "
+            f"cozempic.cli + guard as discrete tokens.",
+        )
+
+    def test_accepts_real_daemon_invocation(self):
+        """Positive: canonical python -m cozempic.cli guard invocation."""
+        from cozempic.guard import _is_cozempic_guard_process
+        real = (
+            "/usr/local/bin/python3 -m cozempic.cli guard "
+            "--session abc-123 --threshold 50.0"
+        )
+        with patch("cozempic.guard.subprocess.run",
+                   side_effect=_patch_ps(real)):
+            self.assertTrue(
+                _is_cozempic_guard_process(55555),
+                "Tightened helper must still accept the canonical daemon invocation",
+            )
+
+
+# ---------------------------------------------------------------------------
+# NF-4 MED — atomic-claim block only catches FileExistsError
+# ---------------------------------------------------------------------------
+class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
+    """`os.open(pid_path, O_CREAT|O_EXCL|O_WRONLY)` can raise OSError with
+    errno ENOSPC / EROFS / EACCES / EMFILE. Currently only FileExistsError is
+    caught — other OSErrors propagate and kill the SessionStart hook silently.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.session_id = "44444444-aaaa-bbbb-cccc-000000000044"
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.pid_path.unlink(missing_ok=True)
+        self.addCleanup(self.pid_path.unlink, missing_ok=True)
+        key = self.session_id[:12]
+        self.log_path = Path("/tmp") / f"cozempic_guard_{key}.log"
+        self.log_path.unlink(missing_ok=True)
+        self.addCleanup(self.log_path.unlink, missing_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _run_with_os_open_raising(self, errno_code: int):
+        """Invoke start_guard_daemon with a mocked os.open that raises OSError
+        with the given errno on the pidfile path. Returns result dict OR
+        `{'_raised': exc}` if uncaught."""
+        from cozempic.guard import start_guard_daemon
+
+        real_os_open = os.open
+
+        def fake_open(path, flags, *args, **kwargs):
+            if str(path) == str(self.pid_path) and (flags & os.O_EXCL):
+                raise OSError(errno_code, os.strerror(errno_code))
+            return real_os_open(path, flags, *args, **kwargs)
+
+        with (
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard.find_claude_pid", return_value=7777),
+            patch("cozempic.guard.subprocess.Popen") as mock_popen,
+            patch("cozempic.guard.os.open", side_effect=fake_open),
+        ):
+            mock_popen.return_value = MagicMock(pid=9999)
+            try:
+                return start_guard_daemon(
+                    cwd=self.tmpdir,
+                    session_id=self.session_id,
+                    threshold_tokens=1000,
+                )
+            except OSError as e:
+                return {"_raised": e}
+
+    def test_enospc_does_not_crash_hook(self):
+        """ENOSPC must NOT propagate — return {started: False, reason: ...}."""
+        import errno as _errno_mod
+        result = self._run_with_os_open_raising(_errno_mod.ENOSPC)
+        self.assertNotIn(
+            "_raised", result,
+            f"ENOSPC propagated uncaught: {result.get('_raised')!r}. "
+            f"start_guard_daemon must return started=False with a reason, "
+            f"not crash the non-interactive SessionStart hook.",
+        )
+        self.assertFalse(
+            result.get("started"),
+            f"Expected started=False on ENOSPC; got {result!r}",
+        )
+        self.assertIn(
+            "reason", result,
+            "Result must carry a reason string explaining the failure",
+        )
+
+    def test_erofs_does_not_crash_hook(self):
+        """EROFS (/tmp read-only) must NOT propagate."""
+        import errno as _errno_mod
+        result = self._run_with_os_open_raising(_errno_mod.EROFS)
+        self.assertNotIn(
+            "_raised", result,
+            f"EROFS propagated uncaught: {result.get('_raised')!r}",
+        )
+        self.assertFalse(result.get("started"))
+        self.assertIn("reason", result)
+
+    def test_eacces_does_not_crash_hook(self):
+        """EACCES (permission denied) must NOT propagate."""
+        import errno as _errno_mod
+        result = self._run_with_os_open_raising(_errno_mod.EACCES)
+        self.assertNotIn(
+            "_raised", result,
+            f"EACCES propagated uncaught: {result.get('_raised')!r}",
+        )
+        self.assertFalse(result.get("started"))
+        self.assertIn("reason", result)
+
+
+# ---------------------------------------------------------------------------
+# NF-5 MED — Windows taskkill bypasses _is_claude_process re-verify
+# ---------------------------------------------------------------------------
+class TestNF5_WindowsTaskkillReVerifies(unittest.TestCase):
+    """On Windows, `_terminate_and_resume` calls `taskkill /PID` and
+    `taskkill /F /PID` with NO identity re-check between the outer verify
+    and the kill call. On POSIX, the SIGKILL at line 975 IS guarded by
+    _is_claude_process; Windows is not.
+    """
+
+    def test_windows_taskkill_f_skipped_when_identity_fails_mid_race(self):
+        """Outer check passes (Claude alive), wait_for_exit times out, THEN
+        identity flips to False (PID recycled). taskkill /F MUST NOT run."""
+        from cozempic.guard import _terminate_and_resume
+
+        # Call sequence: 1st True (outer verify), subsequent False (post-wait)
+        call_sequence = [True, False, False, False, False]
+
+        def fake_is_claude_process(pid):
+            return call_sequence.pop(0) if call_sequence else False
+
+        subprocess_calls = []
+
+        def fake_subprocess_call(cmd, *a, **kw):
+            subprocess_calls.append(list(cmd))
+            return 0
+
+        with (
+            patch("cozempic.guard._detect_terminal_env", return_value="plain"),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.platform.system", return_value="Windows"),
+            patch("cozempic.guard._is_claude_process",
+                  side_effect=fake_is_claude_process),
+            patch("cozempic.guard._wait_for_exit", return_value=False),
+            patch("cozempic.guard.subprocess.call",
+                  side_effect=fake_subprocess_call),
+            patch("cozempic.guard._spawn_reload_watcher"),
+            patch("cozempic.guard.os.kill"),
+        ):
+            _terminate_and_resume(31337, r"C:\proj", session_id="sess-w")
+
+        forced_taskkill = [
+            c for c in subprocess_calls
+            if c and c[0] == "taskkill" and "/F" in c and str(31337) in c
+        ]
+        self.assertEqual(
+            forced_taskkill, [],
+            f"Windows taskkill /F invoked despite identity returning False "
+            f"pre-kill: {forced_taskkill}. Recycled-PID blast radius: "
+            f"force-kills whatever process now owns PID 31337 (Chrome tab, "
+            f"Discord, etc.).",
+        )
+
+    def test_windows_taskkill_proceeds_when_identity_still_valid(self):
+        """Positive: when _is_claude_process stays True, some taskkill MUST
+        run — guards against a fix that over-protects and leaves Claude alive."""
+        from cozempic.guard import _terminate_and_resume
+
+        with (
+            patch("cozempic.guard._detect_terminal_env", return_value="plain"),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.platform.system", return_value="Windows"),
+            patch("cozempic.guard._is_claude_process", return_value=True),
+            patch("cozempic.guard._wait_for_exit", return_value=False),
+            patch("cozempic.guard.subprocess.call") as mock_call,
+            patch("cozempic.guard._spawn_reload_watcher"),
+            patch("cozempic.guard.os.kill"),
+        ):
+            _terminate_and_resume(44444, r"C:\proj", session_id="sess-w2")
+
+            taskkill_for_pid = [
+                c for c in mock_call.call_args_list
+                if c.args and len(c.args[0]) >= 1
+                and c.args[0][0] == "taskkill"
+                and str(44444) in c.args[0]
+            ]
+            self.assertGreaterEqual(
+                len(taskkill_for_pid), 1,
+                "No taskkill invoked when identity check stayed True — "
+                "fix over-protects and leaves Claude running",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -1,0 +1,669 @@
+"""RED tests for guard.py PID-reuse and shell-injection hardening (bugs G1-G8).
+
+Each test class targets one concrete bug from AUDIT_REPORT.md and captures the
+CONTRACT that the fix must satisfy. Tests avoid implementation details — they
+assert what the caller / OS / filesystem observes.
+
+Bugs covered:
+  G1 CRITICAL — _cleanup_legacy_pid signals unverified PID
+  G2 CRITICAL — _cleanup_stale_watchers signals substring-only pgrep match
+  G3 HIGH     — _is_guard_running_for_session missing PID-reuse defence
+  G4 HIGH     — TOCTOU race in PID file creation
+  G5 HIGH     — _terminate_and_resume signals unverified claude_pid
+  G6 HIGH     — Windows cmd injection + unquoted project_dir/flags
+  G7 MED      — _detect_claude_flags breaks on spaces/metachar; injection flows through
+  G8 MED      — main-loop Claude watchdog uses PID with no identity verification
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# BUG-G1 — _cleanup_legacy_pid must NOT SIGTERM unverified PID
+# ---------------------------------------------------------------------------
+class TestG1_CleanupLegacyPidRequiresArgvVerify(unittest.TestCase):
+    """_cleanup_legacy_pid must call _is_cozempic_guard_process before SIGTERM.
+
+    Scenario: pre-1.6.13 legacy pidfile holds PID N. Host has since recycled
+    N to an unrelated user process (editor, node server, shell). The cleanup
+    path must NOT send SIGTERM to N. It should only unlink the legacy file.
+    """
+
+    def setUp(self):
+        # Temp legacy pidfile so we don't touch /tmp globally
+        self.tmpdir = tempfile.mkdtemp()
+        self.cwd = self.tmpdir
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_legacy_pidfile(self, pid: int) -> Path:
+        """Write a legacy-format pidfile; return its Path."""
+        from cozempic.guard import _pid_file_for_cwd
+        legacy = _pid_file_for_cwd(self.cwd)
+        legacy.write_text(str(pid))
+        self.addCleanup(legacy.unlink, missing_ok=True)
+        return legacy
+
+    def test_does_not_sigterm_non_guard_pid(self):
+        """Recycled-PID scenario: pidfile points at a non-cozempic process.
+
+        With the fix, SIGTERM MUST NOT be sent. The legacy file is still unlinked.
+        """
+        from cozempic.guard import _cleanup_legacy_pid
+        self._write_legacy_pidfile(31337)
+
+        with (
+            patch("cozempic.guard._is_cozempic_guard_process", return_value=False),
+            patch("cozempic.guard.os.kill") as mock_kill,
+        ):
+            _cleanup_legacy_pid(self.cwd)
+
+            # Liveness probe kill(pid, 0) is OK; SIGTERM is NOT.
+            sigterm_calls = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGTERM
+            ]
+            self.assertEqual(
+                sigterm_calls, [],
+                "Legacy cleanup sent SIGTERM to a non-guard PID — confused deputy bug",
+            )
+
+    def test_sigterms_legitimate_guard_pid(self):
+        """Positive case: pidfile points at a real cozempic guard — SIGTERM is allowed."""
+        from cozempic.guard import _cleanup_legacy_pid
+        self._write_legacy_pidfile(42000)
+
+        with (
+            patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+            patch("cozempic.guard.os.kill") as mock_kill,
+            patch("cozempic.guard.time.sleep"),
+        ):
+            _cleanup_legacy_pid(self.cwd)
+
+            sigterm_calls = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGTERM and c.args[0] == 42000
+            ]
+            self.assertEqual(
+                len(sigterm_calls), 1,
+                "Legacy cleanup failed to SIGTERM a verified guard PID",
+            )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G2 — _cleanup_stale_watchers must NOT signal substring-only pgrep matches
+# ---------------------------------------------------------------------------
+class TestG2_CleanupStaleWatchersRequiresArgvVerify(unittest.TestCase):
+    """_cleanup_stale_watchers must verify each match's full argv before SIGTERM.
+
+    pgrep -f matches the entire command line as regex. A process like
+    `vim /tmp/cozempic_guard_resumed_Claude_notes.md` matches
+    'cozempic.*resumed Claude' but is NOT a watcher.
+    """
+
+    def test_does_not_sigterm_false_positive_pgrep_match(self):
+        """pgrep returns a PID whose argv is not a real watcher; no SIGTERM."""
+        from cozempic.guard import _cleanup_stale_watchers
+
+        # pgrep returns the PID — but the argv that ps resolves is a vim editor
+        false_pid = "77777"
+        false_argv = "vim /home/u/cozempic_guard_resumed_Claude_notes.md"
+
+        def fake_run(cmd, *args, **kwargs):
+            mock = MagicMock()
+            mock.returncode = 0
+            if cmd[0] == "pgrep":
+                mock.stdout = false_pid + "\n"
+            elif cmd[0] == "ps":
+                mock.stdout = false_argv + "\n"
+            else:
+                mock.stdout = ""
+            return mock
+
+        with (
+            patch("cozempic.guard.subprocess.run", side_effect=fake_run),
+            patch("cozempic.guard.os.kill") as mock_kill,
+        ):
+            _cleanup_stale_watchers()
+
+            sigterm_calls = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGTERM
+            ]
+            self.assertEqual(
+                sigterm_calls, [],
+                "Stale-watcher cleanup SIGTERM'd a process whose argv is not a watcher "
+                "(substring-only match — confused deputy)",
+            )
+
+    def test_sigterms_real_watcher_match(self):
+        """Positive case: pgrep returns a real bash watcher — SIGTERM is allowed."""
+        from cozempic.guard import _cleanup_stale_watchers
+
+        real_pid = "88888"
+        # Matches the real watcher_script shape in _spawn_reload_watcher at ~933-937
+        real_argv = (
+            "bash -c while kill -0 5000 2>/dev/null; do sleep 1; done; sleep 1; "
+            "osascript ... Cozempic guard resumed Claude in /home/u/project"
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            mock = MagicMock()
+            mock.returncode = 0
+            if cmd[0] == "pgrep":
+                mock.stdout = real_pid + "\n"
+            elif cmd[0] == "ps":
+                mock.stdout = real_argv + "\n"
+            else:
+                mock.stdout = ""
+            return mock
+
+        with (
+            patch("cozempic.guard.subprocess.run", side_effect=fake_run),
+            patch("cozempic.guard.os.kill") as mock_kill,
+        ):
+            _cleanup_stale_watchers()
+
+            sigterm_calls = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGTERM
+                and c.args[0] == int(real_pid)
+            ]
+            self.assertGreaterEqual(
+                len(sigterm_calls), 1,
+                "Stale-watcher cleanup failed to SIGTERM a legitimate watcher",
+            )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G3 — _is_guard_running_for_session must verify PID ownership
+# ---------------------------------------------------------------------------
+class TestG3_IsGuardRunningForSessionVerifiesPidOwnership(unittest.TestCase):
+    """_is_guard_running_for_session must return None when the pidfile PID
+    is alive but not a cozempic guard.
+
+    Scenario: daemon crashed, PID recycled to an unrelated process. The
+    function currently only checks `os.kill(pid, 0)` → returns the recycled
+    PID → start_guard_daemon treats session as already_running → session
+    is permanently unprotected.
+    """
+
+    def setUp(self):
+        self.session_id = "11111111-2222-3333-4444-000000000001"
+        # Pre-seed the session pidfile with a recycled-looking PID.
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.pid_path.write_text("98765")
+        self.addCleanup(self.pid_path.unlink, missing_ok=True)
+
+    def test_returns_none_when_pid_is_not_cozempic_guard(self):
+        """PID is alive (os.kill returns) but ps shows it's not our daemon."""
+        from cozempic.guard import _is_guard_running_for_session
+
+        # os.kill(pid, 0) succeeds (liveness OK); but _is_cozempic_guard_process
+        # must return False for this PID → the function MUST return None.
+        with (
+            patch("cozempic.guard.os.kill") as mock_kill,
+            patch("cozempic.guard._is_cozempic_guard_process", return_value=False),
+        ):
+            result = _is_guard_running_for_session(self.session_id)
+
+            self.assertIsNone(
+                result,
+                "Returned a recycled PID as if guard were running — session would "
+                "run permanently unprotected. Must verify PID identity.",
+            )
+            # And liveness probe should have been attempted
+            # (we don't assert on _is_cozempic_guard_process call count, just on
+            # the returned contract — some implementations may short-circuit)
+
+    def test_returns_pid_when_pid_is_cozempic_guard(self):
+        """Positive case: PID is alive AND ps confirms it's a cozempic guard."""
+        from cozempic.guard import _is_guard_running_for_session
+
+        with (
+            patch("cozempic.guard.os.kill"),
+            patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+        ):
+            result = _is_guard_running_for_session(self.session_id)
+
+            self.assertEqual(
+                result, 98765,
+                "Failed to report a legitimate running guard PID",
+            )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G4 — PID file creation must be atomic (no TOCTOU race)
+# ---------------------------------------------------------------------------
+class TestG4_PidfileWriteIsAtomic(unittest.TestCase):
+    """Two concurrent start_guard_daemon() calls for the same session must
+    NOT both succeed in spawning daemons.
+
+    Without atomic pidfile creation (O_CREAT|O_EXCL), both calls pass the
+    _is_guard_running_for_session check with None, both spawn Popen, one
+    overwrites the other's pidfile → orphan daemon.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.session_id = "22222222-3333-4444-5555-000000000002"
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.session_id)
+        # Ensure clean state
+        self.pid_path.unlink(missing_ok=True)
+        # Also clean log file
+        key = self.session_id[:12]
+        self.log_path = Path("/tmp") / f"cozempic_guard_{key}.log"
+        self.log_path.unlink(missing_ok=True)
+        self.addCleanup(self.pid_path.unlink, missing_ok=True)
+        self.addCleanup(self.log_path.unlink, missing_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _run_concurrent_starts(self, pid_base: int):
+        """Shared helper: apply patches on main thread (mock.patch is NOT
+        thread-safe across __enter__/__exit__) and race two start_guard_daemon
+        invocations via the existing threads. Returns (results, on_disk_pid).
+        """
+        from cozempic.guard import start_guard_daemon
+
+        start_gate = threading.Event()
+        popen_counter = {"n": 0}
+        counter_lock = threading.Lock()
+
+        class DummyProc:
+            def __init__(self, pid):
+                self.pid = pid
+
+        def fake_popen(cmd_parts, **kwargs):
+            with counter_lock:
+                popen_counter["n"] += 1
+                pid = pid_base + popen_counter["n"]
+            # Hold until gate releases so both threads pass the pre-check before
+            # either writes the pidfile (worst-case TOCTOU).
+            start_gate.wait(timeout=3.0)
+            return DummyProc(pid)
+
+        results = []
+        results_lock = threading.Lock()
+
+        def runner():
+            try:
+                r = start_guard_daemon(
+                    cwd=self.tmpdir,
+                    session_id=self.session_id,
+                    threshold_tokens=1000,
+                )
+            except Exception as e:
+                r = {"error": repr(e)}
+            with results_lock:
+                results.append(r)
+
+        # Patches applied on the main thread — safe.
+        with (
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard.find_claude_pid", return_value=7777),
+            patch("cozempic.guard.subprocess.Popen", side_effect=fake_popen),
+        ):
+            t1 = threading.Thread(target=runner)
+            t2 = threading.Thread(target=runner)
+            t1.start()
+            t2.start()
+            import time as _t
+            _t.sleep(0.15)
+            start_gate.set()
+            t1.join(timeout=5.0)
+            t2.join(timeout=5.0)
+            self.assertFalse(
+                t1.is_alive() or t2.is_alive(),
+                "Worker threads didn't exit — pollutes mock.patch state",
+            )
+
+        on_disk_pid = None
+        if self.pid_path.exists():
+            try:
+                on_disk_pid = int(self.pid_path.read_text().strip())
+            except (ValueError, OSError):
+                on_disk_pid = None
+        return results, on_disk_pid
+
+    def test_concurrent_starts_only_one_spawn_wins(self):
+        """Race two start_guard_daemon calls; only one must report started=True.
+
+        Without atomic pidfile creation (O_CREAT|O_EXCL), both calls pass the
+        pre-check and both write the pidfile — TOCTOU orphan-daemon bug.
+        """
+        results, _ = self._run_concurrent_starts(pid_base=10000)
+
+        started_count = sum(1 for r in results if r.get("started") is True)
+        self.assertEqual(
+            started_count, 1,
+            f"Concurrent starts: {started_count} reported started=True. Expected 1. "
+            f"TOCTOU race — pidfile creation is not atomic.",
+        )
+
+    def test_final_pidfile_contains_only_winning_pid(self):
+        """After a race, the on-disk pidfile must contain the PID that actually
+        won the spawn, not an orphan of the loser."""
+        results, on_disk_pid = self._run_concurrent_starts(pid_base=20000)
+
+        winner_pids = [r.get("pid") for r in results if r.get("started") is True]
+        self.assertTrue(
+            self.pid_path.exists(),
+            "Pidfile missing after concurrent starts",
+        )
+        self.assertIn(
+            on_disk_pid, winner_pids,
+            f"Pidfile contains pid {on_disk_pid} which is not in the winner set "
+            f"{winner_pids} — orphan-daemon condition",
+        )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G5 — _terminate_and_resume must re-verify claude_pid identity
+# ---------------------------------------------------------------------------
+class TestG5_TerminateAndResumeReVerifiesClaudePid(unittest.TestCase):
+    """_terminate_and_resume must check that claude_pid still points at a
+    Claude process (comm=node/claude) before SIGTERM/SIGKILL.
+
+    claude_pid is captured at daemon start but the daemon lives for hours.
+    If Claude exited and PID was recycled, blind SIGTERM targets a random
+    unrelated process.
+    """
+
+    def test_does_not_sigterm_when_pid_not_claude(self):
+        """Stale claude_pid now maps to a non-Claude process; no SIGTERM."""
+        from cozempic.guard import _terminate_and_resume
+
+        # Simulate: plain terminal path, claude_pid recycled to something else.
+        # The contract: before `os.kill(claude_pid, SIGTERM)` (lines 838, 862,
+        # 880), an identity check must gate the signal.
+        with (
+            patch("cozempic.guard._detect_terminal_env", return_value="plain"),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.platform.system", return_value="Linux"),
+            # Simulate identity check: PID is NOT a claude/node process.
+            # Fix must introduce a helper; we pretend it exists and returns False.
+            patch("cozempic.guard._is_claude_process", create=True, return_value=False),
+            patch("cozempic.guard.os.kill") as mock_kill,
+            patch("cozempic.guard._wait_for_exit", return_value=True),
+            patch("cozempic.guard._spawn_reload_watcher"),
+        ):
+            _terminate_and_resume(31337, "/tmp/proj", session_id="sess-abc")
+
+            sigterm_calls = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGTERM
+                and c.args[0] == 31337
+            ]
+            sigkill_calls = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGKILL
+                and c.args[0] == 31337
+            ]
+            self.assertEqual(
+                sigterm_calls, [],
+                "_terminate_and_resume SIGTERM'd a recycled (non-Claude) PID",
+            )
+            self.assertEqual(
+                sigkill_calls, [],
+                "_terminate_and_resume SIGKILL'd a recycled (non-Claude) PID",
+            )
+
+    def test_tmux_path_does_not_sigterm_when_pid_not_claude(self):
+        """tmux branch (line 838) also must gate SIGTERM on identity check."""
+        from cozempic.guard import _terminate_and_resume
+
+        with (
+            patch("cozempic.guard._detect_terminal_env", return_value="tmux"),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.platform.system", return_value="Linux"),
+            patch("cozempic.guard._is_claude_process", create=True, return_value=False),
+            patch("cozempic.guard.os.kill") as mock_kill,
+            patch("cozempic.guard._wait_for_exit", return_value=False),  # force escalation
+            patch("cozempic.guard.subprocess.run"),
+            patch("cozempic.guard.time.sleep"),
+        ):
+            _terminate_and_resume(44444, "/tmp/proj", session_id="sess-xyz")
+
+            bad_sigterm = [
+                c for c in mock_kill.call_args_list
+                if len(c.args) >= 2 and c.args[1] == signal.SIGTERM
+                and c.args[0] == 44444
+            ]
+            self.assertEqual(
+                bad_sigterm, [],
+                "tmux-path _terminate_and_resume SIGTERM'd a recycled (non-Claude) PID",
+            )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G6 — Windows cmd must quote project_dir; injection must not execute
+# ---------------------------------------------------------------------------
+class TestG6_WindowsCmdQuotesArgs(unittest.TestCase):
+    """_spawn_reload_watcher on Windows must not shell-interpolate project_dir.
+
+    Current code uses: f"start cmd /c \"cd /d {project_dir} && claude ...\""
+    Any cmd metacharacter in project_dir (&, |, %, ^) executes arbitrary cmds.
+    """
+
+    def test_windows_malicious_project_dir_does_not_appear_raw_in_shell_string(self):
+        """A project_dir with `& calc &` must NOT be interpolated raw into
+        the watcher_script passed to bash."""
+        from cozempic.guard import _spawn_reload_watcher
+
+        malicious = r"C:\projects\evil & calc.exe &"
+
+        captured = {"cmd": None, "kwargs": None}
+
+        def fake_popen(cmd_parts, **kwargs):
+            captured["cmd"] = cmd_parts
+            captured["kwargs"] = kwargs
+            proc = MagicMock()
+            proc.pid = 9999
+            return proc
+
+        with (
+            patch("cozempic.guard.platform.system", return_value="Windows"),
+            patch("cozempic.guard.is_ssh_session", return_value=False),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.subprocess.Popen", side_effect=fake_popen),
+        ):
+            _spawn_reload_watcher(5555, malicious, session_id="sess-w")
+
+        # The watcher_script is cmd_parts[-1] (bash -c <script>)
+        self.assertIsNotNone(captured["cmd"], "Popen was not called")
+        script = captured["cmd"][-1] if captured["cmd"] else ""
+
+        # Contract: on any platform, the Windows resume command must quote/escape
+        # `project_dir`. Test: the raw unquoted malicious sequence
+        # "evil & calc.exe &" must NOT appear verbatim in the script — a
+        # correctly-quoted form wraps it in quotes or escapes the `&`.
+        self.assertNotIn(
+            "evil & calc.exe &", script,
+            "project_dir interpolated raw into watcher script — cmd injection risk. "
+            "Must be quoted via subprocess.list2cmdline or argv-passed.",
+        )
+
+    def test_windows_malicious_project_dir_metachars_escaped(self):
+        """Stronger check: at least one of the cmd metacharacters (&, |) in
+        project_dir must be quoted/escaped in the final script."""
+        from cozempic.guard import _spawn_reload_watcher
+
+        malicious = r"C:\bad & pwn"
+        captured = {"cmd": None}
+
+        def fake_popen(cmd_parts, **kwargs):
+            captured["cmd"] = cmd_parts
+            proc = MagicMock()
+            proc.pid = 1
+            return proc
+
+        with (
+            patch("cozempic.guard.platform.system", return_value="Windows"),
+            patch("cozempic.guard.is_ssh_session", return_value=False),
+            patch("cozempic.guard._detect_claude_flags", return_value=""),
+            patch("cozempic.guard.subprocess.Popen", side_effect=fake_popen),
+        ):
+            _spawn_reload_watcher(1234, malicious, session_id="sess-x")
+
+        script = captured["cmd"][-1] if captured["cmd"] else ""
+        # The unquoted run sequence `\bad & pwn` indicates direct interpolation.
+        # A fix quotes the directory (`"C:\bad & pwn"`) or escapes & as `^&`.
+        self.assertFalse(
+            "\\bad & pwn" in script and '"C:\\bad & pwn"' not in script,
+            f"Windows cmd string embeds unquoted metachars: {script!r}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G7 — _detect_claude_flags must preserve flag/value boundaries
+# ---------------------------------------------------------------------------
+class TestG7_DetectClaudeFlagsPreservesBoundaries(unittest.TestCase):
+    """_detect_claude_flags must preserve flag-value boundaries and must not
+    allow shell metacharacters to reach subsequent shell interpolation.
+    """
+
+    def test_space_in_flag_value_preserved(self):
+        """--add-dir '/Users/foo/My Project' must come back with the path intact."""
+        from cozempic.guard import _detect_claude_flags
+
+        # On real POSIX, ps -o args= returns argv joined by spaces — quoting lost.
+        # A correct implementation uses psutil or /proc/<pid>/cmdline to preserve
+        # boundaries.
+        fake_ps = "claude --add-dir /Users/foo/My Project --other flag"
+
+        def fake_run(cmd, *a, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            if cmd[0] == "ps":
+                m.stdout = fake_ps
+            else:
+                m.stdout = ""
+            return m
+
+        with patch("cozempic.guard.subprocess.run", side_effect=fake_run):
+            result = _detect_claude_flags(5000)
+
+        # Contract: either a correctly parsed flag-list is returned, or the
+        # value "/Users/foo/My Project" is preserved as a single token. In the
+        # current broken impl, result ends up as "--add-dir /Users/foo/My Project ..."
+        # — when re-interpolated into a shell, `ls /Users/foo/My` runs and
+        # `Project` is a separate arg. Fix: preserved via real argv parsing.
+        #
+        # Minimum contract: path with spaces must survive re-shell-parse.
+        import shlex
+        tokens = shlex.split(result) if result else []
+        self.assertIn(
+            "/Users/foo/My Project", tokens,
+            f"Space-containing flag value lost after _detect_claude_flags: {result!r}",
+        )
+
+    def test_shell_metachar_in_flag_value_not_executable(self):
+        """A flag value with `;` / `$(...)` / backtick must NOT be re-parseable
+        as a shell command when the result flows through resume_cmd."""
+        from cozempic.guard import _detect_claude_flags
+
+        # Simulate ps returning argv with injected shell metachars
+        fake_ps = "claude --model sonnet --foo \"; touch /tmp/pwned_by_g7 #\""
+
+        def fake_run(cmd, *a, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            if cmd[0] == "ps":
+                m.stdout = fake_ps
+            else:
+                m.stdout = ""
+            return m
+
+        with patch("cozempic.guard.subprocess.run", side_effect=fake_run):
+            result = _detect_claude_flags(5001)
+
+        # Contract: result does not contain an un-quoted `;` or command
+        # substitution syntax that a downstream shell interpolator would
+        # execute. At minimum no bare `;` followed by whitespace+word.
+        import re
+        self.assertIsNone(
+            re.search(r";\s*touch\b", result),
+            f"_detect_claude_flags leaked an executable `;touch ...` into output: {result!r}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# BUG-G8 — Main-loop Claude watchdog must verify PID identity
+# ---------------------------------------------------------------------------
+class TestG8_MainLoopWatchdogVerifiesClaudeIdentity(unittest.TestCase):
+    """The main-loop watchdog (guard.py:414-422) must not accept a
+    liveness-only os.kill(pid, 0) as proof that Claude is still alive.
+
+    After fix, a dedicated identity helper (e.g., _is_claude_process) or
+    equivalent argv check must exist and be called.
+    """
+
+    def test_is_claude_process_helper_exists(self):
+        """Post-fix, the module must expose a helper to verify a PID is Claude.
+
+        This contract mirrors _is_cozempic_guard_process (line 1161) but for
+        claude/node processes. Without it, the watchdog CAN'T verify identity.
+        """
+        import cozempic.guard as g
+        self.assertTrue(
+            hasattr(g, "_is_claude_process"),
+            "Expected cozempic.guard._is_claude_process helper (mirrors "
+            "_is_cozempic_guard_process but for claude/node) — currently missing "
+            "→ watchdog has no way to verify PID identity (BUG-G8).",
+        )
+
+    def test_is_claude_process_rejects_non_claude_pid(self):
+        """The helper, when present, must return False for a non-claude argv."""
+        import cozempic.guard as g
+        if not hasattr(g, "_is_claude_process"):
+            self.skipTest("helper missing — see test_is_claude_process_helper_exists")
+
+        def fake_run(cmd, *a, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            # ps -p <pid> -o args= returns something unrelated
+            m.stdout = "nginx: master process /usr/sbin/nginx"
+            return m
+
+        with patch("cozempic.guard.subprocess.run", side_effect=fake_run):
+            self.assertFalse(
+                g._is_claude_process(12345),
+                "_is_claude_process accepted a non-claude process",
+            )
+
+    def test_is_claude_process_accepts_claude_pid(self):
+        """The helper must return True for a typical Claude/node argv."""
+        import cozempic.guard as g
+        if not hasattr(g, "_is_claude_process"):
+            self.skipTest("helper missing — see test_is_claude_process_helper_exists")
+
+        def fake_run(cmd, *a, **kw):
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = "node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+            return m
+
+        with patch("cozempic.guard.subprocess.run", side_effect=fake_run):
+            self.assertTrue(
+                g._is_claude_process(54321),
+                "_is_claude_process rejected a legitimate claude node process",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A deep audit of `src/cozempic/guard.py` (1346 LOC, 25 top-level defs) surfaced **17 concrete bugs**. Dominant theme: 5 of the top 8 issues are **PID-reuse confused-deputy** bugs where the existing `_is_cozempic_guard_process` identity check (added in earlier work, line 1161) was only wired into `reload_self_daemon` — every other code path that sent signals (cleanup, watchdog, session probe) skipped the verification.

On a recycled PID, `os.kill(pid, 0)` says "alive" even when the PID now belongs to an unrelated user process. Without argv verification, `_cleanup_legacy_pid` / `_cleanup_stale_watchers` / `_terminate_and_resume` would SIGTERM whatever process happened to inherit the recycled PID — Slack, VS Code, nodemon, a user's grep session.

## Audit summary (see `AUDIT_REPORT.md` in branch)

| Severity | Count | Examples |
|---|---|---|
| CRITICAL | 2 | G1 `_cleanup_legacy_pid` confused-deputy; G2 `_cleanup_stale_watchers` pgrep substring |
| HIGH | 6 | G3 PID-reuse in session probe; G4 pidfile TOCTOU; G5-G8 unverified signal paths; G7 argv injection |
| MEDIUM | 7 | log rotation, watcher lifetime, signal-handler I/O, etc. |
| LOW | 2 | filename validation, /tmp read-only |

## Fixes shipped in this PR

**Round 1 — 8 commits** addressed all CRITICAL + HIGH (G1-G8):

- `bfbb498` — G8: added `_is_claude_process` helper (mirrors `_is_cozempic_guard_process` for node/claude processes)
- `1ccbd3c` — G1: `_cleanup_legacy_pid` gates SIGTERM on `_is_cozempic_guard_process`
- `3618655` — G2: added `_is_cozempic_watcher_process`; `_cleanup_stale_watchers` verifies argv via ps
- `b993709` — G3: `_is_guard_running_for_session` verifies PID identity; unlinks stale pidfile on mismatch
- `503913d` — G4: atomic pidfile creation via `os.open(O_CREAT|O_EXCL|O_WRONLY)` before spawning
- `4b49a73` — G5: `_terminate_and_resume` re-verifies identity before SIGTERM/SIGKILL (plain, tmux, screen)
- `3019831` — G6: Windows cmd metachars escaped with `^` prefix to prevent shell injection
- `f03164a` — G7: `_detect_claude_flags` uses `psutil.Process.cmdline()` with `ps + shlex.split` fallback; drops tokens containing shell metachars

**Round 2 — 5 commits** closed adversarial-review findings (CONDITIONAL → SHIP):

- `99be51e` — NF-3: `_is_cozempic_guard_process` strict token match (rejects `run-cozempic`, `grep cozempic.cli guard ...`, `less /tmp/cozempic.cli-log`)
- `0f028cc` — NF-1 **CRITICAL**: `_is_claude_process` binary equality + claude-code marker. Previous substring match accepted ANY node process → on PID reuse, `_terminate_and_resume` would SIGTERM Slack/VS Code/nodemon
- `9149d2c` — NF-2 **CRITICAL**: main watchdog at `start_guard` (line 414-424) now calls `_is_claude_process(claude_pid)` to detect identity change. Previously only `os.kill(pid, 0)` (liveness, not identity)
- `7b1973d` — NF-4: atomic pidfile claim handles ENOSPC/EROFS/EACCES gracefully (was propagating uncaught → killing SessionStart hook silently)
- `14514af` — NF-5: Windows `taskkill /PID` and `taskkill /F /PID` re-verify identity (previously only POSIX SIGKILL had the guard)

**Round 2 regression fix — 1 commit**:

- `be027e0` — R2-REG-2: `_is_cozempic_guard_process` accepts versioned python binaries (`python3.11`, `python3.13.12`) via regex `^python(\d+(\.\d+)*)?$`. NF-3's strict set-membership check was breaking pyenv/Homebrew users

## Validation pipeline

1. **Audit** → `AUDIT_REPORT.md` (17 bugs with file:line + repro + fix direction)
2. **RED TDD round 1** → 11 tests capturing G1-G8 behavior (`46cf294`)
3. **Fix round 1** → 8 commits flipping RED to GREEN
4. **Adversarial review** → `ADVERSARIAL_REPORT.md` surfaced NF-1/NF-2 CRITICAL + NF-3/4/5 MED
5. **RED TDD round 2** → 8 tests capturing NF-1..NF-5 (`4611b06`)
6. **Fix round 2** → 5 commits
7. **Adversarial re-verify** → SHIP verdict, 1 MED regression (R2-REG-2) identified
8. **R2-REG-2 fix** → 1 commit
9. **Final validation** → V1-V6 end-to-end including live daemon test

## Test coverage

- New file: `tests/test_guard_hardening.py` (**+1029 lines**, 29 tests across 13 test classes)
- Covers: all 8 primary bugs (G1-G8) + all 5 adversarial findings (NF-1..NF-5) + 4 GREEN positive regression guards
- All tests mock `os.kill`, `subprocess.run`, `psutil.Process`, `platform.system` — no real daemons spawned

## Test plan

- [x] `pytest tests/test_guard_hardening.py -q` → **29/29 passed**
- [x] `pytest tests/ -q --ignore=tests/test_model_detection.py` → **542 passed, 0 failed, 5 subtests** (the 3 `test_model_detection.py` failures are unrelated to this PR and present on origin/main too)
- [x] Live daemon test: spawned real `cozempic guard --daemon` on PID 99441, confirmed `_is_cozempic_guard_process(99441)` returns True
- [x] BLOCKER-1 replay: 10 realistic non-Claude node processes (webpack, jest, vite, electron, express, ts-node) all correctly rejected by `_is_claude_process`; 3 canonical Claude invocations accepted
- [x] G1/G2/G3 replay via mocks: no false-positive SIGTERM on recycled PIDs
- [x] Performance: `_detect_claude_flags` on 1000-token argv = 21.5ms (under 100ms budget)
- [x] No test ordering dependency: ran full suite twice, identical results

## Breaking changes

**None.** All fixes are narrower identity gates around existing signal sinks — legitimate cozempic daemon/Claude invocations continue to work. pyenv/Homebrew users explicitly supported via the R2-REG-2 regex fix.

## Scope

- **+1739 / -51 LOC** across 3 files: `src/cozempic/guard.py`, `tests/test_guard_hardening.py`, `AUDIT_REPORT.md` (in-branch for reviewer context; can be moved to `docs/` or deleted if you prefer)
- 17 commits: 8 round-1 fixes + 1 round-1 RED + 5 round-2 fixes + 1 round-2 RED + 1 R2-REG-2 + 1 audit doc

## Related

Follow-up to:
- [PR #84](https://github.com/Ruya-AI/cozempic/pull/84) (v1.8.7) — digest noise hardening
- [PR #85](https://github.com/Ruya-AI/cozempic/pull/85) (v1.8.8) — `_infer_scope` word-boundary