### PR TITLE
fix(guard): reduce repeated team recovery context

### DIFF
--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -80,6 +80,23 @@ class TeamState:
             and not self.tasks
         )
 
+    def _task_groups(self) -> tuple[list[TaskInfo], int, int]:
+        """Split tasks into active work and low-value completed/blank noise."""
+        active: list[TaskInfo] = []
+        completed = 0
+        blank = 0
+        inactive_statuses = {"completed", "done", "cancelled", "canceled"}
+        for task in self.tasks:
+            subject = (task.subject or "").strip()
+            if not subject:
+                blank += 1
+                continue
+            if (task.status or "").strip().lower() in inactive_statuses:
+                completed += 1
+                continue
+            active.append(task)
+        return active, completed, blank
+
     def to_markdown(self) -> str:
         """Render team state as markdown for checkpoint file."""
         lines = []
@@ -116,14 +133,26 @@ class TeamState:
             lines.append("")
 
         if self.tasks:
-            lines.append("## Task List")
+            active_tasks, completed_count, blank_count = self._task_groups()
+            lines.append("## Active Task List")
             status_icons = {"completed": "x", "in_progress": "/", "pending": " "}
-            for t in self.tasks:
-                icon = status_icons.get(t.status, " ")
-                owner = f" @{t.owner}" if t.owner else ""
-                lines.append(f"- [{icon}] {t.subject}{owner}")
-                if t.description:
-                    lines.append(f"  {t.description[:200]}")
+            if active_tasks:
+                for t in active_tasks:
+                    icon = status_icons.get(t.status, " ")
+                    owner = f" @{t.owner}" if t.owner else ""
+                    lines.append(f"- [{icon}] {t.subject}{owner}")
+                    if t.description:
+                        lines.append(f"  {t.description[:200]}")
+            else:
+                lines.append("- No active tasks.")
+            omitted = completed_count + blank_count
+            if omitted:
+                detail = []
+                if completed_count:
+                    detail.append(f"{completed_count} completed")
+                if blank_count:
+                    detail.append(f"{blank_count} blank")
+                lines.append(f"_Omitted {', '.join(detail)} task(s) from recovery context._")
             lines.append("")
 
         if self.lead_summary:
@@ -159,10 +188,25 @@ class TeamState:
                     parts.append(f"    Result: {s.result_summary[:150]}")
 
         if self.tasks:
-            parts.append("\nShared task list:")
-            for t in self.tasks:
-                owner = f" (owner: {t.owner})" if t.owner else ""
-                parts.append(f"  - [{t.status.upper()}] {t.subject}{owner}")
+            active_tasks, completed_count, blank_count = self._task_groups()
+            if active_tasks:
+                parts.append("\nShared active tasks:")
+                shown_tasks = active_tasks[:10]
+                for t in shown_tasks:
+                    owner = f" (owner: {t.owner})" if t.owner else ""
+                    parts.append(f"  - [{t.status.upper()}] {t.subject}{owner}")
+                if len(active_tasks) > len(shown_tasks):
+                    parts.append(f"  - ... {len(active_tasks) - len(shown_tasks)} more active task(s) omitted")
+            else:
+                parts.append("\nShared task list: no active tasks.")
+            omitted = completed_count + blank_count
+            if omitted:
+                detail = []
+                if completed_count:
+                    detail.append(f"{completed_count} completed")
+                if blank_count:
+                    detail.append(f"{blank_count} blank")
+                parts.append(f"Completed/empty tasks omitted from recovery context: {', '.join(detail)}.")
 
         if self.lead_summary:
             parts.append(f"\nCoordination context: {self.lead_summary}")
@@ -699,7 +743,28 @@ def inject_team_recovery(messages: list[Message], state: TeamState) -> list[Mess
     user_uuid = str(uuid_mod.uuid4())
     assistant_uuid = str(uuid_mod.uuid4())
 
+    active_tasks, completed_tasks, blank_tasks = state._task_groups()
+    has_actionable_context = bool(
+        state.teammates
+        or state.subagents
+        or active_tasks
+        or state.lead_agent_id
+        or (state.team_name and state.team_name != "unnamed")
+    )
+    if not has_actionable_context:
+        return messages
+
     recovery_text = state.to_recovery_text()
+    for _, msg, _ in reversed(messages[-80:]):
+        inner = msg.get("message", {})
+        content = inner.get("content", "")
+        if (
+            isinstance(content, str)
+            and "[Cozempic Guard: context was pruned." in content
+            and recovery_text in content
+        ):
+            return messages
+
     checkpoint_note = (
         "A team state checkpoint was also written to .claude/team-checkpoint.md."
     )
@@ -713,11 +778,14 @@ def inject_team_recovery(messages: list[Message], state: TeamState) -> list[Mess
     if state.subagents:
         summary_bits.append(f"{len(state.subagents)} subagent(s)")
     if state.tasks:
-        pending = sum(1 for t in state.tasks if t.status.lower() == "pending")
-        in_progress = sum(1 for t in state.tasks if t.status.lower() == "in_progress")
-        task_bit = f"{len(state.tasks)} task(s)"
+        pending = sum(1 for t in active_tasks if t.status.lower() == "pending")
+        in_progress = sum(1 for t in active_tasks if t.status.lower() == "in_progress")
+        task_bit = f"{len(active_tasks)} active task(s)"
+        omitted = completed_tasks + blank_tasks
         if pending or in_progress:
             task_bit += f" ({pending} pending, {in_progress} in progress)"
+        if omitted:
+            task_bit += f", {omitted} omitted"
         summary_bits.append(task_bit)
     summary = ", ".join(summary_bits) if summary_bits else "state restored"
 

--- a/tests/test_team_schema.py
+++ b/tests/test_team_schema.py
@@ -6,10 +6,12 @@ import json
 import unittest
 
 from cozempic.team import (
+    TaskInfo,
     TeamState,
     _is_team_message,
     _is_task_tool_result,
     extract_team_state,
+    inject_team_recovery,
     merge_config_into_state,
 )
 
@@ -140,6 +142,57 @@ class TestMergeConfigStrongJoin(unittest.TestCase):
         state = self._state(team_name="Existing")
         result = merge_config_into_state(state, [])
         self.assertEqual(result.team_name, "Existing")
+
+
+class TestTeamRecoveryRendering(unittest.TestCase):
+
+    def _mixed_task_state(self):
+        return TeamState(tasks=[
+            TaskInfo("1", "Ship current fix", "pending"),
+            TaskInfo("2", "Review tests", "in_progress", owner="dev"),
+            TaskInfo("3", "Old completed task", "completed"),
+            TaskInfo("4", "", "completed"),
+        ])
+
+    def test_recovery_text_lists_active_tasks_and_summarizes_omitted(self):
+        text = self._mixed_task_state().to_recovery_text()
+
+        self.assertIn("Shared active tasks:", text)
+        self.assertIn("[PENDING] Ship current fix", text)
+        self.assertIn("[IN_PROGRESS] Review tests (owner: dev)", text)
+        self.assertIn("1 completed, 1 blank", text)
+        self.assertNotIn("Old completed task", text)
+
+    def test_checkpoint_markdown_lists_active_tasks_and_summarizes_omitted(self):
+        text = self._mixed_task_state().to_markdown()
+
+        self.assertIn("## Active Task List", text)
+        self.assertIn("- [ ] Ship current fix", text)
+        self.assertIn("- [/] Review tests @dev", text)
+        self.assertIn("1 completed, 1 blank", text)
+        self.assertNotIn("Old completed task", text)
+
+    def test_inject_team_recovery_skips_completed_only_tasks(self):
+        messages = [(0, {"uuid": "root", "message": {"role": "assistant", "content": []}}, 1)]
+        state = TeamState(tasks=[
+            TaskInfo("1", "Already finished", "completed"),
+            TaskInfo("2", "", "completed"),
+        ])
+
+        self.assertEqual(inject_team_recovery(messages, state), messages)
+
+    def test_inject_team_recovery_deduplicates_same_recovery_block(self):
+        messages = [(0, {"uuid": "root", "message": {"role": "assistant", "content": []}}, 1)]
+        state = TeamState(tasks=[
+            TaskInfo("1", "Ship current fix", "pending"),
+            TaskInfo("2", "Already finished", "completed"),
+        ])
+
+        once = inject_team_recovery(messages, state)
+        twice = inject_team_recovery(once, state)
+
+        self.assertEqual(len(once), 3)
+        self.assertEqual(len(twice), 3)
 
 
 class TestExtractTeamState(unittest.TestCase):


### PR DESCRIPTION
## Summary\n- render only active tasks in team recovery/checkpoint context\n- summarize completed and blank tasks instead of replaying them after prune/compact recovery\n- skip recovery injection when team state has no actionable context\n- avoid appending an identical Cozempic Guard recovery block repeatedly\n\n## Tests\n- PYTHONPATH=src python3 -m unittest tests.test_team_schema\n- PYTHONPATH=src python3 -m unittest tests.test_team_schema tests.test_post_compact tests.test_guard_hardening tests.test_guard_robustness\n- uv run --with pytest pytest tests/test_team_schema.py tests/test_post_compact.py tests/test_guard_hardening.py tests/test_guard_robustness.py