### PR TITLE
fix(guard): forward claude_pid to guard_prune_cycle at reload thresholds

### DIFF
--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -488,6 +488,7 @@ def start_guard(
                     auto_reload=auto_reload,
                     cwd=cwd or os.getcwd(),
                     session_id=sess["session_id"],
+                    claude_pid=claude_pid,
                 )
 
                 if result.get("reloading"):
@@ -534,6 +535,7 @@ def start_guard(
                         auto_reload=auto_reload,
                         cwd=cwd or os.getcwd(),
                         session_id=sess["session_id"],
+                        claude_pid=claude_pid,
                     )
 
                 if result.get("reloading"):


### PR DESCRIPTION
### Bug

When the guard daemon hits the HARD1 (55%) or HARD2 (80%) reload threshold, `guard_prune_cycle()` is called without `claude_pid` and falls back to `find_claude_pid()`. Once the daemon has been detached and reparented (e.g. under `systemd --user`), the upward process-tree walk in `find_claude_pid()` has no Claude ancestor and returns `None`. The prune still runs, but auto-resume is skipped:

```
WARNING: Could not find Claude PID. Pruned but not reloading.
Restart manually: claude --resume <id>
```

### Root cause

`start_guard()` resolves `claude_pid` once at startup (either from `--claude-pid` per #75, or via `find_claude_pid()` while the daemon is still attached) and keeps it in scope for the watchdog loop. But the calls into `guard_prune_cycle()` at the HARD1 and HARD2 reload sites omitted the `claude_pid=` kwarg, so the value was dropped and `guard_prune_cycle()` re-resolved from scratch from a context where the daemon has lost its Claude ancestor.

### Fix

Two-line patch in `src/cozempic/guard.py`: forward `claude_pid=claude_pid` at both reload-capable call sites. The `auto_reload=False` paths (HARD1 agents-active, SOFT) don't need it because they never reach `_terminate_and_resume()`.

### Relation to #75

#75 added the plumbing to receive `claude_pid` as a CLI arg. This PR threads the resolved value through to the reload trigger, where the gap actually manifests as a user-visible failure.

### Verification

Environment-sensitive: requires the daemon to lose its Claude ancestor. Most reliable on Linux with `systemd --user`. macOS, tmux-anchored shells, and short sessions where the parent shell is still alive may not reproduce because the upward walk still finds Claude.

To verify locally, run a session past the 55% threshold and confirm auto-resume fires instead of printing "Could not find Claude PID."

### Scope

Minimal. 2 insertions, 0 deletions. No tests added; the failure only manifests in the daemon-detached integration path, which the existing test suite doesn't exercise (fork+detach fixtures felt out of scope for a 2-line fix).
