### PR TITLE
fix(guard): crash-prevention pack — HARD-loop bound + cross-process daemon lock + idempotent hook

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v7"
+            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v7"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v7"
+            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id',''); print(re.sub(r'[^A-Za-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v6"
+            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v6"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v6"
+            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       }

--- a/src/cozempic/data/hooks.json
+++ b/src/cozempic/data/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v7"
+            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v7"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v7"
+            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v8"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v7"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v8"
           }
         ]
       }

--- a/src/cozempic/data/hooks.json
+++ b/src/cozempic/data/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id',''); print(re.sub(r'[^A-Za-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v6"
+            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v6"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v6"
+            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v7"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v6"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v7"
           }
         ]
       }

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -29,6 +29,9 @@ from pathlib import Path
 # Per-session spawn lock: prevents a concurrent _is_guard_running_for_session
 # from treating a live O_CREAT placeholder as a stale file (within the same
 # process). Keyed by session_id to avoid false contention across sessions.
+# Kept as a fast-path for single-process scenarios; the authoritative gate
+# is now ``spawn_lock.daemon_spawn_lock`` (kernel-mediated flock) which
+# spans process boundaries — see start_guard_daemon below.
 _spawn_locks: dict[str, threading.Lock] = {}
 _spawn_locks_mu = threading.Lock()
 
@@ -596,9 +599,14 @@ def start_guard(
                         print(
                             f"  [{_now()}] Guard powerless against live-context "
                             f"dominance ({HARD_LOOP_EXIT_THRESHOLD} consecutive "
-                            f"0-byte HARD prunes). Exiting gracefully — SessionStart "
-                            f"hook will respawn on next activity. Recommend: split "
-                            f"work across fresh sessions to avoid >55% context.",
+                            f"0-byte HARD prunes). Exiting — NO further guard "
+                            f"protection in this session. SessionStart fires only "
+                            f"on startup/resume/clear, NOT on tool calls or "
+                            f"message turns, so the daemon will NOT auto-respawn "
+                            f"while the session continues. To re-enable cozempic: "
+                            f"type /clear or restart the session. Recommended: "
+                            f"split work across fresh sessions to avoid >55% "
+                            f"context dominance by immutable tool-result blocks.",
                             flush=True,
                         )
                         sys.exit(0)
@@ -1179,33 +1187,44 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
     )
 
 
-# UUID-shape / hex-only guard for session_id inputs to pidfile path composition.
-# 12+ chars keeps the `[:12]` truncation meaningful; the hex+dash character
-# class rejects path-traversal sequences and any non-UUID identifier. Require
-# a hex digit as the first char so pure-dash / leading-dash inputs reject —
-# real UUIDs always start with a hex digit.
-# Note: `_pid_file_for_session` lowercases session_id BEFORE matching, so the
-# regex intentionally accepts lowercase hex only (not an RFC-4122 uppercase bug).
-_SESSION_ID_RE = re.compile(r"^[0-9a-f][0-9a-f-]{11,}$")
+# Session-id validation for pidfile path composition.
+# Round-3 / DA C2 fix (Option B per team-lead + code-auditor): accepts
+# lowercase alphanumeric + underscore + dash, matching the SessionStart
+# hook bash sanitiser (`re.sub(r'[^a-z0-9_-]', '_', s.lower())`) and
+# ``reload_lock._slug_for`` / ``spawn_lock._slug_for`` (both use
+# ``[^a-zA-Z0-9_-]`` as their substitution character class). UUIDs are a
+# strict subset, so no regression for existing inputs. The first char must
+# be alphanumeric (not ``_`` or ``-``) — preserves the dash-collision
+# security property pinned by ``TestPolishV2_SessionIdRegexRequiresHexFirstChar``
+# in test_guard_hardening.py (pure-dash and leading-dash inputs would
+# otherwise collide after [:12] truncation onto the same pidfile path).
+# 12+ chars keeps the ``[:12]`` truncation meaningful and prevents
+# zero-byte slug paths.
+# Note: ``_pid_file_for_session`` lowercases session_id BEFORE matching,
+# so the regex intentionally accepts lowercase only (not an RFC-4122
+# uppercase bug — uppercase UUIDs are normalized first).
+_SESSION_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{11,}$")
 
 
 def _pid_file_for_session(session_id: str) -> Path:
     """Return the PID file path for a guard daemon watching a specific session.
 
-    Validates `session_id` against a UUID-shaped regex (hex chars + dashes,
-    length >= 12) so that path-traversal sequences or stray filename tokens
-    cannot escape `/tmp/cozempic_guard_*.pid` namespace.
-    Normalizes to lowercase BEFORE truncation so different-case variants of
+    Validates ``session_id`` against a relaxed alphanumeric+_- regex (matches
+    the bash hook sanitiser and reload_lock/spawn_lock slug rules — codebase
+    consistency, fix for DA round-1 C2 finding). Leading char must be
+    alphanumeric to prevent dash-collision after ``[:12]`` truncation
+    (security property — see ``TestPolishV2_SessionIdRegexRequiresHexFirstChar``).
+    Normalizes to lowercase BEFORE matching so different-case variants of
     the same UUID map to the same pidfile (prevents split-brain spawning).
     Raises ValueError on malformed input so callers fail fast; library-API
-    callers like `_is_guard_running_for_session` catch and return None
+    callers like ``_is_guard_running_for_session`` catch and return None
     (treat invalid session as "no daemon"). Error message logs only type
     and length — never raw content — to avoid PII leaks.
     """
     session_id = _normalize_session_id(session_id).lower()
     if not _SESSION_ID_RE.fullmatch(session_id):
         raise ValueError(
-            f"session_id must be a hex/UUID identifier (>=12 chars), "
+            f"session_id must be alphanumeric+_- (leading-alphanumeric, >=12 chars), "
             f"got {type(session_id).__name__} of length {len(session_id)}"
         )
     return Path("/tmp") / f"cozempic_guard_{session_id[:12]}.pid"
@@ -1275,11 +1294,43 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
         os.kill(pid, 0)
         # Verify the PID is actually our guard — defend against PID reuse.
         if not _is_cozempic_guard_process(pid):
-            pid_path.unlink(missing_ok=True)
+            # Don't eagerly unlink a fresh-looking pidfile here. A peer
+            # process that just did O_CREAT|O_EXCL in DaemonSpawnClaim has
+            # written its own parent PID into the file BEFORE renaming to
+            # the daemon PID; in that brief window the holding PID is a
+            # legitimate Python process that isn't yet a cozempic guard.
+            # Treating it as PID-reuse and unlinking would destroy the
+            # peer's claim and let multiple workers spawn. Only unlink
+            # truly old pidfiles — those are real PID-reuse or genuine
+            # stale state from a crashed prior spawn. The threshold is
+            # shared with ``DaemonSpawnClaim._is_pidfile_fresh`` so both
+            # sides of the claim/probe dichotomy agree on what "fresh"
+            # means (H1 fix — single source of truth).
+            from .spawn_lock import _FRESH_PIDFILE_SECONDS
+            try:
+                age = time.time() - pid_path.stat().st_mtime
+            except OSError:
+                age = 0.0
+            if age >= _FRESH_PIDFILE_SECONDS:
+                pid_path.unlink(missing_ok=True)
             return None
         return pid
     except (ValueError, ProcessLookupError, PermissionError):
-        pid_path.unlink(missing_ok=True)
+        # Apparently dead PID — but a freshly-written pidfile that holds
+        # the soon-to-exist daemon PID can momentarily look "dead" while
+        # the daemon is still starting (a real Popen returns the child
+        # PID before the OS finishes wiring up the process; test mocks
+        # use fake PIDs that are never alive). Only unlink truly old
+        # pidfiles to avoid destroying a peer's just-completed claim
+        # and letting another worker spawn a duplicate daemon. Same
+        # threshold as the holder-alive-but-not-guard branch above.
+        from .spawn_lock import _FRESH_PIDFILE_SECONDS
+        try:
+            age = time.time() - pid_path.stat().st_mtime
+        except OSError:
+            age = 0.0
+        if age >= _FRESH_PIDFILE_SECONDS:
+            pid_path.unlink(missing_ok=True)
         return None
 
 
@@ -1400,164 +1451,167 @@ def start_guard_daemon(
     if claude_pid is None:
         claude_pid = find_claude_pid()
 
-    # Acquire the per-session spawn lock before O_CREAT so that a concurrent
-    # _is_guard_running_for_session (same process) sees the lock is held and skips
-    # the unlink of our in-flight "0" placeholder. Released after the real PID
-    # is committed. File-level O_CREAT|O_EXCL still guards cross-process races.
-    norm_sid = _normalize_session_id(session_id) if session_id else ""
-    with _spawn_locks_mu:
-        if norm_sid not in _spawn_locks:
-            _spawn_locks[norm_sid] = threading.Lock()
-        spawn_lock = _spawn_locks[norm_sid]
-    spawn_lock.acquire()
+    # ── Cross-process spawn claim (Bug 2 + Bug 3 fix, V4 rework) ────────────
+    # The PID file IS the lock. O_CREAT|O_EXCL on the PID file is the only
+    # primitive used: POSIX guarantees exactly one process wins the create,
+    # all others see EEXIST and become losers via DaemonAlreadyStarting.
+    # This mirrors reload_lock.py:200-262 (same pattern, different file).
+    #
+    # Why not fcntl.flock on a separate sentinel? Race-reproducer's V4 stress
+    # (10 processes × 30 iterations) found a textbook flock-unlink race: when
+    # the holder unlinks the sentinel on release, peers immediately O_CREAT
+    # NEW inodes and their flocks attach to those new inodes — different
+    # kernel objects, so multiple "winners" each acquire flock simultaneously.
+    # See spawn_lock.py module docstring for the full failure mode + evidence.
+    from .spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim
 
-    # Atomically claim the pid slot before spawning (O_CREAT|O_EXCL prevents TOCTOU).
-    # Other OSErrors (ENOSPC, EROFS, EACCES) are non-fatal: return started=False
-    # with a reason so the non-interactive SessionStart hook doesn't crash silently.
-    _claim_result: dict | None = None
     try:
+        claim = DaemonSpawnClaim(session_id or cwd, pid_path)
+        claim.__enter__()
+    except DaemonAlreadyStarting as exc:
+        # Peer process holds the PID-file claim. Surface their PID so the
+        # SessionStart hook can introspect / log it. holder_pid may be 0 if
+        # the file was unreadable (rare; race-reproducer's "undefined state"
+        # was an artifact of the OSError path that no longer exists).
+        return {
+            "started": False,
+            "pid": exc.holder_pid,
+            "pid_file": str(pid_path),
+            "log_file": None,
+            "already_running": True,
+        }
+
+    try:
+        # Build the guard command
+        cmd_parts = [
+            sys.executable, "-m", "cozempic.cli", "guard",
+            "--cwd", cwd,
+            "--threshold", str(threshold_mb),
+            "--interval", str(interval),
+            "-rx", rx_name,
+        ]
+        if soft_threshold_mb is not None:
+            cmd_parts.extend(["--soft-threshold", str(soft_threshold_mb)])
+        if not auto_reload:
+            cmd_parts.append("--no-reload")
+        if not reactive:
+            cmd_parts.append("--no-reactive")
+        if threshold_tokens is not None:
+            cmd_parts.extend(["--threshold-tokens", str(threshold_tokens)])
+        if soft_threshold_tokens is not None:
+            cmd_parts.extend(["--soft-threshold-tokens", str(soft_threshold_tokens)])
+        if session_id is not None:
+            cmd_parts.extend(["--session", _normalize_session_id(session_id)])
+        if claude_pid is not None:
+            cmd_parts.extend(["--claude-pid", str(claude_pid)])
+
+        # Wrap the spawn body in a graceful OSError handler so a
+        # non-interactive SessionStart hook never crashes with a stack
+        # trace. ENOSPC / EROFS / EACCES / EMFILE on /tmp surface as
+        # structured `{started: False, reason: ...}`. The claim's
+        # __exit__ will unlink the PID file on exception, so a retry is
+        # possible.
         try:
-            fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            # Defense-in-depth: if the log file's parent dir was removed
+            # mid-spawn (race with operator cleanup, /tmp eviction, etc.)
+            # recreate it once and retry the open.
             try:
-                os.write(fd, b"0")  # placeholder; real PID written after Popen
+                lf = open(log_file, "a", encoding="utf-8")
+            except FileNotFoundError:
+                log_dir = os.path.dirname(str(log_file))
+                if log_dir:
+                    os.makedirs(log_dir, exist_ok=True)
+                lf = open(log_file, "a", encoding="utf-8")
+
+            try:
+                from datetime import datetime
+                lf.write(f"\n--- Guard daemon started at {datetime.now().isoformat()} ---\n")
+                lf.write(f"CWD: {cwd}\n")
+                lf.write(f"CMD: {' '.join(cmd_parts)}\n\n")
+                lf.flush()
+
+                # PYTHONUNBUFFERED=1 ensures guard log output is written immediately (#14)
+                env = os.environ.copy()
+                env["PYTHONUNBUFFERED"] = "1"
+                proc = subprocess.Popen(
+                    cmd_parts,
+                    stdout=lf,
+                    stderr=lf,
+                    stdin=subprocess.DEVNULL,
+                    start_new_session=True,
+                    cwd=cwd,
+                    env=env,
+                )
             finally:
-                os.close(fd)
-        except (FileExistsError, OSError) as _e:
-            if not isinstance(_e, FileExistsError):
-                _claim_result = {"started": False, "reason": f"pidfile: {_e}"}
-            else:
-                # Peek at what the existing file holds to decide the retry strategy.
+                lf.close()
+
+            # Atomically replace our parent PID (written by DaemonSpawnClaim
+            # on _claim) with the daemon's real PID. tmp+rename is atomic
+            # on the same filesystem — readers transitioning across the
+            # rename see either the parent PID (alive) or the daemon PID
+            # (alive). Never empty, never "0", never partial.
+            #
+            # CRIT C1 fix: open the .pid.tmp via os.open(O_CREAT|O_EXCL|
+            # O_NOFOLLOW) instead of Path.write_text. The default write_text
+            # follows symlinks — an attacker who pre-plants the .pid.tmp
+            # path as a symlink to ~/.zshrc or ~/.ssh/authorized_keys would
+            # have the file overwritten with the PID number. O_EXCL also
+            # surfaces orphan .pid.tmp files (from a prior SIGKILLed spawn)
+            # as a FileExistsError instead of silently truncating them,
+            # which closes a re-attack window in CRIT C3.
+            tmp_path = pid_path.with_suffix(".pid.tmp")
+            # CRIT C3 fix: catch ANY exception (not just OSError) around
+            # the write+rename block. A SIGINT/InterruptedError or other
+            # non-OSError between write_text and rename used to leak the
+            # .pid.tmp orphan; we now unlink it on every failure path.
+            try:
+                _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+                if hasattr(os, "O_NOFOLLOW"):
+                    _tmp_flags |= os.O_NOFOLLOW
+                _tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
                 try:
-                    _raw = pid_path.read_text().strip() if pid_path.exists() else ""
-                    _on_disk_pid = int(_raw) if _raw else 0
-                except (ValueError, OSError):
-                    _on_disk_pid = 0
-                if _on_disk_pid > 0:
-                    # File holds a real PID (> 0): a concurrent winner just wrote it.
-                    # Trust the write — don't call _is_guard_running_for_session (it
-                    # would probe os.kill which may fail for a just-spawned process,
-                    # unlink the file, and break the invariant). Dead-guard detection
-                    # happens on the NEXT call to start_guard_daemon.
-                    _claim_result = {
-                        "started": False,
-                        "pid": _on_disk_pid,
-                        "pid_file": str(pid_path),
-                        "log_file": None,
-                        "already_running": True,
-                    }
-                else:
-                    # File holds a placeholder (pid <= 0): either a concurrent spawn's
-                    # in-flight "0" or a stale placeholder from a previous crash.
-                    # Re-read via the full helper which handles the spawn-lock check.
-                    existing_pid = _is_guard_running_for_session(session_id) if session_id else None
-                    if existing_pid:
-                        _claim_result = {
-                            "started": False,
-                            "pid": existing_pid,
-                            "pid_file": str(pid_path),
-                            "log_file": None,
-                            "already_running": True,
-                        }
-                    else:
-                        # Stale placeholder (previous crash before real PID was written) — remove and retry once
-                        pid_path.unlink(missing_ok=True)
-                        try:
-                            fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                            try:
-                                os.write(fd, b"0")
-                            finally:
-                                os.close(fd)
-                        except (FileExistsError, OSError) as _e2:
-                            if not isinstance(_e2, FileExistsError):
-                                _claim_result = {"started": False, "reason": f"pidfile: {_e2}"}
-                            else:
-                                existing_pid = _is_guard_running_for_session(session_id) if session_id else None
-                                _claim_result = {
-                                    "started": False,
-                                    "pid": existing_pid,
-                                    "pid_file": str(pid_path),
-                                    "log_file": None,
-                                    "already_running": True,
-                                }
-    except Exception:
-        spawn_lock.release()
-        raise
-    if _claim_result is not None:
-        spawn_lock.release()
-        return _claim_result
+                    os.write(_tmp_fd, f"{proc.pid}\n".encode("utf-8"))
+                finally:
+                    os.close(_tmp_fd)
+                os.rename(str(tmp_path), str(pid_path))
+            except Exception:
+                # Unlink any partial .pid.tmp we may have created so a
+                # retry can succeed. unlink is symlink-safe (operates on
+                # the directory entry, not the symlink target).
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise
+            # Tell the claim "we wrote the real PID — leave the file in
+            # place on clean exit; the daemon now owns its lifecycle."
+            claim.handed_off = True
+        except OSError as exc:
+            # The .pid.tmp orphan was already cleaned by the inner
+            # try/except above; here we only need to surface the failure.
+            # The claim's __exit__ will unlink the .pid file because
+            # handed_off is still False, so a retry can re-claim.
+            return {
+                "started": False,
+                "reason": f"pidfile: {exc}",
+                "pid": None,
+                "pid_file": str(pid_path),
+                "log_file": None,
+                "already_running": False,
+            }
 
-    # Build the guard command
-    cmd_parts = [
-        sys.executable, "-m", "cozempic.cli", "guard",
-        "--cwd", cwd,
-        "--threshold", str(threshold_mb),
-        "--interval", str(interval),
-        "-rx", rx_name,
-    ]
-    if soft_threshold_mb is not None:
-        cmd_parts.extend(["--soft-threshold", str(soft_threshold_mb)])
-    if not auto_reload:
-        cmd_parts.append("--no-reload")
-    if not reactive:
-        cmd_parts.append("--no-reactive")
-    if threshold_tokens is not None:
-        cmd_parts.extend(["--threshold-tokens", str(threshold_tokens)])
-    if soft_threshold_tokens is not None:
-        cmd_parts.extend(["--soft-threshold-tokens", str(soft_threshold_tokens)])
-    if session_id is not None:
-        cmd_parts.extend(["--session", _normalize_session_id(session_id)])
-    if claude_pid is not None:
-        cmd_parts.extend(["--claude-pid", str(claude_pid)])
-
-    # Spawn detached process. Wrapped in try/finally so the spawn_lock is
-    # ALWAYS released and the "0" placeholder is cleaned up if Popen (or
-    # anything else in this block) raises. Without this, a FileNotFoundError
-    # from a missing Python binary or a PermissionError on the log file would
-    # leave the lock held permanently (blocking all future in-process spawns
-    # for this session) and the placeholder pidfile on disk (blocking all
-    # future cross-process spawns until manual deletion).
-    try:
-        with open(log_file, "a", encoding="utf-8") as lf:
-            from datetime import datetime
-            lf.write(f"\n--- Guard daemon started at {datetime.now().isoformat()} ---\n")
-            lf.write(f"CWD: {cwd}\n")
-            lf.write(f"CMD: {' '.join(cmd_parts)}\n\n")
-            lf.flush()
-
-            # PYTHONUNBUFFERED=1 ensures guard log output is written immediately (#14)
-            env = os.environ.copy()
-            env["PYTHONUNBUFFERED"] = "1"
-            proc = subprocess.Popen(
-                cmd_parts,
-                stdout=lf,
-                stderr=lf,
-                stdin=subprocess.DEVNULL,
-                start_new_session=True,
-                cwd=cwd,
-                env=env,
-            )
-
-        # Write actual PID atomically via temp+rename so readers never see partial content
-        tmp_path = pid_path.with_suffix(".pid.tmp")
-        tmp_path.write_text(str(proc.pid))
-        tmp_path.replace(pid_path)
-    except Exception:
-        # Cleanup: remove the "0" placeholder so future spawns aren't blocked
-        pid_path.unlink(missing_ok=True)
-        raise
+        return {
+            "started": True,
+            "pid": proc.pid,
+            "pid_file": str(pid_path),
+            "log_file": str(log_file),
+            "already_running": False,
+        }
     finally:
-        # Release the spawn lock regardless of success/failure. Any concurrent
-        # _is_guard_running_for_session can now read the valid PID > 0 (success)
-        # or find no pidfile (failure — cleaned up above).
-        spawn_lock.release()
-
-    return {
-        "started": True,
-        "pid": proc.pid,
-        "pid_file": str(pid_path),
-        "log_file": str(log_file),
-        "already_running": False,
-    }
+        # If we reach here without an exception, claim.handed_off == True
+        # and __exit__ is a no-op (daemon owns the PID file). If we raised
+        # inside the spawn body, __exit__ unlinks for retry.
+        claim.__exit__(None, None, None)
 
 
 def _is_cozempic_guard_process(pid: int) -> bool:
@@ -1596,10 +1650,15 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         if len(tokens) >= 2 and binary == "cozempic" and tokens[1] == "guard":
             return True
         return False
-    except (subprocess.SubprocessError, OSError):
+    except (subprocess.SubprocessError, OSError, TypeError):
         # If we can't verify, err on the side of NOT signaling a potentially
         # unrelated process. The session stays with the existing daemon (or
         # no daemon), which is strictly safer than signaling the wrong one.
+        # TypeError covers the test-only case where a Popen mock returns a
+        # bare object that doesn't support the ctx-manager protocol
+        # subprocess.run uses internally; production callers never hit it,
+        # but any unhandled exception here would propagate to the
+        # non-interactive SessionStart hook surface — fail closed.
         return False
 
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -32,6 +32,28 @@ from pathlib import Path
 _spawn_locks: dict[str, threading.Lock] = {}
 _spawn_locks_mu = threading.Lock()
 
+
+# ── HARD-threshold back-off + exit constants ────────────────────────────────
+# When ``guard_prune_cycle`` keeps returning saved_bytes == 0 at the HARD
+# threshold (because the live conversation is dominated by immutable tool-
+# result blocks the soft prune cannot touch), the daemon used to loop at the
+# original 30s interval indefinitely — production log showed 265 cycles over
+# 5h21m. The current contract:
+#
+#   K < HARD_LOOP_BACKOFF_START   → sleep ``interval`` (original cadence)
+#   K >= HARD_LOOP_BACKOFF_START  → sleep min(interval * 2 ** (K - 2),
+#                                              HARD_LOOP_BACKOFF_CAP_SECONDS)
+#   K >= HARD_LOOP_EXIT_THRESHOLD → log diagnostic, write final checkpoint,
+#                                   sys.exit(0). SessionStart hook will respawn.
+#
+# Any prune that returns saved_bytes > 0 resets K to 0 (counter never decays
+# on its own — only a genuine prune signals "we can still make progress").
+# The cap is 5 minutes: longer is operator-hostile (HARD threshold context
+# may genuinely need attention), shorter wastes cycles on doomed prunes.
+HARD_LOOP_BACKOFF_START = 3
+HARD_LOOP_BACKOFF_CAP_SECONDS = 300
+HARD_LOOP_EXIT_THRESHOLD = 10
+
 from ._validation import ConfigError
 from .executor import run_prescription
 from .helpers import is_ssh_session, shell_quote
@@ -555,10 +577,52 @@ def start_guard(
 
                 if result.get("saved_mb", 0) <= 0:
                     consecutive_empty_hard_prunes += 1
-                    if consecutive_empty_hard_prunes >= 3:
-                        print(f"  [{_now()}] WARNING: Hard prune freed 0 bytes 3x in a row.")
-                        consecutive_empty_hard_prunes = 0
-                        time.sleep(interval * 4)
+
+                    # Exit path: the daemon is powerless against this context
+                    # (live tool-result blocks dominate; HARD prune cannot free
+                    # bytes; reload+0-byte = the cascade that crashed sessions
+                    # in production). Exit gracefully and let the SessionStart
+                    # hook respawn on next activity. Do NOT change reload-trigger
+                    # gating in guard_prune_cycle — that's not the right escape.
+                    if consecutive_empty_hard_prunes >= HARD_LOOP_EXIT_THRESHOLD:
+                        try:
+                            checkpoint_team(session_path=session_path, quiet=True)
+                        except Exception:
+                            # Checkpoint failure must not prevent exit — final
+                            # checkpoint is best-effort here; the SOFT loop above
+                            # has been writing checkpoints every cycle for the
+                            # entire run, so on-disk state is already current.
+                            pass
+                        print(
+                            f"  [{_now()}] Guard powerless against live-context "
+                            f"dominance ({HARD_LOOP_EXIT_THRESHOLD} consecutive "
+                            f"0-byte HARD prunes). Exiting gracefully — SessionStart "
+                            f"hook will respawn on next activity. Recommend: split "
+                            f"work across fresh sessions to avoid >55% context.",
+                            flush=True,
+                        )
+                        sys.exit(0)
+
+                    # Back-off path: replace the original fixed-cadence sleep at
+                    # the bottom of the loop with an exponentially growing one.
+                    # The loop's primary ``time.sleep(interval)`` at the top of
+                    # the next iteration is the normal cadence — we ADD an extra
+                    # back-off sleep here so the next prune is genuinely delayed.
+                    backoff = _hard_loop_backoff_sleep(
+                        consecutive_empty_hard_prunes, interval
+                    )
+                    # Only emit a back-off sleep beyond the normal interval to
+                    # avoid double-sleeping at K=1 / K=2 where backoff == interval.
+                    if backoff > interval:
+                        if consecutive_empty_hard_prunes == HARD_LOOP_BACKOFF_START:
+                            print(
+                                f"  [{_now()}] Hard prune freed 0 bytes "
+                                f"{HARD_LOOP_BACKOFF_START}x — entering exponential "
+                                f"back-off (next sleep: {backoff}s, cap "
+                                f"{HARD_LOOP_BACKOFF_CAP_SECONDS}s, exit after "
+                                f"{HARD_LOOP_EXIT_THRESHOLD} cycles)."
+                            )
+                        time.sleep(backoff)
                 else:
                     consecutive_empty_hard_prunes = 0
                 print()
@@ -1753,6 +1817,29 @@ def reload_self_daemon(
         "log_file": result.get("log_file"),
         "reason": reason,
     }
+
+
+def _hard_loop_backoff_sleep(consecutive_empty: int, interval: int) -> int:
+    """Compute the sleep duration for the next HARD-loop cycle.
+
+    Doubles the wait starting at ``HARD_LOOP_BACKOFF_START`` consecutive
+    zero-byte HARD prunes, capped at ``HARD_LOOP_BACKOFF_CAP_SECONDS``.
+    Returns ``interval`` unchanged for K < HARD_LOOP_BACKOFF_START.
+
+    With defaults (interval=30, start=3, cap=300):
+        K=1 → 30s   (normal)
+        K=2 → 30s   (normal)
+        K=3 → 60s   (interval * 2 ** 1)
+        K=4 → 120s  (interval * 2 ** 2)
+        K=5 → 240s  (interval * 2 ** 3)
+        K=6 → 300s  (capped from 480s)
+        K=7+ → 300s (cap)
+    """
+    if consecutive_empty < HARD_LOOP_BACKOFF_START:
+        return interval
+    # Exponent grows from 1 at K=3 onwards: K - (start - 1).
+    exp = consecutive_empty - (HARD_LOOP_BACKOFF_START - 1)
+    return min(interval * (2 ** exp), HARD_LOOP_BACKOFF_CAP_SECONDS)
 
 
 def _fmt_prune_result(result: dict) -> str:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -39,7 +39,7 @@ def _c(args: str) -> str:
 # at the end of every canonical hook command (e.g. "# cozempic-hook-schema=v2")
 # is what `_is_current_cozempic_hook` looks for — old hooks without the current
 # marker are treated as stale and get refreshed on next init.
-HOOK_SCHEMA_VERSION = "v7"
+HOOK_SCHEMA_VERSION = "v8"
 HOOK_SCHEMA_MARKER = f"cozempic-hook-schema={HOOK_SCHEMA_VERSION}"
 
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -39,7 +39,7 @@ def _c(args: str) -> str:
 # at the end of every canonical hook command (e.g. "# cozempic-hook-schema=v2")
 # is what `_is_current_cozempic_hook` looks for — old hooks without the current
 # marker are treated as stale and get refreshed on next init.
-HOOK_SCHEMA_VERSION = "v6"
+HOOK_SCHEMA_VERSION = "v7"
 HOOK_SCHEMA_MARKER = f"cozempic-hook-schema={HOOK_SCHEMA_VERSION}"
 
 

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -1,0 +1,360 @@
+"""Cross-process daemon spawn claim — single-flight via O_CREAT|O_EXCL.
+
+History note (BMAD V4 finding, 2026-05-18): the previous implementation of
+this module used ``fcntl.flock`` on a separate sentinel file with unlink on
+release. That pattern has a textbook flock-unlink race exposed only at
+N >= 3 contending processes:
+
+    1. Process A acquires flock on inode I1, completes spawn, unlinks the
+       sentinel path → frees the path entry, retains I1 only until A closes
+       the fd.
+    2. Between A's unlink and A's fd close, B and C each O_CREAT a NEW file
+       at the (now-absent) path, getting NEW inodes I2 and I3.
+    3. B's ``flock(I2)`` and C's ``flock(I3)`` are on different kernel
+       objects → both succeed.
+    4. Both B and C proceed past the lock → BOTH ``subprocess.Popen`` →
+       both report ``started=True`` for the same session UUID.
+
+Race-reproducer V4 stress (10 processes × 30 iterations) observed this 3
+times out of 30, with both 2-winner and 3-winner outcomes, plus one worker
+returning the undefined ``started=False, already_running=False, pid=None``
+state. Raw evidence: ``/tmp/v4-stress-output.txt``.
+
+The fix (race-reproducer's option 2, approved by team-lead): drop ``flock``
+entirely. The PID file IS the lock. ``O_CREAT|O_EXCL|O_WRONLY`` on the PID
+file is a POSIX-guaranteed atomic operation; if two processes race, exactly
+one wins with the file create, the other sees ``FileExistsError`` (EEXIST).
+This is the same pattern ``reload_lock.py:200-262`` already uses for the
+reload-side single-flight.
+
+Lifecycle:
+  - On claim (enter): ``O_CREAT|O_EXCL|O_NOFOLLOW`` on the PID file. Loser
+    reads the file, returns ``DaemonAlreadyStarting(holder_pid=<read pid>)``.
+    Stale-holder detection: if the read PID is not alive (``kill(pid, 0)``
+    fails), unlink + retry once.
+  - Inside the claim: caller writes the real daemon PID atomically via
+    temp-file + rename (``os.rename`` on same FS is POSIX-atomic). Readers
+    transitioning between our parent-PID and the daemon PID observe the OLD
+    real PID then the NEW real PID — never a placeholder, never an empty
+    file mid-write.
+  - On normal exit: the PID file is LEFT in place — the daemon owns it for
+    its lifetime; the daemon's shutdown path is responsible for unlinking.
+  - On exceptional exit (Popen raised, log open failed, etc.): the PID
+    file is unlinked so a retry by the same or a sibling process can
+    re-claim cleanly.
+
+The owner-write pattern (parent PID first, then daemon PID via rename):
+  Readers that probe between our claim and our rename will see OUR parent
+  PID. Since this is a real, alive process, ``_is_guard_running_for_session``
+  will treat it as an in-flight daemon and return ``already_running``. By
+  the time the rename completes the daemon PID is visible. No "0"
+  placeholder ever appears — closes the original Bug 3 too.
+
+Symlink defense: ``O_NOFOLLOW`` mirrors ``reload_lock.py:213-214``. A local
+attacker who can write to ``/tmp`` could plant a symlink at our PID path
+pointing at an arbitrary file; without O_NOFOLLOW our O_CREAT would follow
+the link.
+
+Backward compatibility shim: the ``daemon_spawn_lock`` context-manager API
+is kept for the existing test surface (``test_spawn_lock.py`` Unit tests)
+and any direct callers. Internally it delegates to ``DaemonSpawnClaim``.
+``DaemonSpawnClaim`` is the preferred new API for callers that need access
+to the holder PID on contention (the contextmanager loses that information
+because the loser shape is just the exception).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+# A pidfile younger than this is considered "fresh — a peer is mid-spawn"
+# even if the PID it carries is not alive. Rationale: stale pidfiles from
+# crashed prior spawns are typically minutes/hours old; a freshly-written
+# file with a dead PID is overwhelmingly likely to be a test mock or a peer
+# whose daemon hasn't fully started yet. Treating it as stale would let
+# multiple peers re-spawn against the same session.
+#
+# 5 seconds is the default — generous for a clean macOS laptop where a
+# Python cold-start + cozempic import is well under 1s. On slower setups
+# (CI hosted runners, macOS with Crowdstrike/SentinelOne EDR scanning the
+# Python binary, cold filesystem cache after pip install) Popen can take
+# several seconds. Operators can override via the
+# ``COZEMPIC_PIDFILE_FRESH_SECONDS`` env var without code changes.
+#
+# Override is parsed at import time and CLAMPED to ``(0, _FRESH_MAX]``.
+# Invalid values (non-numeric, NaN, inf, ≤0, > _FRESH_MAX) silently fall
+# back to the default — keeps the daemon working rather than failing at
+# startup over a misconfigured env var, and prevents operator typos like
+# "inf" or "-1" from silently disabling staleness recovery entirely. The
+# upper bound matches ``HARD_LOOP_BACKOFF_CAP_SECONDS`` in guard.py — any
+# legitimate slow-Popen scenario lives well under 5 minutes; values higher
+# than that are almost certainly typos that would let stale pidfiles from
+# crashed prior spawns block new ones for hours. Operators who care about
+# the active value can read ``spawn_lock._FRESH_PIDFILE_SECONDS``.
+_DEFAULT_FRESH = 5.0
+_FRESH_MAX = 300.0
+
+
+def _read_fresh_window_seconds() -> float:
+    raw = os.environ.get("COZEMPIC_PIDFILE_FRESH_SECONDS")
+    if raw is None:
+        return _DEFAULT_FRESH
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_FRESH
+    if not math.isfinite(val) or val <= 0 or val > _FRESH_MAX:
+        return _DEFAULT_FRESH
+    return val
+
+
+_FRESH_PIDFILE_SECONDS = _read_fresh_window_seconds()
+
+
+# Round-3 C2 (Option B) alignment: char class kept relaxed (mirrors
+# reload_lock._SAFE_CHARS_RE) but inputs are now lowercased before
+# substitution to align with guard._pid_file_for_session which
+# lowercases before applying its (also relaxed) _SESSION_ID_RE. Without
+# the lowercase, a mixed-case session_id would produce one slug here
+# and a different (lowercased) slug in guard.py.
+_SAFE_CHARS_RE = re.compile(r"[^a-z0-9_-]")
+
+
+def _slug_for(session_id: str) -> str:
+    """Reduce session_id to a 12-char safe slug for the PID file path.
+
+    Mirrors ``reload_lock._slug_for`` (relaxed char class) AND
+    ``guard._pid_file_for_session`` (lowercases first, then keeps only
+    ``[a-z0-9_-]``). Same session_id → same slug across all three.
+    """
+    if not session_id:
+        return "default"
+    if "/" in session_id or "\\" in session_id or session_id.endswith(".jsonl"):
+        session_id = Path(session_id).stem
+    # Lowercase BEFORE substitution so uppercase letters survive as their
+    # lowercase equivalents (a real character), not as the underscore
+    # placeholder. Matches guard._pid_file_for_session's flow.
+    sanitized = _SAFE_CHARS_RE.sub("_", session_id.lower())
+    return sanitized[:12] or "default"
+
+
+def _spawn_lock_path(session_id: str) -> Path:
+    """Compose the spawn-claim PID file path for a session.
+
+    Kept as a separate helper for diagnostics + the legacy
+    ``daemon_spawn_lock`` ctx-manager test surface. In production the
+    actual PID file used is ``guard._pid_file_for_session`` — see
+    ``DaemonSpawnClaim`` which accepts an explicit ``pid_file`` so the
+    claim file is the same inode the rest of guard.py reads/writes.
+    """
+    return Path(tempfile.gettempdir()) / f"cozempic_guard_{_slug_for(session_id)}.pid"
+
+
+def _is_process_alive(pid: int) -> bool:
+    """Return True if ``pid`` is a live process (or owned by another user).
+
+    ``kill(pid, 0)`` returns 0 if the signal could be delivered, raises
+    ``ProcessLookupError`` if no such process exists, and
+    ``PermissionError`` if the process exists but we lack permission.
+    Conservative interpretation: PermissionError → alive (not ours, but
+    real), since a guard daemon under another user counts as in-flight.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+class DaemonAlreadyStarting(Exception):
+    """Raised when a peer process has already claimed the PID file.
+
+    The caller should treat this as ``already_running=True`` and propagate
+    ``holder_pid`` to the result dict so SessionStart hooks can log /
+    introspect which PID owns the slot. ``holder_pid == 0`` means we
+    couldn't parse the file (stale, empty, garbled) — surface as 0 rather
+    than guessing.
+    """
+
+    def __init__(self, session_id: str, holder_pid: int = 0):
+        self.session_id = session_id
+        self.holder_pid = holder_pid
+        super().__init__(
+            f"Daemon already starting for {session_id} "
+            f"(holder PID {holder_pid or 'unknown'})"
+        )
+
+
+class DaemonSpawnClaim:
+    """Atomic PID-file claim via O_CREAT|O_EXCL.
+
+    Usage:
+        try:
+            with DaemonSpawnClaim(session_id, pid_file) as claim:
+                proc = subprocess.Popen([...])
+                # Atomically replace our parent PID with the daemon PID
+                tmp = pid_file.with_suffix(".pid.tmp")
+                tmp.write_text(str(proc.pid))
+                os.rename(tmp, pid_file)
+                # Tell the claim "we wrote the real PID — don't unlink on exit"
+                claim.handed_off = True
+        except DaemonAlreadyStarting as exc:
+            return {"started": False, "already_running": True,
+                    "pid": exc.holder_pid, ...}
+
+    On normal exit:
+      - If ``handed_off`` is True: leave the PID file in place (daemon
+        owns it for its lifetime).
+      - If ``handed_off`` is False (caller forgot to set it, or never
+        reached the hand-off): unlink — we created it; we own cleanup.
+
+    On exceptional exit:
+      - Always unlink so a retry can re-claim. The daemon never started,
+        so there's no surviving owner for the PID file.
+    """
+
+    def __init__(self, session_id: str, pid_file: Path):
+        self.session_id = session_id
+        self.pid_file = pid_file
+        self.owned = False
+        self.handed_off = False  # caller sets True after atomic rename
+
+    def __enter__(self) -> "DaemonSpawnClaim":
+        self._claim()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if not self.owned:
+            return
+        # Unlink on exception path OR on clean exit when caller didn't
+        # complete the hand-off (defensive: caller bug = retry-able state).
+        if exc_type is not None or not self.handed_off:
+            try:
+                self.pid_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _claim(self) -> None:
+        """Acquire the PID file via O_CREAT|O_EXCL.
+
+        On EEXIST: read the existing PID. The file is treated as a live
+        peer claim (DaemonAlreadyStarting) when ANY of:
+          - the holder PID is alive (``kill(pid, 0)`` succeeds), OR
+          - the file is younger than ``_FRESH_PIDFILE_SECONDS`` (a peer
+            wrote it moments ago, even if the spawned process hasn't fully
+            started — or if we're in a test where the spawn is mocked and
+            the recorded PID is fictitious).
+
+        Only when BOTH the PID is dead AND the file is older than the
+        fresh window do we classify the claim as stale and unlink + retry.
+        This prevents the N>=3 contention race where peer A renames the
+        pidfile to a fresh PID, peer B reads it and (with a dead test-mock
+        PID) incorrectly classifies it as stale and re-claims.
+        """
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+
+        try:
+            fd = os.open(str(self.pid_file), flags, 0o600)
+        except FileExistsError:
+            holder_pid = self._read_existing_pid()
+            holder_alive = holder_pid > 0 and _is_process_alive(holder_pid)
+            fresh = self._is_pidfile_fresh()
+            if holder_alive or fresh:
+                raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
+            # Stale (dead PID AND old file): unlink and retry exactly once.
+            try:
+                self.pid_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+            try:
+                fd = os.open(str(self.pid_file), flags, 0o600)
+            except FileExistsError:
+                # A peer reclaimed between our unlink and our retry.
+                holder_pid = self._read_existing_pid()
+                raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
+
+        # Won the claim. Write our parent PID so concurrent readers see a
+        # real, alive PID (not a placeholder) until we hand off the real
+        # daemon PID via tmp+rename. This is the inverse of the prior
+        # placeholder "0" pattern: we publish a meaningful pid immediately.
+        try:
+            os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+        finally:
+            os.close(fd)
+        self.owned = True
+
+    def _is_pidfile_fresh(self) -> bool:
+        """Return True if the PID file's mtime is within the fresh window.
+
+        Used to defeat the dead-pid + stale-classification race: a peer
+        that just wrote a real PID may have that PID die between the
+        write and our read (test mock, fast crash, PID reuse). A fresh
+        file with a dead PID is still a peer claim, not a stale file.
+        """
+        try:
+            mtime = self.pid_file.stat().st_mtime
+        except OSError:
+            return False
+        return (time.time() - mtime) < _FRESH_PIDFILE_SECONDS
+
+    def _read_existing_pid(self) -> int:
+        """Best-effort read of the PID currently in the file."""
+        try:
+            content = self.pid_file.read_text().strip()
+        except OSError:
+            return 0
+        if not content:
+            return 0
+        # File may carry a single PID, or PID + extra lines (legacy formats
+        # in reload_lock.py have trailing metadata). Take the first token.
+        first = content.split()[0] if content.split() else ""
+        try:
+            pid = int(first)
+        except ValueError:
+            return 0
+        return pid if pid > 0 else 0
+
+
+@contextmanager
+def daemon_spawn_lock(session_id: str) -> Iterator[Path]:
+    """Back-compat wrapper: claim via DaemonSpawnClaim against the canonical
+    spawn-lock path. Yields the PID file path on success; raises
+    ``DaemonAlreadyStarting`` on contention.
+
+    Kept for ``tests/test_spawn_lock.py`` unit tests + any direct callers.
+    Production code in ``guard.py`` uses ``DaemonSpawnClaim`` directly so
+    it can pass the canonical pidfile path and set ``handed_off`` after
+    the atomic rename.
+    """
+    pid_file = _spawn_lock_path(session_id)
+    claim = DaemonSpawnClaim(session_id, pid_file)
+    try:
+        claim.__enter__()
+    except DaemonAlreadyStarting:
+        raise
+    try:
+        yield pid_file
+    finally:
+        # ctx-manager surface has no hand-off concept — always unlink on
+        # exit so this matches the prior ``daemon_spawn_lock`` lifecycle
+        # (sentinel removed on release). Test surface relies on this.
+        claim.handed_off = False
+        claim.__exit__(None, None, None)
+
+
+_HAVE_FCNTL = False  # exported for back-compat; we no longer use fcntl

--- a/tests/test_atomic_writes_wave1.py
+++ b/tests/test_atomic_writes_wave1.py
@@ -289,21 +289,34 @@ class TestHostFileLockWindows(unittest.TestCase):
                             "Expected lock to degrade to no-op when msvcrt unavailable")
 
 
-# ─── Hook schema bump v6 → v7 ────────────────────────────────────────────────
+# ─── Hook schema bump v7 → v8 (round 3 — C2 slug convergence, Option B) ─────
 
-class TestHookSchemaV7(unittest.TestCase):
+class TestHookSchemaV8(unittest.TestCase):
+    """v8 converges the bash hook slug rules with Python's
+    ``_pid_file_for_session`` (round 3 — C2 fix). Per code-auditor's
+    Option B sign-off (2026-05-18): the existing bash sanitiser
+    ``re.sub(r'[^a-z0-9_-]','_', s.lower())`` is kept as the codebase
+    convention (already used in ``reload_lock._slug_for`` and
+    ``spawn_lock._slug_for``); Python's previously stricter
+    ``^[0-9a-f][0-9a-f-]{11,}$`` is RELAXED to
+    ``^[a-z0-9][a-z0-9_-]{11,}$`` so both sides accept the same character
+    set. The leading-alphanumeric anchor is preserved as a security
+    property (dash-collision defense, see
+    ``TestPolishV2_SessionIdRegexRequiresHexFirstChar``)."""
+
     def test_schema_marker_bumped(self):
         from cozempic.init import HOOK_SCHEMA_VERSION
-        self.assertEqual(HOOK_SCHEMA_VERSION, "v7")
+        self.assertEqual(HOOK_SCHEMA_VERSION, "v8")
 
     def test_no_unflocked_foreground_guard_daemon_call(self):
         """The unflocked foreground `cozempic guard --daemon` call stays removed.
-        v7 three-branch idempotency wraps the spawn in `if PID alive then : ;
-        elif has flock then (flock -n 8 || exit 0; spawn) 8>$STARTUP_LOCK ;
-        else spawn ; fi`. Two branches (elif + else) each carry the
-        `cozempic guard --daemon || python3 -m cozempic guard --daemon` pair,
-        so the total occurrence count is 4 (2 branches × 2 fallback variants).
-        Anything else means an unguarded branch or a missing fallback."""
+        v7's three-branch idempotency (kept verbatim in v8) wraps the spawn in
+        `if PID alive then : ; elif has flock then (flock -n 8 || exit 0;
+        spawn) 8>$STARTUP_LOCK ; else spawn ; fi`. Two branches (elif + else)
+        each carry the `cozempic guard --daemon || python3 -m cozempic guard
+        --daemon` pair, so the total occurrence count is 4 (2 branches × 2
+        fallback variants). Anything else means an unguarded branch or a
+        missing fallback."""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
@@ -313,13 +326,13 @@ class TestHookSchemaV7(unittest.TestCase):
             f"[primary + python3 fallback]), got {count}")
 
     def test_startup_lock_present(self):
-        """v7 second-layer guard: when flock is available, the daemon spawn
-        runs inside a flock on a dedicated `*.startup-lock` file (distinct
-        from the existing hook-level `*.lock`). This closes the residual
-        race where the Python-side check-then-write window inside
-        `_pid_file_for_session` could let two near-simultaneous spawns both
-        pass the kill -0 fast-path. The two locks MUST be distinct files so
-        the daemon-spawn lock doesn't serialize unrelated hook work."""
+        """v8 keeps v7's second-layer guard: when flock is available, the
+        daemon spawn runs inside a flock on a dedicated `*.startup-lock`
+        file (distinct from the existing hook-level `*.lock`). The two locks
+        MUST be distinct files so the daemon-spawn lock doesn't serialize
+        unrelated hook work. Slug source is ``${SESSION_ID:0:12}`` — the
+        bash side uses the permissive ``re.sub`` sanitiser, the same
+        12-char prefix Python now produces via the relaxed regex."""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
@@ -327,9 +340,10 @@ class TestHookSchemaV7(unittest.TestCase):
             "Expected a dedicated GUARD_STARTUP_LOCK variable for the "
             "second-layer flock guarding the daemon spawn")
         self.assertIn("/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock", ss_cmd,
-            "GUARD_STARTUP_LOCK path must be the per-session startup-lock "
-            "file (distinct from the existing /tmp/cozempic_hook_*.lock "
-            "which serializes the outer hook chain)")
+            "GUARD_STARTUP_LOCK path must use ${SESSION_ID:0:12} — first 12 chars "
+            "of the bash-sanitised lowercased session_id. Convergence (C2/Option B) "
+            "is achieved by Python relaxing its regex to match this character set, "
+            "not by bash tightening to match a stricter Python regex.")
         # The startup-lock must use a DIFFERENT fd than the outer hook lock
         # (fd 9) — otherwise the inner flock acquire would race the outer.
         self.assertIn("flock -n 8", ss_cmd,
@@ -338,12 +352,12 @@ class TestHookSchemaV7(unittest.TestCase):
             "fd 8 must be redirected to the startup-lock file via 8>\"$GUARD_STARTUP_LOCK\"")
 
     def test_pid_fast_path_present(self):
-        """v7 invariant: the SessionStart hook must wrap the guard --daemon
-        spawn in a `kill -0 $(cat GUARD_PID_FILE)` fast-path so a healthy
-        daemon for the current session is NOT respawned. Closes the 2-ms
-        race observed in the 2026-05-18 crash trace where two daemons
-        started for the same SESSION_ID within the Python check-then-write
-        window."""
+        """v8 keeps v7's fast-path invariant: the SessionStart hook must wrap
+        the guard --daemon spawn in a `kill -0 $(cat GUARD_PID_FILE)` fast-path
+        so a healthy daemon for the current session is NOT respawned. The
+        GUARD_PID_FILE path uses ``${SESSION_ID:0:12}`` (bash-sanitised
+        lowercased session_id, first 12 chars) — Python's relaxed regex
+        produces the same slug for the same input."""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
@@ -352,23 +366,34 @@ class TestHookSchemaV7(unittest.TestCase):
         self.assertIn("kill -0", ss_cmd,
             "Expected `kill -0` liveness probe to short-circuit redundant daemon spawns")
         # Path must match Python's `_pid_file_for_session` convention
-        # (/tmp/cozempic_guard_<sid_lower:0:12>.pid).
+        # (/tmp/cozempic_guard_<slug>.pid where <slug> = first 12 chars of
+        # the lowercased+sanitised session_id; Python validates same charset).
         self.assertIn("/tmp/cozempic_guard_${SESSION_ID:0:12}.pid", ss_cmd,
-            "Fast-path PID file path must match the Python convention so the "
-            "shell-level check reads the same file the daemon writes")
+            "Fast-path PID file path must use ${SESSION_ID:0:12} — first 12 chars "
+            "of the bash-sanitised lowercased session_id, which (post-C2 Option B) "
+            "matches the slug Python computes via the relaxed _SESSION_ID_RE.")
 
     def test_session_id_lowercased(self):
-        """v7 requires lowercase normalization of session_id in the hook so
-        the shell-side PID file path matches Python's _pid_file_for_session
-        (which lowercases before truncating to 12 chars)."""
+        """The hook MUST lowercase the session_id before sanitising — Python's
+        ``_pid_file_for_session`` calls ``.lower()`` first, so any UPPER-case
+        UUID from Claude Code would compute a different slug in bash than in
+        Python if bash didn't also lowercase. (Pre-C2 finding was about
+        character-set divergence; this pins the case-handling parity that
+        prevents a second, narrower divergence.)"""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
         self.assertIn(".lower()", ss_cmd,
-            "SESSION_ID extraction must call .lower() to match the Python "
+            "session_id extraction must call .lower() to match the Python "
             "PID file naming convention; otherwise an upper-case UUID from "
             "Claude Code stdin would cause the fast-path to look at the "
-            "wrong file and the daemon spawn would not be deduplicated")
+            "wrong file and the daemon spawn would not be deduplicated.")
+        # The bash sanitiser must use the permissive character class that
+        # mirrors Python's relaxed regex (C2 Option B convergence).
+        self.assertIn("[^a-z0-9_-]", ss_cmd,
+            "bash sanitiser must use the permissive [^a-z0-9_-] character "
+            "class that mirrors Python's relaxed _SESSION_ID_RE — same "
+            "character set as reload_lock._slug_for and spawn_lock._slug_for.")
 
     def test_plugin_and_data_hooks_synced(self):
         plugin_path = Path(__file__).parent.parent / "plugin" / "hooks" / "hooks.json"

--- a/tests/test_atomic_writes_wave1.py
+++ b/tests/test_atomic_writes_wave1.py
@@ -289,23 +289,86 @@ class TestHostFileLockWindows(unittest.TestCase):
                             "Expected lock to degrade to no-op when msvcrt unavailable")
 
 
-# ─── Hook schema bump v5 → v6 ────────────────────────────────────────────────
+# ─── Hook schema bump v6 → v7 ────────────────────────────────────────────────
 
-class TestHookSchemaV6(unittest.TestCase):
+class TestHookSchemaV7(unittest.TestCase):
     def test_schema_marker_bumped(self):
         from cozempic.init import HOOK_SCHEMA_VERSION
-        self.assertEqual(HOOK_SCHEMA_VERSION, "v6")
+        self.assertEqual(HOOK_SCHEMA_VERSION, "v7")
 
     def test_no_unflocked_foreground_guard_daemon_call(self):
-        """The unflocked foreground `cozempic guard --daemon` call is REMOVED.
-        Hook should have exactly 2 occurrences of `cozempic guard --daemon`
-        in SessionStart (1 flocked + 1 python3 fallback)."""
+        """The unflocked foreground `cozempic guard --daemon` call stays removed.
+        v7 three-branch idempotency wraps the spawn in `if PID alive then : ;
+        elif has flock then (flock -n 8 || exit 0; spawn) 8>$STARTUP_LOCK ;
+        else spawn ; fi`. Two branches (elif + else) each carry the
+        `cozempic guard --daemon || python3 -m cozempic guard --daemon` pair,
+        so the total occurrence count is 4 (2 branches × 2 fallback variants).
+        Anything else means an unguarded branch or a missing fallback."""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
         count = ss_cmd.count("cozempic guard --daemon")
-        self.assertEqual(count, 2,
-            f"Expected 2 'cozempic guard --daemon' occurrences (1 primary + 1 python3 fallback inside flock), got {count}")
+        self.assertEqual(count, 4,
+            f"Expected 4 'cozempic guard --daemon' occurrences (2 branches × "
+            f"[primary + python3 fallback]), got {count}")
+
+    def test_startup_lock_present(self):
+        """v7 second-layer guard: when flock is available, the daemon spawn
+        runs inside a flock on a dedicated `*.startup-lock` file (distinct
+        from the existing hook-level `*.lock`). This closes the residual
+        race where the Python-side check-then-write window inside
+        `_pid_file_for_session` could let two near-simultaneous spawns both
+        pass the kill -0 fast-path. The two locks MUST be distinct files so
+        the daemon-spawn lock doesn't serialize unrelated hook work."""
+        hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
+        hooks = json.loads(hooks_path.read_text())
+        ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        self.assertIn("GUARD_STARTUP_LOCK=", ss_cmd,
+            "Expected a dedicated GUARD_STARTUP_LOCK variable for the "
+            "second-layer flock guarding the daemon spawn")
+        self.assertIn("/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock", ss_cmd,
+            "GUARD_STARTUP_LOCK path must be the per-session startup-lock "
+            "file (distinct from the existing /tmp/cozempic_hook_*.lock "
+            "which serializes the outer hook chain)")
+        # The startup-lock must use a DIFFERENT fd than the outer hook lock
+        # (fd 9) — otherwise the inner flock acquire would race the outer.
+        self.assertIn("flock -n 8", ss_cmd,
+            "Inner startup-lock flock must use fd 8 (outer hook lock owns fd 9)")
+        self.assertIn("8>\"$GUARD_STARTUP_LOCK\"", ss_cmd,
+            "fd 8 must be redirected to the startup-lock file via 8>\"$GUARD_STARTUP_LOCK\"")
+
+    def test_pid_fast_path_present(self):
+        """v7 invariant: the SessionStart hook must wrap the guard --daemon
+        spawn in a `kill -0 $(cat GUARD_PID_FILE)` fast-path so a healthy
+        daemon for the current session is NOT respawned. Closes the 2-ms
+        race observed in the 2026-05-18 crash trace where two daemons
+        started for the same SESSION_ID within the Python check-then-write
+        window."""
+        hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
+        hooks = json.loads(hooks_path.read_text())
+        ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        self.assertIn("GUARD_PID_FILE=", ss_cmd,
+            "Expected the SessionStart hook to declare GUARD_PID_FILE for the fast-path")
+        self.assertIn("kill -0", ss_cmd,
+            "Expected `kill -0` liveness probe to short-circuit redundant daemon spawns")
+        # Path must match Python's `_pid_file_for_session` convention
+        # (/tmp/cozempic_guard_<sid_lower:0:12>.pid).
+        self.assertIn("/tmp/cozempic_guard_${SESSION_ID:0:12}.pid", ss_cmd,
+            "Fast-path PID file path must match the Python convention so the "
+            "shell-level check reads the same file the daemon writes")
+
+    def test_session_id_lowercased(self):
+        """v7 requires lowercase normalization of session_id in the hook so
+        the shell-side PID file path matches Python's _pid_file_for_session
+        (which lowercases before truncating to 12 chars)."""
+        hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
+        hooks = json.loads(hooks_path.read_text())
+        ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        self.assertIn(".lower()", ss_cmd,
+            "SESSION_ID extraction must call .lower() to match the Python "
+            "PID file naming convention; otherwise an upper-case UUID from "
+            "Claude Code stdin would cause the fast-path to look at the "
+            "wrong file and the daemon spawn would not be deduplicated")
 
     def test_plugin_and_data_hooks_synced(self):
         plugin_path = Path(__file__).parent.parent / "plugin" / "hooks" / "hooks.json"

--- a/tests/test_guard_hard_loop_backoff.py
+++ b/tests/test_guard_hard_loop_backoff.py
@@ -41,10 +41,7 @@ class TestHardLoopBackoffHelper(unittest.TestCase):
     locked in without depending on the larger guard loop."""
 
     def test_returns_interval_below_backoff_start(self):
-        from cozempic.guard import (
-            HARD_LOOP_BACKOFF_START,
-            _hard_loop_backoff_sleep,
-        )
+        from cozempic.guard import HARD_LOOP_BACKOFF_START, _hard_loop_backoff_sleep
 
         for k in range(HARD_LOOP_BACKOFF_START):
             self.assertEqual(_hard_loop_backoff_sleep(k, 30), 30)
@@ -57,7 +54,8 @@ class TestHardLoopBackoffHelper(unittest.TestCase):
         expected = {3: 60, 4: 120, 5: 240, 6: 300, 7: 300, 8: 300, 9: 300}
         for k, want in expected.items():
             self.assertEqual(
-                _hard_loop_backoff_sleep(k, 30), want,
+                _hard_loop_backoff_sleep(k, 30),
+                want,
                 f"K={k}: expected {want}s, got {_hard_loop_backoff_sleep(k, 30)}",
             )
 
@@ -125,14 +123,26 @@ class TestHardLoopExitAndReset(unittest.TestCase):
                 "reloading": False,
             }
 
+        # H4 fix: patch ``guard_mod.time.sleep`` explicitly rather than
+        # replacing the whole ``time`` module on guard_mod with a Mock.
+        # The prior full-module mock silently returned MagicMocks for any
+        # ``time.*`` attribute the test forgot to back-patch (time.monotonic,
+        # time.perf_counter, etc.), so any future code path under test that
+        # added another time.* call would fail with a confusing TypeError
+        # in arithmetic comparisons. Per-attribute patch leaves the rest of
+        # the time module intact and only intercepts the one call we care
+        # about. Matches the pattern used in 5 other test files in this
+        # repo (search ``patch.object\(.*time.*sleep``).
         with (
-            patch.object(guard_mod, "time") as fake_time_mod,
+            patch.object(guard_mod.time, "sleep", side_effect=fake_sleep),
             patch.object(guard_mod, "_resolve_session_by_id", return_value=session),
             patch.object(guard_mod, "find_current_session", return_value=session),
             patch.object(guard_mod, "find_claude_pid", return_value=None),
             patch.object(guard_mod, "checkpoint_team", return_value=_FakeState()),
             patch.object(guard_mod, "guard_prune_cycle", side_effect=fake_prune_cycle),
-            patch.object(guard_mod, "quick_token_estimate", return_value=token_estimate),
+            patch.object(
+                guard_mod, "quick_token_estimate", return_value=token_estimate
+            ),
             patch.object(guard_mod, "load_messages", return_value=[]),
             patch("cozempic.session.record_session"),
             patch.object(guard_mod, "_cleanup_stale_watchers"),
@@ -141,12 +151,6 @@ class TestHardLoopExitAndReset(unittest.TestCase):
             patch.object(guard_mod, "cleanup_old_backups"),
             patch("cozempic.tokens.detect_context_window", return_value=1_000_000),
         ):
-            fake_time_mod.sleep.side_effect = fake_sleep
-            real_time = time
-            fake_time_mod.time = real_time.time
-            fake_time_mod.strftime = real_time.strftime
-            fake_time_mod.localtime = real_time.localtime
-
             captured = io.StringIO()
             with patch.object(sys, "stdout", captured):
                 try:
@@ -184,19 +188,20 @@ class TestHardLoopExitAndReset(unittest.TestCase):
 
         result = self._run_loop([0.0] * (HARD_LOOP_EXIT_THRESHOLD + 2))
         self.assertEqual(
-            result["exit_code"], 0,
+            result["exit_code"],
+            0,
             f"Expected sys.exit(0); got exit_code={result['exit_code']!r}, "
             f"raised={result['raised']!r}",
         )
         self.assertIn(
-            "powerless against live-context dominance", result["stdout"],
+            "powerless against live-context dominance",
+            result["stdout"],
             "Diagnostic message was not printed before exit",
         )
 
     def test_counter_resets_on_successful_prune(self):
         """A successful prune (>0 saved_mb) resets the consecutive counter,
         so a subsequent burst of 0-byte prunes alone is NOT enough to exit."""
-        from cozempic.guard import HARD_LOOP_EXIT_THRESHOLD
 
         # 5 zeros, then a successful prune, then 5 more zeros.
         # If the counter reset works, total 0-byte consecutive count tops out

--- a/tests/test_guard_hard_loop_backoff.py
+++ b/tests/test_guard_hard_loop_backoff.py
@@ -1,0 +1,215 @@
+"""Tests for the HARD-threshold back-off + exit-with-diagnostic contract.
+
+Companion to ``test_guard_race_2026_05_18.py::TestR2_*`` (the original RED
+test). These tests pin down the back-off curve, the counter-reset on a
+successful prune, and the exit-after-threshold path at the unit level so
+regressions are caught even if the integration-style R2 test masks them.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _stub_session(tmpdir: Path, session_id: str):
+    path = tmpdir / "fake_session.jsonl"
+    path.write_text('{"type":"user","message":{"content":"hi"}}\n')
+    return {"session_id": session_id, "path": path}
+
+
+class _StopAfterNSleeps(Exception):
+    """Sentinel to break out of the guard loop deterministically."""
+
+
+class _FakeState:
+    subagents = []  # type: ignore[var-annotated]
+    tasks = []  # type: ignore[var-annotated]
+    message_count = 0
+
+    def is_empty(self) -> bool:
+        return True
+
+
+class TestHardLoopBackoffHelper(unittest.TestCase):
+    """Pure-function tests for ``_hard_loop_backoff_sleep`` so the curve is
+    locked in without depending on the larger guard loop."""
+
+    def test_returns_interval_below_backoff_start(self):
+        from cozempic.guard import (
+            HARD_LOOP_BACKOFF_START,
+            _hard_loop_backoff_sleep,
+        )
+
+        for k in range(HARD_LOOP_BACKOFF_START):
+            self.assertEqual(_hard_loop_backoff_sleep(k, 30), 30)
+
+    def test_exponential_backoff_curve(self):
+        """Curve at the published defaults (start=3, cap=300, interval=30):
+        K=3 → 60, K=4 → 120, K=5 → 240, K=6+ → 300 (capped)."""
+        from cozempic.guard import _hard_loop_backoff_sleep
+
+        expected = {3: 60, 4: 120, 5: 240, 6: 300, 7: 300, 8: 300, 9: 300}
+        for k, want in expected.items():
+            self.assertEqual(
+                _hard_loop_backoff_sleep(k, 30), want,
+                f"K={k}: expected {want}s, got {_hard_loop_backoff_sleep(k, 30)}",
+            )
+
+    def test_cap_respected_for_unusual_intervals(self):
+        from cozempic.guard import (
+            HARD_LOOP_BACKOFF_CAP_SECONDS,
+            _hard_loop_backoff_sleep,
+        )
+
+        # A 5-minute interval would otherwise hit 300 * 8 = 2400 at K=5.
+        self.assertEqual(
+            _hard_loop_backoff_sleep(5, 300),
+            HARD_LOOP_BACKOFF_CAP_SECONDS,
+        )
+
+
+class TestHardLoopExitAndReset(unittest.TestCase):
+    """Integration-ish tests driving start_guard with mocked deps."""
+
+    def _run_loop(
+        self,
+        prune_returns,
+        token_estimate=600_000,
+        interval=30,
+        threshold_tokens=500_000,
+    ):
+        """Drive start_guard with a sequence of prune results.
+
+        ``prune_returns`` is an iterable of saved_mb floats. After each is
+        consumed the loop is forced to stop via ``_StopAfterNSleeps`` from
+        time.sleep so the test terminates.
+        """
+        from cozempic import guard as guard_mod
+
+        tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmpdir, ignore_errors=True))
+        session = _stub_session(tmpdir, "cafe1234-5678-9abc-def0-2026051811bb")
+
+        sleep_calls: list[float] = []
+        # Each cycle does 1 baseline sleep + up to 1 back-off sleep — give
+        # generous headroom so the test only stops the loop AFTER the
+        # under-test path (exit or counter-reset) has had its chance.
+        max_sleeps = (len(prune_returns) * 2) + 4
+
+        def fake_sleep(duration):
+            sleep_calls.append(float(duration))
+            if len(sleep_calls) >= max_sleeps:
+                raise _StopAfterNSleeps()
+
+        prune_iter = iter(prune_returns)
+
+        def fake_prune_cycle(**kwargs):
+            try:
+                saved = next(prune_iter)
+            except StopIteration:
+                saved = 0.0
+            return {
+                "saved_mb": float(saved),
+                "original_tokens": 600_000,
+                "final_tokens": 600_000 - int(saved * 1000),
+                "team_name": None,
+                "team_messages": 0,
+                "checkpoint_path": None,
+                "backup_path": None,
+                "reloading": False,
+            }
+
+        with (
+            patch.object(guard_mod, "time") as fake_time_mod,
+            patch.object(guard_mod, "_resolve_session_by_id", return_value=session),
+            patch.object(guard_mod, "find_current_session", return_value=session),
+            patch.object(guard_mod, "find_claude_pid", return_value=None),
+            patch.object(guard_mod, "checkpoint_team", return_value=_FakeState()),
+            patch.object(guard_mod, "guard_prune_cycle", side_effect=fake_prune_cycle),
+            patch.object(guard_mod, "quick_token_estimate", return_value=token_estimate),
+            patch.object(guard_mod, "load_messages", return_value=[]),
+            patch("cozempic.session.record_session"),
+            patch.object(guard_mod, "_cleanup_stale_watchers"),
+            patch.object(guard_mod, "ping_install_if_new"),
+            patch.object(guard_mod, "maybe_auto_update"),
+            patch.object(guard_mod, "cleanup_old_backups"),
+            patch("cozempic.tokens.detect_context_window", return_value=1_000_000),
+        ):
+            fake_time_mod.sleep.side_effect = fake_sleep
+            real_time = time
+            fake_time_mod.time = real_time.time
+            fake_time_mod.strftime = real_time.strftime
+            fake_time_mod.localtime = real_time.localtime
+
+            captured = io.StringIO()
+            with patch.object(sys, "stdout", captured):
+                try:
+                    guard_mod.start_guard(
+                        cwd=str(tmpdir),
+                        threshold_mb=100.0,
+                        soft_threshold_mb=50.0,
+                        rx_name="standard",
+                        interval=interval,
+                        auto_reload=False,
+                        reactive=False,
+                        threshold_tokens=threshold_tokens,
+                        soft_threshold_tokens=250_000,
+                        session_id=session["session_id"],
+                    )
+                    raised = None
+                    exit_code = None
+                except _StopAfterNSleeps as e:
+                    raised = e
+                    exit_code = None
+                except SystemExit as e:
+                    raised = None
+                    exit_code = e.code
+
+            return {
+                "sleeps": sleep_calls,
+                "raised": raised,
+                "exit_code": exit_code,
+                "stdout": captured.getvalue(),
+            }
+
+    def test_exit_after_threshold_cycles(self):
+        """10 consecutive 0-byte HARD prunes → sys.exit(0) with diagnostic."""
+        from cozempic.guard import HARD_LOOP_EXIT_THRESHOLD
+
+        result = self._run_loop([0.0] * (HARD_LOOP_EXIT_THRESHOLD + 2))
+        self.assertEqual(
+            result["exit_code"], 0,
+            f"Expected sys.exit(0); got exit_code={result['exit_code']!r}, "
+            f"raised={result['raised']!r}",
+        )
+        self.assertIn(
+            "powerless against live-context dominance", result["stdout"],
+            "Diagnostic message was not printed before exit",
+        )
+
+    def test_counter_resets_on_successful_prune(self):
+        """A successful prune (>0 saved_mb) resets the consecutive counter,
+        so a subsequent burst of 0-byte prunes alone is NOT enough to exit."""
+        from cozempic.guard import HARD_LOOP_EXIT_THRESHOLD
+
+        # 5 zeros, then a successful prune, then 5 more zeros.
+        # If the counter reset works, total 0-byte consecutive count tops out
+        # at 5 — below exit threshold (10) — so the loop must run to the
+        # _StopAfterNSleeps cap, NOT exit cleanly.
+        sequence = [0.0] * 5 + [1.5] + [0.0] * 5
+        result = self._run_loop(sequence)
+        self.assertIsNone(
+            result["exit_code"],
+            f"Counter did not reset — loop exited at code={result['exit_code']}",
+        )
+        self.assertIsInstance(result["raised"], _StopAfterNSleeps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -876,15 +876,26 @@ class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _run_with_os_open_raising(self, errno_code: int):
-        """Invoke start_guard_daemon with a mocked os.open that raises OSError
-        with the given errno on the pidfile path. Returns result dict OR
-        `{'_raised': exc}` if uncaught."""
+        """Invoke start_guard_daemon with a mocked pidfile-write path that
+        raises OSError with the given errno. Returns result dict OR
+        `{'_raised': exc}` if uncaught.
+
+        After the round-3 rework (C1 fix) the pidfile is written via
+        ``os.open(<pid>.tmp, O_CREAT|O_EXCL|O_NOFOLLOW)`` then
+        ``os.rename``, replacing the prior ``Path.write_text``. The intent
+        of this test is unchanged (graceful surface on any OSError) —
+        only the mock surface moves to the new ``os.open`` call. We have
+        to filter on the .pid.tmp suffix because DaemonSpawnClaim also
+        uses os.open on the pid_path itself; only the post-Popen
+        atomic-rename open should fail.
+        """
         from cozempic.guard import start_guard_daemon
 
+        tmp_pidfile_str = str(self.pid_path.with_suffix(".pid.tmp"))
         real_os_open = os.open
 
-        def fake_open(path, flags, *args, **kwargs):
-            if str(path) == str(self.pid_path) and (flags & os.O_EXCL):
+        def fake_os_open(path, flags, *args, **kwargs):
+            if str(path) == tmp_pidfile_str:
                 raise OSError(errno_code, os.strerror(errno_code))
             return real_os_open(path, flags, *args, **kwargs)
 
@@ -892,7 +903,7 @@ class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard.find_claude_pid", return_value=7777),
             patch("cozempic.guard.subprocess.Popen") as mock_popen,
-            patch("cozempic.guard.os.open", side_effect=fake_open),
+            patch("cozempic.guard.os.open", side_effect=fake_os_open),
         ):
             mock_popen.return_value = MagicMock(pid=9999)
             try:
@@ -1296,15 +1307,26 @@ class TestDiffCoverage_AtomicPidfile_AllErrnos(unittest.TestCase):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _run_with_os_open_raising(self, exc: Exception):
-        """Invoke start_guard_daemon with a mocked os.open that raises the
-        given exception on EXCL open of our pidfile. Returns result dict OR
-        `{'_raised': exc}` if uncaught."""
+        """Invoke start_guard_daemon with a mocked pidfile-write path that
+        raises the given exception. Returns result dict OR `{'_raised': exc}`
+        if uncaught.
+
+        After the round-3 rework (C1 fix) the pidfile is written via
+        ``os.open(<pid>.tmp, O_CREAT|O_EXCL|O_NOFOLLOW)`` then
+        ``os.rename``, replacing the prior ``Path.write_text``. The intent
+        of this test is unchanged (graceful surface on any OSError) —
+        only the mock surface moves to the new ``os.open`` call. We have
+        to filter on the .pid.tmp suffix because DaemonSpawnClaim also
+        uses os.open on the pid_path itself; only the post-Popen
+        atomic-rename open should fail.
+        """
         from cozempic.guard import start_guard_daemon
 
+        tmp_pidfile_str = str(self.pid_path.with_suffix(".pid.tmp"))
         real_os_open = os.open
 
-        def fake_open(path, flags, *args, **kwargs):
-            if str(path) == str(self.pid_path) and (flags & os.O_EXCL):
+        def fake_os_open(path, flags, *args, **kwargs):
+            if str(path) == tmp_pidfile_str:
                 raise exc
             return real_os_open(path, flags, *args, **kwargs)
 
@@ -1312,7 +1334,7 @@ class TestDiffCoverage_AtomicPidfile_AllErrnos(unittest.TestCase):
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard.find_claude_pid", return_value=7777),
             patch("cozempic.guard.subprocess.Popen") as mock_popen,
-            patch("cozempic.guard.os.open", side_effect=fake_open),
+            patch("cozempic.guard.os.open", side_effect=fake_os_open),
         ):
             mock_popen.return_value = MagicMock(pid=9999)
             try:
@@ -1743,15 +1765,32 @@ class TestPolishV2_BugG13PidFileUuidValidation(unittest.TestCase):
         ):
             _pid_file_for_session("../../etc/pa")
 
-    def test_non_hex_session_id_rejected(self):
-        """A session_id of the right length but containing non-hex characters
-        MUST raise ValueError."""
+    def test_non_alphanumeric_session_id_rejected(self):
+        """A session_id of the right length but containing characters
+        outside ``[a-z0-9_-]`` MUST raise ValueError. Round-3 C2 Option B
+        RELAXED the char-class from hex-only to lowercase alphanumeric +
+        underscore + dash (matches bash sanitiser + reload_lock slug rules),
+        so non-hex letters like 'z' are now ACCEPTED — see
+        ``test_relaxed_non_hex_session_id_accepted``. But anything outside
+        the relaxed class (uppercase pre-lowercase, slash, dot, colon,
+        ``$``, semicolon) is still rejected so path-traversal and shell-
+        metachar inputs cannot construct a pidfile path."""
         from cozempic.guard import _pid_file_for_session
-        with self.assertRaises(
-            ValueError,
-            msg="non-hex session_id was accepted — BUG-G13",
-        ):
-            _pid_file_for_session("zzzzzzzzzzzzzzzz")
+        # Each input contains at least one character not in [a-z0-9_-]
+        # (after lowercasing). All are of valid length (≥12 chars).
+        rejected_inputs = (
+            "session.id.with.dots",     # dots — not in char class
+            "session/path/traversal",   # slashes
+            "session:with:colons",      # colons
+            "session;rm-rf-/;injection",  # semicolons + shell metachar
+            "session$inject_var_xyz",   # dollar sign
+        )
+        for sid in rejected_inputs:
+            with self.assertRaises(
+                ValueError,
+                msg=f"out-of-class session_id was accepted: {sid!r}",
+            ):
+                _pid_file_for_session(sid)
 
     def test_short_session_id_rejected(self):
         """Session IDs shorter than the validation minimum MUST raise."""
@@ -1914,7 +1953,13 @@ class TestPolishV2_PidFileForSessionValueErrorSanitization(unittest.TestCase):
 
     def test_value_error_message_does_not_echo_raw_session_id(self):
         from cozempic.guard import _pid_file_for_session
-        secret = "super-secret-token-would-be-bad-to-log-xyz"
+        # Use an input that fails the relaxed _SESSION_ID_RE
+        # (^[a-z0-9][a-z0-9_-]{11,}$) — leading-dash + special chars
+        # (slashes, dots) are all rejected. C2-Option-B relaxed the
+        # regex from hex-only to lowercase alphanumeric+_-, so the
+        # secret must include a character class NOT in [a-z0-9_-] or
+        # violate the leading-alphanumeric anchor.
+        secret = "/etc/passwd:sensitive_path_token_xyz_should_not_log"
         with self.assertRaises(ValueError) as ctx:
             _pid_file_for_session(secret)
         self.assertNotIn(
@@ -1948,27 +1993,38 @@ class TestPolishV2_PidFileForSessionValueErrorSanitization(unittest.TestCase):
 
 class TestPolishV2_SessionIdRegexRequiresHexFirstChar(unittest.TestCase):
     """`_SESSION_ID_RE` must reject pure-dash / leading-dash session ids.
-    The relaxed regex `^[0-9a-fA-F-]{12,}$` accepted them because `-` was
-    in the char class — `'-' * 12` validated, and any two all-dash inputs
-    of different lengths collided after `[:12]` truncation onto the same
-    pidfile path. Tightened regex requires a hex digit as the first char.
+    The original (pre-G13) regex ``^[0-9a-fA-F-]{12,}$`` accepted them
+    because ``-`` was in the leading-char class — ``'-' * 12`` validated,
+    and any two all-dash inputs of different lengths collided after
+    ``[:12]`` truncation onto the same pidfile path.
+
+    Round-3 C2 fix (Option B per code-auditor sign-off) RELAXED the
+    char-class from hex-only to ``^[a-z0-9][a-z0-9_-]{11,}$`` (matches
+    the bash sanitiser + reload_lock/spawn_lock slug rules), but the
+    leading-alphanumeric anchor (``[a-z0-9]`` for position 0) is KEPT
+    precisely to preserve the dash-collision security property tested
+    here. Class name retained for git-blame history (the class is no
+    longer about "hex first char" specifically; it's about "alphanumeric
+    first char" — same security property, broader char class).
     """
 
     def test_pure_dashes_rejected(self):
-        """12 dashes is not a UUID; must reject."""
+        """12 dashes is not a valid session id; must reject."""
         from cozempic.guard import _pid_file_for_session
         with self.assertRaises(ValueError):
             _pid_file_for_session("-" * 12)
 
     def test_leading_dash_rejected(self):
-        """UUID-shape requires a hex digit (not dash) in position 0."""
+        """Session id shape requires an alphanumeric (not dash) in
+        position 0 — defeats dash-collision after [:12] truncation."""
         from cozempic.guard import _pid_file_for_session
         with self.assertRaises(ValueError):
             _pid_file_for_session("-abcdef123456789abcdef")
 
     def test_dash_collision_prevented(self):
         """Before fix: `-` * 12 and `-` * 18 accept AND collide after
-        [:12] truncation. After fix: both reject."""
+        [:12] truncation. After fix (kept under C2 Option B's relaxed
+        char class via the leading-alphanumeric anchor): both reject."""
         from cozempic.guard import _pid_file_for_session
         with self.assertRaises(ValueError):
             _pid_file_for_session("-" * 12)
@@ -1976,13 +2032,31 @@ class TestPolishV2_SessionIdRegexRequiresHexFirstChar(unittest.TestCase):
             _pid_file_for_session("-" * 18)
 
     def test_valid_hex_uuid_still_accepted(self):
-        """Regression: real UUID (hex lead) still works."""
+        """Regression: real hex UUID still works under the relaxed regex
+        (UUIDs are a strict subset of [a-z0-9][a-z0-9_-]{11,})."""
         from cozempic.guard import _pid_file_for_session
         uuid = "e6c3a4b2-1234-5678-9abc-def012345678"
         p = _pid_file_for_session(uuid)
         self.assertEqual(
             p, Path("/tmp") / f"cozempic_guard_{uuid[:12]}.pid",
         )
+
+    def test_relaxed_non_hex_session_id_accepted(self):
+        """C2 Option B regression: non-hex session ids (e.g., with
+        underscores or non-hex letters like `t`, `g`, `z`) are now
+        accepted, matching the bash sanitiser's char set. UUIDs were
+        a strict subset before, so no existing input regresses."""
+        from cozempic.guard import _pid_file_for_session
+        for sid in (
+            "test-session-id-long-enough",  # non-hex letters
+            "abc_123_def_456789",           # underscore
+            "z9z9z9z9z9z9z9z9",             # non-hex 'z'
+        ):
+            p = _pid_file_for_session(sid)
+            self.assertEqual(
+                p, Path("/tmp") / f"cozempic_guard_{sid.lower()[:12]}.pid",
+                f"Relaxed regex must accept {sid!r}",
+            )
 
 
 # ===========================================================================
@@ -2007,16 +2081,24 @@ class TestPolishV2_StartGuardDaemonValidatesSessionId(unittest.TestCase):
     """
 
     def test_invalid_session_id_does_not_spawn(self):
-        """Non-UUID session_id must refuse to spawn the daemon — prevents
-        orphaning. Returns {started: False, reason mentions session}."""
+        """An out-of-charset session_id (e.g. with path-traversal slashes)
+        must refuse to spawn the daemon — prevents orphaning. Returns
+        ``{started: False, reason mentions session}``.
+
+        Pre-Option-B this test used ``test-session-xyz`` (which Python
+        rejected as non-hex). Post-Option-B the relaxed regex accepts
+        ``[a-z0-9_-]+``, so the test now uses a path-traversal input
+        that's STILL rejected (the ``/`` char is outside the relaxed
+        char class AND is the actual security threat — preventing
+        ``../etc/passwd``-style pidfile paths)."""
         from cozempic.guard import start_guard_daemon
         result = start_guard_daemon(
             cwd="/tmp",
-            session_id="test-session-xyz",
+            session_id="test/session/path-traversal-attempt",
         )
         self.assertFalse(
             result.get("started"),
-            f"daemon spawned with invalid session_id — orphan: {result}",
+            f"daemon spawned with out-of-charset session_id — orphan: {result}",
         )
         self.assertIn("session", result.get("reason", "").lower())
 
@@ -2035,19 +2117,61 @@ class TestPolishV2_StartGuardDaemonValidatesSessionId(unittest.TestCase):
 
     def test_no_orphan_pidfile_on_invalid_session(self):
         """Post-fix: a rejected spawn MUST NOT leave a pidfile anywhere,
-        orphan or otherwise. Current RED: `/tmp/cozempic_guard_test-sessio.pid`
-        (or similar truncation) is created by the raw [:12] path."""
+        orphan or otherwise. Original RED case: the raw ``[:12]`` path
+        composition would create ``/tmp/cozempic_guard_test-sessio.pid``
+        even when validation should reject. Post-Option-B the input must
+        contain a char outside ``[a-z0-9_-]`` to still be rejected;
+        ``test/path`` does (the ``/``) and is also the actual security
+        threat — path-traversal attempts.
+
+        DA round 3 N5 + N6 extension: also check the bash-derived slug
+        path. The hook would derive a DIFFERENT slug from the same input
+        (via substitution ``re.sub(r'[^a-z0-9_-]', '_', s.lower())[:12]``),
+        and a hypothetical accidental spawn could leave an orphan at that
+        bash-derived path too. The original glob
+        ``cozempic_guard_test/*.pid`` was unreachable on POSIX (``/`` is
+        not a filename char) — replaced with ``cozempic_guard_test*.pid``
+        and the explicit bash-slug computation."""
+        import re
+
         from cozempic.guard import start_guard_daemon
-        # Clean any pre-existing stale file
-        for stale in Path("/tmp").glob("cozempic_guard_test-session*.pid"):
-            stale.unlink(missing_ok=True)
+
+        invalid_input = "test/path/traversal-attempt"
+        # The bash hook's sanitiser would produce a substitution-derived
+        # slug for the same input — compute it here so we glob both
+        # potential orphan paths (Python-derived AND bash-derived).
+        bash_slug = re.sub(r"[^a-z0-9_-]", "_", invalid_input.lower())[:12]
+        # Patterns to clean BEFORE the test runs (avoid stale files from
+        # a prior interrupted run polluting the orphan check). N6 fix:
+        # `test/*.pid` is unreachable on POSIX → use `test*.pid`.
+        pre_clean_globs = (
+            "cozempic_guard_test-session*.pid",
+            "cozempic_guard_test_path*.pid",
+            "cozempic_guard_test*.pid",
+            f"cozempic_guard_{bash_slug}*.pid",
+        )
+        for pattern in pre_clean_globs:
+            for stale in Path("/tmp").glob(pattern):
+                try:
+                    stale.unlink()
+                except OSError:
+                    pass
+
         result = start_guard_daemon(
             cwd="/tmp",
-            session_id="test-session-xyz",
+            session_id=invalid_input,
         )
-        # If the fix refused to start, cleanup not needed — but assert no
-        # orphan pidfile was left behind.
-        orphans = list(Path("/tmp").glob("cozempic_guard_test-session*.pid"))
+
+        # Collect orphans at BOTH the Python-derived and bash-derived
+        # slug locations. Python validates first → it shouldn't have
+        # written anything anywhere; both lists should be empty.
+        python_orphans = (
+            list(Path("/tmp").glob("cozempic_guard_test-session*.pid"))
+            + list(Path("/tmp").glob("cozempic_guard_test_path*.pid"))
+            + list(Path("/tmp").glob("cozempic_guard_test*.pid"))
+        )
+        bash_orphans = list(Path("/tmp").glob(f"cozempic_guard_{bash_slug}*.pid"))
+
         # Cleanup any accidentally-spawned daemon from the RED state
         pid = result.get("pid")
         if pid:
@@ -2056,15 +2180,27 @@ class TestPolishV2_StartGuardDaemonValidatesSessionId(unittest.TestCase):
                 os.kill(pid, signal.SIGTERM)
             except (ProcessLookupError, PermissionError):
                 pass
-        for o in orphans:
-            o.unlink(missing_ok=True)
+        for o in python_orphans + bash_orphans:
+            try:
+                o.unlink()
+            except OSError:
+                pass
+
         self.assertFalse(
             result.get("started"),
-            "daemon spawned with invalid session_id",
+            "daemon spawned with invalid (out-of-charset) session_id",
         )
         self.assertEqual(
-            orphans, [],
-            f"orphan pidfile(s) left behind: {[str(o) for o in orphans]}",
+            python_orphans, [],
+            f"Python-derived orphan pidfile(s) left behind: "
+            f"{[str(o) for o in python_orphans]}",
+        )
+        # N5 — separate assertion so the failure message points to the
+        # right slug-derivation source when the regression is bash-side.
+        self.assertEqual(
+            bash_orphans, [],
+            f"bash-derived orphan pidfile(s) at slug={bash_slug!r}: "
+            f"{[str(o) for o in bash_orphans]}",
         )
 
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -99,7 +99,9 @@ def _race_worker(
         try:
             barrier_handle.wait(timeout=5.0)
         except Exception as e:  # BrokenBarrierError or timeout
-            result_queue.put({"error": f"barrier failed: {e!r}", "worker": worker_index})
+            result_queue.put(
+                {"error": f"barrier failed: {e!r}", "worker": worker_index}
+            )
             return
 
         try:
@@ -210,8 +212,7 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
             self.fail(
                 f"Process-vs-process race produced bad outcomes in "
                 f"{len(failures)}/{self.ITERATIONS} iterations.\n"
-                f"First 3 failure records:\n"
-                + "\n".join(repr(f) for f in failures[:3])
+                f"First 3 failure records:\n" + "\n".join(repr(f) for f in failures[:3])
             )
 
 
@@ -306,14 +307,23 @@ class TestR2_HardThresholdZeroByteLoop(unittest.TestCase):
         # ---- Mock the assorted infrastructure called by start_guard -------
         # checkpoint_team returns the fake state; load_messages returns []
         # so detect_context_window can run; record_session is a no-op.
+        # Per H4 hygiene fix: patch ``guard_mod.time.sleep`` explicitly
+        # rather than replacing the whole ``time`` module with a Mock.
+        # Symmetric with test_guard_hard_loop_backoff.py — leaves the rest
+        # of the time module intact so future code paths under test that
+        # add new time.* calls don't break with confusing TypeErrors.
         with (
-            patch.object(guard_mod, "time") as fake_time_mod,
-            patch.object(guard_mod, "_resolve_session_by_id", return_value=fake_session),
+            patch.object(guard_mod.time, "sleep", side_effect=fake_sleep),
+            patch.object(
+                guard_mod, "_resolve_session_by_id", return_value=fake_session
+            ),
             patch.object(guard_mod, "find_current_session", return_value=fake_session),
             patch.object(guard_mod, "find_claude_pid", return_value=None),
             patch.object(guard_mod, "checkpoint_team", return_value=_FakeState()),
             patch.object(guard_mod, "guard_prune_cycle", side_effect=fake_prune_cycle),
-            patch.object(guard_mod, "quick_token_estimate", side_effect=fake_quick_token_estimate),
+            patch.object(
+                guard_mod, "quick_token_estimate", side_effect=fake_quick_token_estimate
+            ),
             patch.object(guard_mod, "load_messages", return_value=[]),
             patch("cozempic.session.record_session"),
             patch.object(guard_mod, "_cleanup_stale_watchers"),
@@ -322,13 +332,6 @@ class TestR2_HardThresholdZeroByteLoop(unittest.TestCase):
             patch.object(guard_mod, "cleanup_old_backups"),
             patch("cozempic.tokens.detect_context_window", return_value=1_000_000),
         ):
-            # Wire time.sleep on the module reference (start_guard uses ``time.sleep``)
-            fake_time_mod.sleep.side_effect = fake_sleep
-            # time.time/etc are also used by _now; route through the real module
-            real_time = time
-            fake_time_mod.time = real_time.time
-            fake_time_mod.strftime = real_time.strftime
-            fake_time_mod.localtime = real_time.localtime
 
             # Run the loop. Expect either:
             #   - the loop exits cleanly under a back-off path (PASS), or
@@ -358,7 +361,8 @@ class TestR2_HardThresholdZeroByteLoop(unittest.TestCase):
                 # than max_cycles proves the loop bounded itself.
                 self.assertIn(e.code, (0, None, 1, 2), f"unexpected exit code {e.code}")
                 self.assertLess(
-                    len(sleep_calls), max_cycles,
+                    len(sleep_calls),
+                    max_cycles,
                     f"Loop exited but recorded {len(sleep_calls)} sleeps "
                     f"(>= max_cycles={max_cycles}); back-off was ineffective.",
                 )
@@ -412,17 +416,19 @@ class TestR2_HardThresholdZeroByteLoop(unittest.TestCase):
             # signal, or a setup bug. Accept it as PASS only if it carries
             # a message suggesting back-off was the cause.
             msg = str(raised).lower()
-            if not any(kw in msg for kw in ("backoff", "back-off", "stalled", "ineffective", "0 bytes")):
-                self.fail(
-                    f"Unexpected exception (not back-off-related): {raised!r}"
-                )
+            if not any(
+                kw in msg
+                for kw in ("backoff", "back-off", "stalled", "ineffective", "0 bytes")
+            ):
+                self.fail(f"Unexpected exception (not back-off-related): {raised!r}")
 
         # If we got here, raised is None — loop completed cleanly.
         # That's an acceptable post-fix behavior IF the prune count is small.
         self.assertLess(
-            prune_call_count["n"], max_cycles - 5,
+            prune_call_count["n"],
+            max_cycles - 5,
             f"Loop returned cleanly but ran {prune_call_count['n']} prunes "
-            f"— that's the bug (no back-off, no exit, just exhausted sleeps)."
+            f"— that's the bug (no back-off, no exit, just exhausted sleeps).",
         )
 
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -1,0 +1,421 @@
+"""Mechanical reproducers for the 2026-05-18 cozempic guard crash.
+
+Source handoff: /Users/yanisnaamane/sanofi/silc-data/.claude/handoffs/cozempic-guard-crash-2026-05-18.md
+
+Two bugs to reproduce on the current v1.8.11 / main-branch code:
+
+R1 — Process-vs-process daemon race
+    The SessionStart hook fires on both ``startup`` and ``resume`` events. When
+    a HARD-threshold reload kicks in and the resume hook fires from two
+    different angles within ms of each other, two completely separate Python
+    processes call ``start_guard_daemon(session_id=<same uuid>)``. The
+    in-process ``threading.Lock`` in ``_spawn_locks`` does NOT span processes;
+    only the ``O_CREAT|O_EXCL`` race on the pidfile + the on-disk pid-read
+    fallback can prevent a double spawn.
+
+    This test launches TWO ``multiprocessing.Process`` instances synchronized
+    at an ``os.Barrier(2)`` instant and asserts that EXACTLY ONE comes back
+    with ``started=True`` and the other with ``already_running=True``. Loops
+    50× to catch the race window.
+
+R2 — HARD-threshold zero-byte loop
+    When ``guard_prune_cycle`` repeatedly returns ``saved_mb == 0`` (because
+    the live conversation is dominated by immutable tool-result blocks the
+    soft prune cannot touch), the current loop:
+      - prints a warning after 3 consecutive 0-byte hards,
+      - sleeps ``interval * 4`` once,
+      - resets the consecutive counter to 0,
+      - keeps looping at the original 30s interval forever.
+
+    A 20-cycle bounded run with mocked dependencies and a counted
+    ``time.sleep`` proves the loop never exits, never backs off long-term,
+    and never raises a diagnostic exception.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure src/ is importable when run with PYTHONPATH=src
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ---------------------------------------------------------------------------
+# R1: daemon-vs-daemon process-vs-process race
+# ---------------------------------------------------------------------------
+
+
+def _race_worker(
+    barrier_handle,
+    result_queue,
+    session_id: str,
+    cwd: str,
+    worker_index: int,
+) -> None:
+    """Run in a separate process. Wait at the barrier so both processes call
+    ``start_guard_daemon`` at essentially the same instant, then report the
+    result back via the shared queue.
+
+    Heavy-handed mocking is used so the child does NOT actually spawn a guard
+    subprocess — we want to test the pidfile claim contention, not the full
+    daemon lifecycle.
+    """
+    # Re-import in the child (multiprocessing spawn does not inherit imports
+    # in a useful way on macOS).
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+    from unittest.mock import patch as _patch
+
+    from cozempic.guard import start_guard_daemon
+
+    class _DummyProc:
+        # PID range avoids collision with the host process's real PIDs.
+        def __init__(self, pid: int):
+            self.pid = pid
+
+    def _fake_popen(cmd_parts, **kwargs):
+        # The PID we hand back must look unique per worker so the test can
+        # tell which child "won" if both raced through. Use a value that is
+        # extremely unlikely to be a real running PID.
+        fake_pid = 900_000 + worker_index
+        return _DummyProc(fake_pid)
+
+    # Mock subprocess.Popen so no real daemon is spawned, and mock
+    # find_claude_pid so we don't fail when no Claude is running.
+    with (
+        _patch("cozempic.guard.subprocess.Popen", side_effect=_fake_popen),
+        _patch("cozempic.guard.find_claude_pid", return_value=12345),
+        _patch("cozempic.guard._cleanup_legacy_pid"),
+    ):
+        # Barrier sync: both children pile up here and release at the same instant
+        try:
+            barrier_handle.wait(timeout=5.0)
+        except Exception as e:  # BrokenBarrierError or timeout
+            result_queue.put({"error": f"barrier failed: {e!r}", "worker": worker_index})
+            return
+
+        try:
+            r = start_guard_daemon(
+                cwd=cwd,
+                session_id=session_id,
+                threshold_tokens=1000,
+            )
+        except Exception as e:
+            r = {"error": repr(e)}
+
+        r["worker"] = worker_index
+        result_queue.put(r)
+
+
+class TestR1_DaemonProcessRace(unittest.TestCase):
+    """Process-vs-process race on start_guard_daemon for the same session UUID.
+
+    The in-process ``_spawn_locks`` ``threading.Lock`` does NOT span Python
+    processes — only the on-disk pidfile claim does. This test verifies the
+    O_CREAT|O_EXCL claim path holds across process boundaries.
+    """
+
+    # Must match _SESSION_ID_RE = ^[0-9a-f][0-9a-f-]{11,}$  (hex chars + dashes only)
+    SESSION_ID = "abcd1234-5678-9abc-def0-2026051811aa"
+    ITERATIONS = 50
+
+    def setUp(self):
+        # Compute and pre-clean the pidfile + log file for our session.
+        from cozempic.guard import _pid_file_for_session
+
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path = self.pid_path.with_suffix(".log")
+        self.log_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path.unlink(missing_ok=True)
+
+    def _race_once(self) -> list[dict]:
+        """Spawn two processes, sync at a barrier, collect results."""
+        # On macOS the default start method is spawn; force it explicitly so
+        # the test is platform-deterministic.
+        ctx = mp.get_context("spawn")
+
+        barrier = ctx.Barrier(2)
+        result_queue = ctx.Queue()
+
+        # Fresh cwd per iteration so the legacy-pid cleanup path doesn't
+        # interfere across iterations.
+        cwd = os.getcwd()
+
+        procs = [
+            ctx.Process(
+                target=_race_worker,
+                args=(barrier, result_queue, self.SESSION_ID, cwd, i),
+                name=f"race-child-{i}",
+            )
+            for i in range(2)
+        ]
+        for p in procs:
+            p.start()
+
+        # Collect both results
+        results = []
+        for _ in range(2):
+            try:
+                results.append(result_queue.get(timeout=10.0))
+            except Exception as e:
+                results.append({"error": f"queue.get failed: {e!r}"})
+
+        for p in procs:
+            p.join(timeout=5.0)
+            if p.is_alive():
+                p.terminate()
+                p.join(timeout=2.0)
+
+        return results
+
+    def test_two_processes_one_winner(self):
+        """Across ITERATIONS races, every race must produce exactly one
+        ``started=True`` and exactly one ``already_running=True``.
+
+        If either:
+          - both report started=True (double spawn — orphan daemon), or
+          - both report already_running=True (deadlock, no daemon spawned), or
+          - any race throws an unexpected exception,
+        the test fails with the full record so the team-lead can diagnose.
+        """
+        failures = []
+
+        for it in range(self.ITERATIONS):
+            # Clean state before each race
+            self.pid_path.unlink(missing_ok=True)
+            self.log_path.unlink(missing_ok=True)
+
+            results = self._race_once()
+
+            started = [r for r in results if r.get("started") is True]
+            already = [r for r in results if r.get("already_running") is True]
+            errors = [r for r in results if "error" in r]
+
+            if errors or len(started) != 1 or len(already) != 1:
+                failures.append({"iteration": it, "results": results})
+
+        if failures:
+            self.fail(
+                f"Process-vs-process race produced bad outcomes in "
+                f"{len(failures)}/{self.ITERATIONS} iterations.\n"
+                f"First 3 failure records:\n"
+                + "\n".join(repr(f) for f in failures[:3])
+            )
+
+
+# ---------------------------------------------------------------------------
+# R2: HARD-threshold zero-byte loop
+# ---------------------------------------------------------------------------
+
+
+class _StopAfterNSleeps(Exception):
+    """Sentinel raised by the patched time.sleep after N cycles to break the
+    otherwise-infinite guard loop deterministically."""
+
+
+class TestR2_HardThresholdZeroByteLoop(unittest.TestCase):
+    """When guard_prune_cycle keeps returning ``saved_mb == 0`` at the HARD
+    threshold, the loop must NOT silently continue at the original interval
+    forever.
+
+    Acceptable behavior (any one of):
+      a) raise a backoff exception that takes the daemon down cleanly,
+      b) progressively double the sleep interval (exponential backoff),
+      c) exit the loop with a diagnostic message.
+
+    Current v1.8.11 behavior (the bug): logs a warning after 3 consecutive
+    0-byte hards, sleeps ``interval * 4`` ONCE, resets the counter to 0, then
+    keeps looping at the original 30s interval. This test demonstrates the
+    bug by running 20 cycles and showing the loop never exits and the average
+    sleep stays near the original interval.
+    """
+
+    def test_loop_does_not_back_off_under_sustained_zero_byte_hards(self):
+        from cozempic import guard as guard_mod
+
+        # ---- Per-cycle bookkeeping ----------------------------------------
+        sleep_calls: list[float] = []
+        max_cycles = 20
+        interval = 30  # The default in production
+
+        # ---- Patched time.sleep -------------------------------------------
+        # Records every sleep; raises _StopAfterNSleeps after max_cycles so
+        # the test terminates. Returns immediately (no real sleep) so the
+        # test runs in <1s.
+        def fake_sleep(duration: float) -> None:
+            sleep_calls.append(float(duration))
+            if len(sleep_calls) >= max_cycles:
+                raise _StopAfterNSleeps(
+                    f"Guard loop did not back off / exit after {max_cycles} "
+                    f"cycles of 0-byte HARD prunes. Recorded sleeps: {sleep_calls}"
+                )
+
+        # ---- Fake session path + minimal session sidecar -------------------
+        import tempfile
+        from pathlib import Path as _P
+
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmpdir, ignore_errors=True))
+        session_path = _P(tmpdir) / "fake_session.jsonl"
+        session_path.write_text('{"type":"user","message":{"content":"hi"}}\n')
+
+        fake_session = {"session_id": "fake-r2-uuid-2026-05-18", "path": session_path}
+
+        # ---- Fake state object (looks like TeamState) ----------------------
+        class _FakeState:
+            subagents = []
+            tasks = []
+            message_count = 0
+
+            def is_empty(self):
+                return True
+
+        # ---- Mock guard_prune_cycle: ALWAYS returns 0 bytes freed ---------
+        prune_call_count = {"n": 0}
+
+        def fake_prune_cycle(**kwargs):
+            prune_call_count["n"] += 1
+            return {
+                "saved_mb": 0.0,  # critical: the bug condition
+                "original_tokens": 600_000,
+                "final_tokens": 600_000,
+                "team_name": None,
+                "team_messages": 0,
+                "checkpoint_path": None,
+                "backup_path": None,
+                "reloading": False,
+            }
+
+        # ---- Mock quick_token_estimate: ALWAYS above HARD threshold ------
+        # threshold_tokens=500_000, return 600_000 so HARD branch fires every cycle.
+        def fake_quick_token_estimate(_p):
+            return 600_000
+
+        # ---- Mock the assorted infrastructure called by start_guard -------
+        # checkpoint_team returns the fake state; load_messages returns []
+        # so detect_context_window can run; record_session is a no-op.
+        with (
+            patch.object(guard_mod, "time") as fake_time_mod,
+            patch.object(guard_mod, "_resolve_session_by_id", return_value=fake_session),
+            patch.object(guard_mod, "find_current_session", return_value=fake_session),
+            patch.object(guard_mod, "find_claude_pid", return_value=None),
+            patch.object(guard_mod, "checkpoint_team", return_value=_FakeState()),
+            patch.object(guard_mod, "guard_prune_cycle", side_effect=fake_prune_cycle),
+            patch.object(guard_mod, "quick_token_estimate", side_effect=fake_quick_token_estimate),
+            patch.object(guard_mod, "load_messages", return_value=[]),
+            patch("cozempic.session.record_session"),
+            patch.object(guard_mod, "_cleanup_stale_watchers"),
+            patch.object(guard_mod, "ping_install_if_new"),
+            patch.object(guard_mod, "maybe_auto_update"),
+            patch.object(guard_mod, "cleanup_old_backups"),
+            patch("cozempic.tokens.detect_context_window", return_value=1_000_000),
+        ):
+            # Wire time.sleep on the module reference (start_guard uses ``time.sleep``)
+            fake_time_mod.sleep.side_effect = fake_sleep
+            # time.time/etc are also used by _now; route through the real module
+            real_time = time
+            fake_time_mod.time = real_time.time
+            fake_time_mod.strftime = real_time.strftime
+            fake_time_mod.localtime = real_time.localtime
+
+            # Run the loop. Expect either:
+            #   - the loop exits cleanly under a back-off path (PASS), or
+            #   - it raises _StopAfterNSleeps because it ran max_cycles
+            #     without exiting (FAIL — the bug).
+            raised = None
+            try:
+                guard_mod.start_guard(
+                    cwd=tmpdir,
+                    threshold_mb=100.0,
+                    soft_threshold_mb=50.0,
+                    rx_name="standard",
+                    interval=interval,
+                    auto_reload=False,  # don't try to kill Claude
+                    reactive=False,  # don't spin up the watcher thread
+                    threshold_tokens=500_000,
+                    soft_threshold_tokens=250_000,
+                    session_id="fake-r2-uuid-2026-05-18",
+                )
+            except _StopAfterNSleeps as e:
+                raised = e
+            except SystemExit as e:
+                # Acceptable: guard.start_guard could exit cleanly with a diagnostic
+                self.assertNotEqual(e.code, 0, "Loop must NOT exit silently with 0")
+                return  # PASS — exit-with-diagnostic counts as a back-off behavior
+            except Exception as e:
+                raised = e
+
+        # ---- RED assertions (desired behavior; current v1.8.11 FAILS) ----
+        # Acceptable post-fix behavior (any of):
+        #   (a) the loop raises a backoff exception → captured in `raised`
+        #       as something OTHER than _StopAfterNSleeps,
+        #   (b) the loop exponentially backs off → recorded sleeps grow
+        #       monotonically over time, so the average late-cycle sleep
+        #       is much larger than the original interval,
+        #   (c) the loop exits cleanly with a diagnostic → SystemExit was
+        #       raised above and we returned early.
+        #
+        # The current v1.8.11 bug: loop keeps firing at 30s with only a
+        # one-shot 4×interval pause every 3 cycles, then resets the counter.
+        # This test FAILS RED under that behavior.
+
+        if isinstance(raised, _StopAfterNSleeps):
+            # Loop never exited. Check whether back-off happened.
+            # True back-off: late-cycle sleeps should be MUCH larger than
+            # early-cycle sleeps. Compare last quarter vs first quarter average.
+            n = len(sleep_calls)
+            if n < 8:
+                self.fail(
+                    f"Loop did not back off (only {n} cycles recorded — "
+                    f"too few to be a real back-off)."
+                )
+            first_q = sleep_calls[: n // 4]
+            last_q = sleep_calls[-(n // 4) :]
+            avg_first = sum(first_q) / len(first_q)
+            avg_last = sum(last_q) / len(last_q)
+
+            self.fail(
+                "Guard loop kept firing HARD prunes at the original interval "
+                "with no real back-off. Bug present.\n"
+                f"  prune_calls={prune_call_count['n']}\n"
+                f"  total_cycles={n}\n"
+                f"  first-quarter avg sleep={avg_first:.1f}s  "
+                f"last-quarter avg sleep={avg_last:.1f}s\n"
+                f"  (true exponential back-off would push last-quarter avg "
+                f"to >> {interval}s)\n"
+                f"  sleeps={sleep_calls}"
+            )
+
+        if raised is not None and not isinstance(raised, _StopAfterNSleeps):
+            # A different exception bubbled out — could be a real backoff
+            # signal, or a setup bug. Accept it as PASS only if it carries
+            # a message suggesting back-off was the cause.
+            msg = str(raised).lower()
+            if not any(kw in msg for kw in ("backoff", "back-off", "stalled", "ineffective", "0 bytes")):
+                self.fail(
+                    f"Unexpected exception (not back-off-related): {raised!r}"
+                )
+
+        # If we got here, raised is None — loop completed cleanly.
+        # That's an acceptable post-fix behavior IF the prune count is small.
+        self.assertLess(
+            prune_call_count["n"], max_cycles - 5,
+            f"Loop returned cleanly but ran {prune_call_count['n']} prunes "
+            f"— that's the bug (no back-off, no exit, just exhausted sleeps)."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -351,8 +351,17 @@ class TestR2_HardThresholdZeroByteLoop(unittest.TestCase):
             except _StopAfterNSleeps as e:
                 raised = e
             except SystemExit as e:
-                # Acceptable: guard.start_guard could exit cleanly with a diagnostic
-                self.assertNotEqual(e.code, 0, "Loop must NOT exit silently with 0")
+                # Acceptable: guard.start_guard exits cleanly after detecting
+                # sustained 0-byte HARDs and emitting a diagnostic. The handoff
+                # specifies sys.exit(0) — what matters is that the loop did NOT
+                # silently iterate forever. Any number of sleeps strictly fewer
+                # than max_cycles proves the loop bounded itself.
+                self.assertIn(e.code, (0, None, 1, 2), f"unexpected exit code {e.code}")
+                self.assertLess(
+                    len(sleep_calls), max_cycles,
+                    f"Loop exited but recorded {len(sleep_calls)} sleeps "
+                    f"(>= max_cycles={max_cycles}); back-off was ineffective.",
+                )
                 return  # PASS — exit-with-diagnostic counts as a back-off behavior
             except Exception as e:
                 raised = e

--- a/tests/test_hook_idempotency_shell.py
+++ b/tests/test_hook_idempotency_shell.py
@@ -17,6 +17,7 @@ This is the test the 2026-05-18 crash report asked for explicitly:
   > concurrently with the same SESSION_ID and counts the spawned daemons
   > — must be <= 1.
 """
+
 import json
 import os
 import shutil
@@ -27,7 +28,6 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS_JSON = REPO_ROOT / "src" / "cozempic" / "data" / "hooks.json"
@@ -129,7 +129,9 @@ class TestHookSpawnIdempotency(unittest.TestCase):
             esac
             exit 0
         """))
-        stub_path.chmod(stub_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        stub_path.chmod(
+            stub_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        )
 
         # Neutralize upgrade chain: stub `uv` and `pip` to no-ops so the
         # SessionStart hook's `uv pip install --upgrade cozempic ...` and
@@ -162,12 +164,14 @@ class TestHookSpawnIdempotency(unittest.TestCase):
         # fallback is unreachable. But disabling the cozempic package
         # discovery in PYTHONPATH belt-and-suspenders for hermeticity.
         env["PYTHONPATH"] = ""
-        payload = json.dumps({
-            "session_id": self.session_id,
-            "transcript_path": f"/tmp/{self.session_id}.jsonl",
-            "hook_event_name": "SessionStart",
-            "source": "startup",
-        })
+        payload = json.dumps(
+            {
+                "session_id": self.session_id,
+                "transcript_path": f"/tmp/{self.session_id}.jsonl",
+                "hook_event_name": "SessionStart",
+                "source": "startup",
+            }
+        )
         return subprocess.run(
             ["bash", "-c", hook_cmd],
             input=payload,
@@ -205,13 +209,17 @@ class TestHookSpawnIdempotency(unittest.TestCase):
         """Baseline: one hook fire → one `guard --daemon` spawn."""
         cmd = _load_session_start_command()
         result = self._run_hook_once(cmd)
-        self.assertEqual(result.returncode, 0,
-            f"hook exited non-zero. stderr={result.stderr!r}")
+        self.assertEqual(
+            result.returncode, 0, f"hook exited non-zero. stderr={result.stderr!r}"
+        )
         self._wait_for_background_subshells()
         spawns = self._count_daemon_spawns()
-        self.assertEqual(spawns, 1,
+        self.assertEqual(
+            spawns,
+            1,
             f"Expected exactly 1 daemon spawn on cold start, got {spawns}. "
-            f"Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}")
+            f"Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}",
+        )
 
     def test_concurrent_fires_spawn_at_most_one(self):
         """The 2026-05-18 crash signature: two SessionStart hooks fire 2 ms
@@ -220,22 +228,32 @@ class TestHookSpawnIdempotency(unittest.TestCase):
         env = os.environ.copy()
         env["PATH"] = f"{self.stub_bin_dir}:{env.get('PATH', '')}"
         env["PYTHONPATH"] = ""
-        payload = json.dumps({
-            "session_id": self.session_id,
-            "transcript_path": f"/tmp/{self.session_id}.jsonl",
-            "hook_event_name": "SessionStart",
-            "source": "resume",
-        })
+        payload = json.dumps(
+            {
+                "session_id": self.session_id,
+                "transcript_path": f"/tmp/{self.session_id}.jsonl",
+                "hook_event_name": "SessionStart",
+                "source": "resume",
+            }
+        )
         # Fire two processes nearly simultaneously. We start both then wait
         # for both to return; the hook backgrounds its subshell so the parent
         # bash exits quickly (~50 ms).
         p1 = subprocess.Popen(
-            ["bash", "-c", cmd], stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True,
+            ["bash", "-c", cmd],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
         )
         p2 = subprocess.Popen(
-            ["bash", "-c", cmd], stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True,
+            ["bash", "-c", cmd],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
         )
         p1.communicate(payload, timeout=30)
         p2.communicate(payload, timeout=30)
@@ -243,12 +261,15 @@ class TestHookSpawnIdempotency(unittest.TestCase):
         self.assertEqual(p2.returncode, 0)
         self._wait_for_background_subshells()
         spawns = self._count_daemon_spawns()
-        self.assertLessEqual(spawns, 1,
+        self.assertLessEqual(
+            spawns,
+            1,
             f"Concurrent SessionStart fires spawned {spawns} daemons for "
             f"session {self.session_id} (expected <=1). "
             f"This is the bug from /tmp/cozempic_guard_c492ae5e-971.log "
             f"where two `--- Guard daemon started ---` lines appeared 2 ms apart. "
-            f"Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}")
+            f"Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}",
+        )
 
     def test_fast_path_skips_spawn_when_pid_file_live(self):
         """If the guard PID file already points to a live process for THIS
@@ -280,11 +301,14 @@ class TestHookSpawnIdempotency(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
             self._wait_for_background_subshells()
             spawns = self._count_daemon_spawns()
-            self.assertEqual(spawns, 0,
+            self.assertEqual(
+                spawns,
+                0,
                 f"Expected 0 daemon spawns when PID file points to live process, "
                 f"got {spawns}. The fast-path is broken — every SessionStart will "
                 f"redundantly respawn the daemon, defeating the v7 idempotency "
-                f"contract. Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}")
+                f"contract. Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}",
+            )
         finally:
             sleeper.terminate()
             try:

--- a/tests/test_hook_idempotency_shell.py
+++ b/tests/test_hook_idempotency_shell.py
@@ -1,0 +1,298 @@
+"""Shell-level idempotency test for the SessionStart hook command.
+
+Fires the canonical SessionStart hook command twice concurrently with the
+same SESSION_ID and counts how many `cozempic guard --daemon ...` spawns
+actually happen. The contract introduced in hook-schema v7 is: at most ONE
+spawn per session, regardless of how many concurrent SessionStart hook fires
+the harness produces (resume + auto-compact + clear can all race).
+
+Validation strategy: replace the real `cozempic` binary on $PATH with a
+counter stub that logs every invocation to a file, then drive the hook
+command twice in parallel. After both finish, assert the stub recorded
+`guard --daemon` AT MOST ONCE for the test session.
+
+This is the test the 2026-05-18 crash report asked for explicitly:
+
+  > Validate: write a tiny shell test that fires the hook command twice
+  > concurrently with the same SESSION_ID and counts the spawned daemons
+  > — must be <= 1.
+"""
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_JSON = REPO_ROOT / "src" / "cozempic" / "data" / "hooks.json"
+
+
+def _load_session_start_command() -> str:
+    hooks = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+    return hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+
+class TestHookSpawnIdempotency(unittest.TestCase):
+    """Drive the real SessionStart command twice concurrently with the same
+    SESSION_ID and verify only one `guard --daemon` spawn lands.
+
+    Uses a stub `cozempic` binary that:
+      - prints a fixed version on `--version` so the upgrade short-circuits
+      - records every invocation (with all args) to a log file
+      - on `guard --daemon`, writes a PID file the way the real binary would
+        (so a second concurrent run sees the fast-path)
+      - exits 0 immediately (no actual daemon backgrounding)
+
+    The test isolates everything in a tmpdir; nothing touches real /tmp
+    PID files or the user's installed cozempic.
+    """
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="cozempic_hook_idem_"))
+        # A real-looking lowercase UUID. The 12-char prefix the PID-file uses
+        # is deterministic; we use one we can assert against.
+        self.session_id = "abcdef01-2345-4678-9abc-deadbeefcafe"
+        self.sid12 = self.session_id[:12]  # "abcdef01-234"
+        # Per-test isolated TMPDIR so /tmp/cozempic_guard_* paths created
+        # by the hook go into this dir, not the real /tmp.
+        self.fake_tmp = self.tmpdir / "tmp"
+        self.fake_tmp.mkdir()
+        # We *cannot* redirect the hook's hard-coded "/tmp/cozempic_guard_..."
+        # path via $TMPDIR (the hook string is literal "/tmp/..."). So we use
+        # a unique session_id whose first-12 chars are unlikely to collide
+        # with any real session on this host, and we clean up after.
+        self.pid_file = Path(f"/tmp/cozempic_guard_{self.sid12}.pid")
+        self.hook_lock = Path(f"/tmp/cozempic_hook_{self.sid12}.lock")
+        for p in (self.pid_file, self.hook_lock):
+            if p.exists():
+                p.unlink()
+
+        self.invocation_log = self.tmpdir / "invocations.log"
+        self.stub_bin_dir = self.tmpdir / "bin"
+        self.stub_bin_dir.mkdir()
+        self._install_stub_cozempic()
+
+    def tearDown(self):
+        self._kill_pid_file_daemon()
+        for p in (self.pid_file, self.hook_lock):
+            if p.exists():
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _install_stub_cozempic(self):
+        """Drop a fake `cozempic` executable in self.stub_bin_dir.
+
+        Records every call's argv into invocation_log. On `guard --daemon`
+        and `guard --reload-self`, spawns a long-lived sleeper subprocess
+        and writes ITS pid to the PID file — mimicking the real daemon
+        whose PID file points to a process that stays alive. Without this,
+        the fast-path's `kill -0` would always see the stub's own pid
+        (already exited by then) and decide the daemon is dead.
+
+        Also stubs `uv` and `pip` so the upgrade chain is a no-op (otherwise
+        the chain would attempt a real pip install of cozempic, polluting
+        the host environment and slowing the test).
+        """
+        stub_path = self.stub_bin_dir / "cozempic"
+        stub_path.write_text(textwrap.dedent(f"""\
+            #!/usr/bin/env bash
+            # Log every invocation with PID + args. Append is atomic for
+            # short writes on POSIX so concurrent stub calls don't garble.
+            printf '%s\\n' "$$ $*" >> {self.invocation_log!s}
+            case "$1" in
+              --version)
+                echo "cozempic 99.0.0"
+                ;;
+              guard)
+                if [[ "$2" == "--daemon" || "$2" == "--reload-self" ]]; then
+                  # Spawn a long-lived sleeper so the PID file points to a
+                  # process that's still alive when the next hook fires.
+                  # Redirect stdio so the sleep survives parent exit; nohup
+                  # so it isn't reaped by SIGHUP when the calling subshell
+                  # closes. macOS lacks setsid in /usr/bin, so don't use it.
+                  nohup sleep 30 </dev/null >/dev/null 2>&1 &
+                  printf '%s' "$!" > {self.pid_file!s}
+                fi
+                ;;
+              *)
+                : # checkpoint/remind/digest/etc: no-op
+                ;;
+            esac
+            exit 0
+        """))
+        stub_path.chmod(stub_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        # Neutralize upgrade chain: stub `uv` and `pip` to no-ops so the
+        # SessionStart hook's `uv pip install --upgrade cozempic ...` and
+        # `pip install --upgrade cozempic ...` fallback don't actually touch
+        # the host Python. Both succeed silently → the PRE/POST version
+        # check sees PRE == POST (both "99.0.0") → reload-self is skipped.
+        for name in ("uv", "pip"):
+            stub = self.stub_bin_dir / name
+            stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+            stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    def _kill_pid_file_daemon(self):
+        """Reap the sleeper subprocess that backs the PID file, if any."""
+        if not self.pid_file.exists():
+            return
+        try:
+            pid = int(self.pid_file.read_text().strip())
+            os.kill(pid, 9)
+        except (ValueError, ProcessLookupError, OSError):
+            pass
+
+    def _run_hook_once(self, hook_cmd: str) -> subprocess.CompletedProcess:
+        """Pipe a synthetic SessionStart payload into the hook command."""
+        env = os.environ.copy()
+        # Put the stub bin FIRST on PATH so `cozempic` resolves to it.
+        env["PATH"] = f"{self.stub_bin_dir}:{env.get('PATH', '')}"
+        # Prevent the hook from calling out to a real Python `cozempic` install
+        # via the python3 -m fallback. The python3 fallback runs only when
+        # the bare `cozempic` call fails; our stub always succeeds, so the
+        # fallback is unreachable. But disabling the cozempic package
+        # discovery in PYTHONPATH belt-and-suspenders for hermeticity.
+        env["PYTHONPATH"] = ""
+        payload = json.dumps({
+            "session_id": self.session_id,
+            "transcript_path": f"/tmp/{self.session_id}.jsonl",
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        })
+        return subprocess.run(
+            ["bash", "-c", hook_cmd],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+    def _count_daemon_spawns(self) -> int:
+        if not self.invocation_log.exists():
+            return 0
+        spawns = 0
+        for line in self.invocation_log.read_text().splitlines():
+            # Format: "<pid> <args...>"
+            args = line.split(None, 1)[1] if " " in line else ""
+            if args.startswith("guard --daemon"):
+                spawns += 1
+        return spawns
+
+    def _wait_for_background_subshells(self):
+        """The hook backgrounds the upgrade+daemon subshell with `&`. Give it
+        time to complete + write its PID file before we count."""
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            time.sleep(0.2)
+            if self.invocation_log.exists():
+                # Wait for the log to stop growing (proxy for subshells done)
+                size = self.invocation_log.stat().st_size
+                time.sleep(0.5)
+                if self.invocation_log.stat().st_size == size:
+                    return
+
+    def test_single_invocation_spawns_one_daemon(self):
+        """Baseline: one hook fire → one `guard --daemon` spawn."""
+        cmd = _load_session_start_command()
+        result = self._run_hook_once(cmd)
+        self.assertEqual(result.returncode, 0,
+            f"hook exited non-zero. stderr={result.stderr!r}")
+        self._wait_for_background_subshells()
+        spawns = self._count_daemon_spawns()
+        self.assertEqual(spawns, 1,
+            f"Expected exactly 1 daemon spawn on cold start, got {spawns}. "
+            f"Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}")
+
+    def test_concurrent_fires_spawn_at_most_one(self):
+        """The 2026-05-18 crash signature: two SessionStart hooks fire 2 ms
+        apart for the same SESSION_ID. v7 contract: net spawn count <= 1."""
+        cmd = _load_session_start_command()
+        env = os.environ.copy()
+        env["PATH"] = f"{self.stub_bin_dir}:{env.get('PATH', '')}"
+        env["PYTHONPATH"] = ""
+        payload = json.dumps({
+            "session_id": self.session_id,
+            "transcript_path": f"/tmp/{self.session_id}.jsonl",
+            "hook_event_name": "SessionStart",
+            "source": "resume",
+        })
+        # Fire two processes nearly simultaneously. We start both then wait
+        # for both to return; the hook backgrounds its subshell so the parent
+        # bash exits quickly (~50 ms).
+        p1 = subprocess.Popen(
+            ["bash", "-c", cmd], stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True,
+        )
+        p2 = subprocess.Popen(
+            ["bash", "-c", cmd], stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True,
+        )
+        p1.communicate(payload, timeout=30)
+        p2.communicate(payload, timeout=30)
+        self.assertEqual(p1.returncode, 0)
+        self.assertEqual(p2.returncode, 0)
+        self._wait_for_background_subshells()
+        spawns = self._count_daemon_spawns()
+        self.assertLessEqual(spawns, 1,
+            f"Concurrent SessionStart fires spawned {spawns} daemons for "
+            f"session {self.session_id} (expected <=1). "
+            f"This is the bug from /tmp/cozempic_guard_c492ae5e-971.log "
+            f"where two `--- Guard daemon started ---` lines appeared 2 ms apart. "
+            f"Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}")
+
+    def test_fast_path_skips_spawn_when_pid_file_live(self):
+        """If the guard PID file already points to a live process for THIS
+        session, the hook MUST NOT spawn another daemon. This is the
+        narrow contract: an external `guard --daemon` (or a survivor from
+        a prior reload-self) leaves a healthy PID; the next SessionStart
+        respects it.
+
+        Plants a long-lived sleeper as the "existing daemon" rather than
+        the pytest PID. Using pytest's own PID risks the subprocess.run
+        hanging on pipe-inheritance (the backgrounded hook subshell sees
+        pytest as its parent group leader and keeps stdio descriptors open
+        until pytest itself exits — a classic POSIX subprocess gotcha).
+        A standalone sleeper is reaped in tearDown so it doesn't leak.
+        """
+        # Spawn an actual sleeper to back the PID file. setsid would be ideal
+        # but macOS lacks /usr/bin/setsid, so use Popen with start_new_session.
+        sleeper = subprocess.Popen(
+            ["sleep", "60"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            self.pid_file.write_text(str(sleeper.pid))
+            cmd = _load_session_start_command()
+            result = self._run_hook_once(cmd)
+            self.assertEqual(result.returncode, 0)
+            self._wait_for_background_subshells()
+            spawns = self._count_daemon_spawns()
+            self.assertEqual(spawns, 0,
+                f"Expected 0 daemon spawns when PID file points to live process, "
+                f"got {spawns}. The fast-path is broken — every SessionStart will "
+                f"redundantly respawn the daemon, defeating the v7 idempotency "
+                f"contract. Log: {self.invocation_log.read_text() if self.invocation_log.exists() else '(empty)'}")
+        finally:
+            sleeper.terminate()
+            try:
+                sleeper.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                sleeper.kill()
+                sleeper.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_id_parity.py
+++ b/tests/test_session_id_parity.py
@@ -1,0 +1,127 @@
+"""Bash↔Python slug parity regression test for C2 (DA round 1 finding).
+
+C2 was: the bash hook sanitiser and Python ``_pid_file_for_session``
+accepted different character sets for ``session_id``. Non-UUID inputs
+would compute one path in bash and a different one (or ValueError) in
+Python → silent guard disablement.
+
+Round-3 fix per code-auditor's Option B sign-off: relax Python's
+``_SESSION_ID_RE`` from ``^[0-9a-f][0-9a-f-]{11,}$`` to
+``^[a-z0-9][a-z0-9_-]{11,}$``. This matches the char-class of the bash
+sanitiser ``re.sub(r'[^a-z0-9_-]','_', s.lower())`` AND
+``reload_lock._slug_for``/``spawn_lock._slug_for``.
+
+This test pins the parity contract: for a fixed set of synthetic
+session_ids representative of UUIDs, non-hex names, underscores, mixed
+case, etc., the bash sanitiser's first-12-chars output MUST equal the
+slug Python derives via ``_pid_file_for_session``. If either side
+regresses to a stricter or laxer char class, this test fails.
+
+Test set chosen to cover:
+- canonical UUIDs (the production case)
+- non-hex letters (`t`, `g`, `z` — would have been rejected pre-Option-B)
+- underscores (allowed in both)
+- mixed case (lowercased by both)
+- short suffix (≥12 chars is the only length constraint after truncation)
+
+Inputs that should be REJECTED by both (leading dash, too short, special
+chars) are covered elsewhere — see
+``test_guard_hardening.py::TestPolishV2_SessionIdRegexRequiresHexFirstChar``.
+This file is solely about parity on ACCEPTED inputs.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _bash_slug(session_id: str) -> str:
+    """Pure-Python mirror of the bash SessionStart hook's slug logic.
+
+    Bash hook does:
+        SESSION_ID=$(python3 -c "
+            import sys, json, re
+            s = json.load(sys.stdin).get('session_id','').lower()
+            print(re.sub(r'[^a-z0-9_-]', '_', s))
+        ")
+        GUARD_PID_FILE="/tmp/cozempic_guard_${SESSION_ID:0:12}.pid"
+
+    So the bash slug is: ``re.sub(r'[^a-z0-9_-]', '_', s.lower())[:12]``.
+    """
+    return re.sub(r"[^a-z0-9_-]", "_", session_id.lower())[:12]
+
+
+class TestSessionIdSlugParity(unittest.TestCase):
+    """C2 parity regression: bash slug == Python slug for every valid input."""
+
+    # Synthetic test set per code-auditor's spec (with two extras for
+    # underscore + mixed-case coverage).
+    PARITY_INPUTS = [
+        "5d53e013-32d9-4e72-9a3a-deadbeefcafe",     # canonical UUID
+        "deadbeef-cafe-1234-5678-abcdef012345",     # another canonical
+        "test-session-id-long-enough",              # non-hex letters
+        "abc_123_def_456789",                       # underscore in body
+        "Test-Session-Id-Mixed-Case-Long",          # mixed case → lower
+        "z9z9z9z9z9z9z9z9z9z9",                     # non-hex 'z' repeats
+        "0123456789ab",                             # exactly 12 chars
+    ]
+
+    def test_bash_python_slug_parity(self):
+        from cozempic.guard import _pid_file_for_session
+
+        failures = []
+        for sid in self.PARITY_INPUTS:
+            bash_slug = _bash_slug(sid)
+            try:
+                python_path = _pid_file_for_session(sid)
+            except ValueError as exc:
+                failures.append(
+                    f"{sid!r} → bash slug={bash_slug!r}, "
+                    f"Python REJECTED ({exc!s})"
+                )
+                continue
+            python_slug = (
+                python_path.name
+                .removeprefix("cozempic_guard_")
+                .removesuffix(".pid")
+            )
+            if bash_slug != python_slug:
+                failures.append(
+                    f"{sid!r} → bash={bash_slug!r} python={python_slug!r}"
+                )
+
+        if failures:
+            self.fail(
+                "Bash↔Python slug divergence (C2 regression).\n"
+                "If you tightened Python's _SESSION_ID_RE or the bash "
+                "sanitiser, both sides must change together.\n"
+                "Failures:\n  " + "\n  ".join(failures)
+            )
+
+    def test_uuid_canonical_unchanged(self):
+        """Canonical UUID inputs (the production case) must produce a slug
+        that's just the first 12 chars of the lowercased UUID — no
+        substitution should fire for any character."""
+        from cozempic.guard import _pid_file_for_session
+
+        for sid in (
+            "5d53e013-32d9-4e72-9a3a-deadbeefcafe",
+            "5D53E013-32D9-4E72-9A3A-DEADBEEFCAFE",  # uppercase variant
+        ):
+            python_path = _pid_file_for_session(sid)
+            self.assertEqual(
+                python_path.name,
+                "cozempic_guard_5d53e013-32d.pid",
+                f"Canonical UUID slug regressed for {sid!r}: got {python_path.name!r}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -1,0 +1,863 @@
+"""Tests for the cross-process daemon spawn lock.
+
+Companion to ``test_guard_race_2026_05_18.py::TestR1_*`` (the original RED
+test). These tests pin down:
+
+  - Three-process contention (extends R1's two-process race).
+  - The "no placeholder PID 0 ever visible" invariant — closes Bug 3.
+  - FileNotFoundError recovery on the log file open path.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _race_worker(
+    barrier_handle,
+    result_queue,
+    session_id: str,
+    cwd: str,
+    worker_index: int,
+):
+    """Mirror of the R1 worker — fakes Popen + claude-pid so the test stays
+    on the spawn-lock contract, not the daemon lifecycle."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+    from unittest.mock import patch as _patch
+
+    from cozempic.guard import start_guard_daemon
+
+    class _DummyProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+    def _fake_popen(cmd_parts, **kwargs):
+        return _DummyProc(900_000 + worker_index)
+
+    with (
+        _patch("cozempic.guard.subprocess.Popen", side_effect=_fake_popen),
+        _patch("cozempic.guard.find_claude_pid", return_value=12345),
+        _patch("cozempic.guard._cleanup_legacy_pid"),
+    ):
+        try:
+            barrier_handle.wait(timeout=10.0)
+        except Exception as e:
+            result_queue.put(
+                {"error": f"barrier failed: {e!r}", "worker": worker_index}
+            )
+            return
+
+        try:
+            r = start_guard_daemon(
+                cwd=cwd,
+                session_id=session_id,
+                threshold_tokens=1000,
+            )
+        except Exception as e:
+            r = {"error": repr(e)}
+        r["worker"] = worker_index
+        result_queue.put(r)
+
+
+class TestThreeProcessContention(unittest.TestCase):
+    """Three processes race for the same session — exactly ONE must win."""
+
+    SESSION_ID = "fade1234-5678-9abc-def0-2026051811cc"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path = self.pid_path.with_suffix(".log")
+        self.log_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path.unlink(missing_ok=True)
+
+    def test_three_process_contention(self):
+
+        ctx = mp.get_context("spawn")
+        N = 3
+        ITERATIONS = 20
+        cwd = os.getcwd()
+
+        failures = []
+        for it in range(ITERATIONS):
+            self.pid_path.unlink(missing_ok=True)
+            self.log_path.unlink(missing_ok=True)
+
+            barrier = ctx.Barrier(N)
+            queue = ctx.Queue()
+            procs = [
+                ctx.Process(
+                    target=_race_worker,
+                    args=(barrier, queue, self.SESSION_ID, cwd, i),
+                    name=f"race-3-{i}",
+                )
+                for i in range(N)
+            ]
+            for p in procs:
+                p.start()
+
+            results = []
+            for _ in range(N):
+                try:
+                    results.append(queue.get(timeout=15.0))
+                except Exception as e:
+                    results.append({"error": f"queue.get failed: {e!r}"})
+            for p in procs:
+                p.join(timeout=5.0)
+                if p.is_alive():
+                    p.terminate()
+                    p.join(timeout=2.0)
+
+            started = [r for r in results if r.get("started") is True]
+            already = [r for r in results if r.get("already_running") is True]
+
+            if len(started) != 1 or len(already) != (N - 1):
+                failures.append({"iteration": it, "results": results})
+
+        if failures:
+            self.fail(
+                f"3-process race produced bad outcomes in "
+                f"{len(failures)}/{ITERATIONS} iterations. "
+                f"First 2: {failures[:2]!r}"
+            )
+
+
+class TestV4TenProcessContention(unittest.TestCase):
+    """V4 regression: 10 contending processes × 30 iterations.
+
+    The V4 stress (race-reproducer, 2026-05-18) exposed the original
+    ``fcntl.flock`` implementation's unlink-on-release race: peers that
+    O_CREAT'd new inodes after the holder's unlink got flocks on
+    different kernel objects and both proceeded to spawn. The fix replaces
+    flock with ``O_CREAT|O_EXCL`` on the PID file directly — POSIX
+    guarantees exactly one winner per file create.
+
+    This test is heavier than ``TestThreeProcessContention`` (10 procs ×
+    30 iter ≈ 8s on a healthy laptop) and serves as the per-PR regression
+    gate for any change to spawn_lock.py or start_guard_daemon.
+    """
+
+    SESSION_ID = "feedbeef-1234-5678-9abc-2026051811ff"
+    N = 10
+    ITERATIONS = 30
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path = self.pid_path.with_suffix(".log")
+        self.log_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+
+    def test_ten_process_contention_30x(self):
+        ctx = mp.get_context("spawn")
+        cwd = os.getcwd()
+
+        failures = []
+        for it in range(self.ITERATIONS):
+            self.pid_path.unlink(missing_ok=True)
+            self.log_path.unlink(missing_ok=True)
+
+            barrier = ctx.Barrier(self.N)
+            queue = ctx.Queue()
+            procs = [
+                ctx.Process(
+                    target=_race_worker,
+                    args=(barrier, queue, self.SESSION_ID, cwd, i),
+                    name=f"v4-{i}",
+                )
+                for i in range(self.N)
+            ]
+            for p in procs:
+                p.start()
+
+            results = []
+            for _ in range(self.N):
+                try:
+                    results.append(queue.get(timeout=20.0))
+                except Exception as e:
+                    results.append({"error": f"queue.get: {e!r}"})
+            for p in procs:
+                p.join(timeout=5.0)
+                if p.is_alive():
+                    p.terminate()
+                    p.join(timeout=2.0)
+
+            started = [r for r in results if r.get("started") is True]
+            already = [r for r in results if r.get("already_running") is True]
+            undefined = [
+                r
+                for r in results
+                if r.get("started") is not True and r.get("already_running") is not True
+            ]
+
+            if len(started) != 1 or len(already) != (self.N - 1) or undefined:
+                failures.append(
+                    {
+                        "iter": it,
+                        "started_count": len(started),
+                        "already_count": len(already),
+                        "undefined_count": len(undefined),
+                        "started_workers": [r.get("worker") for r in started],
+                        "first_undefined": undefined[0] if undefined else None,
+                    }
+                )
+
+        if failures:
+            self.fail(
+                f"V4 stress (10p × {self.ITERATIONS}it) produced "
+                f"{len(failures)}/{self.ITERATIONS} bad outcomes. "
+                f"First 3: {failures[:3]!r}"
+            )
+
+
+class TestNoPlaceholderPidVisible(unittest.TestCase):
+    """The pidfile must NEVER hold '0' between any two reads — closes Bug 3.
+
+    After the v1.8.14 refactor the file is created via atomic-rename, so
+    only "no file" or "file with real PID > 0" should ever be observable.
+    """
+
+    SESSION_ID = "babe1234-5678-9abc-def0-2026051811dd"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path = self.pid_path.with_suffix(".log")
+        self.log_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+
+    def test_no_placeholder_pid_ever_visible(self):
+        """Run start_guard_daemon while a tight reader loop observes the
+        pidfile. Any observation of '0' is a Bug 3 regression."""
+        from cozempic.guard import start_guard_daemon
+
+        observed_values: list[str] = []
+        stop = {"flag": False}
+
+        def reader():
+            while not stop["flag"]:
+                try:
+                    if self.pid_path.exists():
+                        observed_values.append(self.pid_path.read_text().strip())
+                except OSError:
+                    pass
+
+        import threading
+
+        t = threading.Thread(target=reader, daemon=True)
+        t.start()
+
+        with (
+            patch("cozempic.guard.subprocess.Popen") as mock_popen,
+            patch("cozempic.guard.find_claude_pid", return_value=12345),
+            patch("cozempic.guard._cleanup_legacy_pid"),
+        ):
+            mock_popen.return_value.pid = 88888
+            result = start_guard_daemon(
+                cwd=os.getcwd(),
+                session_id=self.SESSION_ID,
+                threshold_tokens=1000,
+            )
+
+        # Let the reader catch the post-spawn state too
+        time.sleep(0.05)
+        stop["flag"] = True
+        t.join(timeout=1.0)
+
+        self.assertTrue(result.get("started"), f"spawn failed: {result!r}")
+        # The reader may have caught the file empty or with the real PID, but
+        # NEVER with "0".
+        self.assertNotIn(
+            "0",
+            observed_values,
+            f"Placeholder PID 0 observed on disk — Bug 3 regression. "
+            f"Observations: {observed_values[:10]}",
+        )
+
+
+class TestFreshWindowEnvVarClamping(unittest.TestCase):
+    """DA round 3 N2 regression test: the ``COZEMPIC_PIDFILE_FRESH_SECONDS``
+    env var must be clamped to ``(0, _FRESH_MAX]``. Operator typos like
+    ``inf``, ``1e10``, ``-1``, ``0``, ``NaN``, or non-numeric junk must
+    fall back to the default rather than silently disabling staleness
+    recovery (an inf/1e10 fresh window would treat ANY pidfile as fresh
+    forever; a 0/negative window would never classify anything fresh).
+    """
+
+    ENV_VAR = "COZEMPIC_PIDFILE_FRESH_SECONDS"
+
+    def _reload_with_env(self, value):
+        """Set or unset the env var, reload spawn_lock, and return the
+        active _FRESH_PIDFILE_SECONDS value."""
+        import importlib
+
+        import cozempic.spawn_lock as sl
+
+        prior = os.environ.get(self.ENV_VAR)
+        try:
+            if value is None:
+                os.environ.pop(self.ENV_VAR, None)
+            else:
+                os.environ[self.ENV_VAR] = value
+            importlib.reload(sl)
+            return sl._FRESH_PIDFILE_SECONDS
+        finally:
+            # Restore prior env state so other tests aren't affected.
+            if prior is None:
+                os.environ.pop(self.ENV_VAR, None)
+            else:
+                os.environ[self.ENV_VAR] = prior
+            importlib.reload(sl)
+
+    def test_env_var_clamps_inf(self):
+        """``inf`` is not finite → must fall back to default. Without the
+        clamp, an inf fresh window would treat every pidfile as fresh
+        forever — peer-claim recovery would never fire."""
+        from cozempic.spawn_lock import _DEFAULT_FRESH
+
+        for val in ("inf", "Infinity", "-inf", "1e400"):  # 1e400 → inf
+            with self.subTest(value=val):
+                self.assertEqual(
+                    self._reload_with_env(val), _DEFAULT_FRESH,
+                    f"{val!r} should clamp to _DEFAULT_FRESH",
+                )
+
+    def test_env_var_clamps_zero_and_negative(self):
+        """``0``, ``-1``, ``-100`` are <=0 → must fall back to default.
+        Without the clamp, a 0/negative fresh window would never classify
+        anything as fresh, defeating the peer-protection window."""
+        from cozempic.spawn_lock import _DEFAULT_FRESH
+
+        for val in ("0", "0.0", "-1", "-100", "-0.001"):
+            with self.subTest(value=val):
+                self.assertEqual(
+                    self._reload_with_env(val), _DEFAULT_FRESH,
+                    f"{val!r} should clamp to _DEFAULT_FRESH",
+                )
+
+    def test_env_var_clamps_above_max(self):
+        """Values > _FRESH_MAX (300s) must clamp to default. Reason:
+        legitimate slow-Popen scenarios live well under 5 minutes; values
+        higher are almost certainly typos (e.g. ``COZEMPIC_PIDFILE_FRESH_SECONDS=300000``
+        meaning "1e10 ns" or similar) that would let stale pidfiles from
+        crashed prior spawns block new ones for hours."""
+        from cozempic.spawn_lock import _DEFAULT_FRESH, _FRESH_MAX
+
+        for val in (str(_FRESH_MAX + 1), "1e10", "999999"):
+            with self.subTest(value=val):
+                self.assertEqual(
+                    self._reload_with_env(val), _DEFAULT_FRESH,
+                    f"{val!r} should clamp to _DEFAULT_FRESH",
+                )
+
+    def test_env_var_nan_clamps(self):
+        """``nan`` is not finite per IEEE-754 → must fall back to default."""
+        from cozempic.spawn_lock import _DEFAULT_FRESH
+
+        self.assertEqual(
+            self._reload_with_env("nan"), _DEFAULT_FRESH,
+            "nan should clamp to _DEFAULT_FRESH",
+        )
+
+    def test_env_var_garbage_clamps(self):
+        """Non-numeric junk (``abc``, empty-after-strip, mixed) → default."""
+        from cozempic.spawn_lock import _DEFAULT_FRESH
+
+        for val in ("abc", "5seconds", "five", "  "):
+            with self.subTest(value=val):
+                self.assertEqual(
+                    self._reload_with_env(val), _DEFAULT_FRESH,
+                    f"{val!r} should clamp to _DEFAULT_FRESH",
+                )
+
+    def test_env_var_valid_value_respected(self):
+        """A value in the allowed (0, _FRESH_MAX] range must be honored
+        unchanged. This is the happy path operators rely on for slow CI."""
+        for val in ("1", "10", "30", "300", "0.1"):
+            with self.subTest(value=val):
+                self.assertEqual(
+                    self._reload_with_env(val), float(val),
+                    f"{val!r} should be respected as-is",
+                )
+
+    def test_env_var_unset_uses_default(self):
+        """No env var set → default applies (regression check on the
+        ``raw is None`` branch)."""
+        from cozempic.spawn_lock import _DEFAULT_FRESH
+
+        self.assertEqual(self._reload_with_env(None), _DEFAULT_FRESH)
+
+
+class TestSymlinkDefense(unittest.TestCase):
+    """Round-3 C1 regression test: the post-Popen ``.pid.tmp`` write must
+    NOT follow symlinks. A local user with write access to ``/tmp`` (a
+    real condition on shared dev boxes / CI runners) could pre-plant
+    ``/tmp/cozempic_guard_<sid12>.pid.tmp`` as a symlink to ``~/.zshrc``
+    or ``~/.ssh/authorized_keys``; the prior ``Path.write_text`` followed
+    the symlink and overwrote the target with the PID number.
+
+    Post-fix the write uses ``os.open(O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW)``,
+    which:
+      - rejects symlinks with ``OSError`` (ELOOP on Linux, EEXIST on macOS
+        since O_EXCL fires first when the path exists at all)
+      - rejects pre-existing regular files too (orphan ``.pid.tmp`` from
+        a crashed prior spawn)
+      - leaves the victim file untouched in both cases
+    """
+
+    SESSION_ID = "ca7ec0de-1234-5678-9abc-2026051811f0"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.tmp_pid_path = self.pid_path.with_suffix(".pid.tmp")
+        self.log_path = self.pid_path.with_suffix(".log")
+        # Clean slate
+        for p in (self.pid_path, self.tmp_pid_path, self.log_path):
+            try:
+                p.unlink()
+            except (FileNotFoundError, OSError):
+                pass
+        # Victim file lives in a separate tmpdir so the test doesn't
+        # depend on any real file in /tmp.
+        import tempfile
+
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="cozempic_symlink_test_"))
+        self.victim = self.tmpdir / "victim.txt"
+        self.victim.write_text("ORIGINAL\n", encoding="utf-8")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        for p in (self.pid_path, self.tmp_pid_path, self.log_path):
+            try:
+                p.unlink()
+            except (FileNotFoundError, OSError):
+                pass
+
+    def test_pid_tmp_write_rejects_symlink(self):
+        """Attacker pre-plants .pid.tmp as a symlink to a victim file.
+        The post-Popen atomic-rename write path MUST refuse it and leave
+        the victim untouched."""
+        from unittest.mock import patch
+
+        from cozempic.guard import start_guard_daemon
+
+        # Plant the symlink BEFORE start_guard_daemon runs.
+        os.symlink(str(self.victim), str(self.tmp_pid_path))
+        self.assertTrue(
+            self.tmp_pid_path.is_symlink(),
+            "test setup failed: symlink not in place",
+        )
+
+        class _DummyProc:
+            def __init__(self, pid):
+                self.pid = pid
+
+        with (
+            patch(
+                "cozempic.guard.subprocess.Popen",
+                side_effect=lambda *a, **k: _DummyProc(99999),
+            ),
+            patch("cozempic.guard.find_claude_pid", return_value=12345),
+            patch("cozempic.guard._cleanup_legacy_pid"),
+        ):
+            result = start_guard_daemon(
+                cwd=str(self.tmpdir),
+                session_id=self.SESSION_ID,
+                threshold_tokens=1000,
+            )
+
+        # The spawn body raised OSError on the os.open(O_EXCL|O_NOFOLLOW)
+        # and surfaced a structured failure (started=False, reason="pidfile:
+        # ..."). The DaemonSpawnClaim's __exit__ unlinked the parent-PID
+        # claim file we wrote at _claim time (handed_off=False).
+        self.assertFalse(
+            result.get("started"),
+            f"Spawn should have FAILED — symlink defense breached. " f"Got: {result!r}",
+        )
+        self.assertIn(
+            "reason",
+            result,
+            f"Failure path must carry a structured reason; got {result!r}",
+        )
+        # CRITICAL: the victim file must be untouched.
+        self.assertEqual(
+            self.victim.read_text(encoding="utf-8"),
+            "ORIGINAL\n",
+            "Victim file was overwritten — C1 symlink TOCTOU regression. "
+            "The .pid.tmp write must use O_NOFOLLOW (or fail closed on "
+            "EEXIST when the path already exists, which O_EXCL guarantees).",
+        )
+
+
+class TestFileNotFoundErrorRecovery(unittest.TestCase):
+    """If the log file's parent dir vanishes mid-spawn, the daemon must
+    recover with one retry — not crash the SessionStart hook."""
+
+    SESSION_ID = "feed1234-5678-9abc-def0-2026051811ee"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path = self.pid_path.with_suffix(".log")
+        self.log_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+        self.log_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+
+    def test_filenotfounderror_recovery(self):
+        """First open(log_file) raises FileNotFoundError, second succeeds."""
+        from cozempic.guard import start_guard_daemon
+
+        # We track open() calls on the log_file path; the FIRST call raises,
+        # the rest are passed through. Mock os.makedirs to confirm the retry
+        # path is taken.
+        real_open = open
+        call_state = {"n": 0}
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == str(self.log_path):
+                call_state["n"] += 1
+                if call_state["n"] == 1:
+                    raise FileNotFoundError(2, "No such file or directory", str(path))
+            return real_open(path, *args, **kwargs)
+
+        with (
+            patch("cozempic.guard.subprocess.Popen") as mock_popen,
+            patch("cozempic.guard.find_claude_pid", return_value=12345),
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("builtins.open", side_effect=fake_open),
+            patch("cozempic.guard.os.makedirs") as mock_makedirs,
+        ):
+            mock_popen.return_value.pid = 77777
+            result = start_guard_daemon(
+                cwd=os.getcwd(),
+                session_id=self.SESSION_ID,
+                threshold_tokens=1000,
+            )
+
+        self.assertTrue(
+            result.get("started"),
+            f"Daemon failed to recover from missing log dir: {result!r}",
+        )
+        self.assertEqual(
+            call_state["n"],
+            2,
+            "Expected exactly 2 open() calls on log file (1 fail + 1 retry); "
+            f"got {call_state['n']}.",
+        )
+        mock_makedirs.assert_called_once()
+
+
+class TestDaemonSpawnLockUnit(unittest.TestCase):
+    """Direct contract tests on the spawn_lock module."""
+
+    def test_lock_yields_path(self):
+        """Post-V4-rework: the spawn claim writes to the .pid file directly
+        (the PID file IS the lock, no separate sentinel). This pins that
+        contract."""
+        from cozempic.spawn_lock import daemon_spawn_lock
+
+        sid = "deadbeef-1234-5678-9abc-de00deadbeef"
+        with daemon_spawn_lock(sid) as lock_path:
+            self.assertIsInstance(lock_path, Path)
+            self.assertIn("cozempic_guard_", lock_path.name)
+            self.assertTrue(
+                lock_path.name.endswith(".pid"),
+                f"V4 rework: claim path must be the .pid file, got {lock_path.name}",
+            )
+
+    def test_double_acquire_raises(self):
+        """A second concurrent acquire MUST raise DaemonAlreadyStarting."""
+        from cozempic.spawn_lock import DaemonAlreadyStarting, daemon_spawn_lock
+
+        sid = "deadbeef-1234-5678-9abc-de00cafebabe"
+        with daemon_spawn_lock(sid):
+            with self.assertRaises(DaemonAlreadyStarting):
+                with daemon_spawn_lock(sid):
+                    pass
+
+    def test_release_allows_reacquire(self):
+        """After the first lock exits, a fresh acquire succeeds."""
+        from cozempic.spawn_lock import daemon_spawn_lock
+
+        sid = "deadbeef-1234-5678-9abc-de00f00dbabe"
+        with daemon_spawn_lock(sid):
+            pass
+        # Should not raise
+        with daemon_spawn_lock(sid):
+            pass
+
+
+class TestC2_SlugConvergence(unittest.TestCase):
+    """Round-3 C2 regression test: the bash hook session-id sanitizer and the
+    Python ``_pid_file_for_session`` validator MUST agree on every input —
+    same accept/reject decision, and same 12-char slug when accepted.
+
+    The post-Round-3 implementer's intent (per commit e124614 message and
+    the Option-B path agreed with team-lead + code-auditor) was to
+    converge by RELAXING Python rather than tightening bash. Today:
+
+      - bash:   ``re.sub(r'[^a-z0-9_-]', '_', s.lower())`` then ``[:12]``
+                (always returns a slug; non-``[a-z0-9_-]`` chars become ``_``)
+      - python: ``re.fullmatch(r'^[a-z0-9][a-z0-9_-]{11,}$', s.lower())``
+                (rejects if shape doesn't match; raises ValueError)
+
+    These two procedures CONVERGE on inputs already in the ``[a-z0-9_-]``
+    alphabet (≥12 chars, alphanumeric first char) and DIVERGE on inputs
+    containing other characters (bash substitutes to ``_``, Python rejects).
+    This test pins BOTH halves of the contract so any future drift in
+    either side surfaces immediately.
+    """
+
+    @staticmethod
+    def _bash_hook_slug(session_id: str) -> str:
+        """Reproduce the bash hook's actual Python one-liner verbatim:
+
+            s = json.load(sys.stdin).get('session_id','').lower()
+            print(re.sub(r'[^a-z0-9_-]', '_', s))
+
+        Then the shell takes ``${SESSION_ID:0:12}`` as the slug. So the
+        composite contract is: lowercase → sub non-``[a-z0-9_-]`` with
+        ``_`` → take first 12 chars. Always returns a string (possibly
+        empty if input is empty); the shell's ``[ -n "$SESSION_ID" ]``
+        gate is what skips the spawn for empty inputs.
+        """
+        import re
+
+        s = (session_id or "").lower()
+        return re.sub(r"[^a-z0-9_-]", "_", s)[:12]
+
+    @staticmethod
+    def _python_slug(session_id: str) -> str | None:
+        """Reproduce the Python validator's accept/reject contract:
+
+        _pid_file_for_session raises ValueError on bad shape; the
+        caller-facing ``_is_guard_running_for_session`` catches that
+        and returns None. We report None ↔ ValueError, else the
+        12-char prefix that ends up in the pid path.
+        """
+        from cozempic.guard import _pid_file_for_session
+
+        try:
+            p = _pid_file_for_session(session_id)
+        except ValueError:
+            return None
+        # Path is /tmp/cozempic_guard_<sid12>.pid — extract sid12.
+        name = p.name
+        prefix = "cozempic_guard_"
+        suffix = ".pid"
+        self_assert_invariant = name.startswith(prefix) and name.endswith(suffix)
+        assert self_assert_invariant, f"unexpected pid path shape: {name!r}"
+        return name[len(prefix) : -len(suffix)]
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Inputs in the SHARED alphabet (alphanumeric + `_` + `-`, leading
+    # alphanumeric, ≥12 chars). For these, bash and python MUST produce
+    # the SAME 12-char slug. Any divergence here is a real C2 regression.
+    # ─────────────────────────────────────────────────────────────────────
+    SHARED_ALPHABET_TABLE = [
+        # (description, session_id, expected_slug)
+        ("canonical uuid v4", "aabbccdd-1122-4455-8899-2026051811bb", "aabbccdd-112"),
+        (
+            "uppercase uuid → lowercased",
+            "AABBCCDD-1122-4455-8899-2026051811BB",
+            "aabbccdd-112",
+        ),
+        ("hex-only minimum length (12)", "0123456789ab", "0123456789ab"),
+        ("hex-only longer", "0123456789abcdef", "0123456789ab"),
+        # `_` is in the shared alphabet — bash accepts and python accepts.
+        ("underscores (in shared alphabet)", "abcd_1234_5678", "abcd_1234_56"),
+        # Leading alphanumeric is required by Python; bash's `[:12]` would
+        # still produce a slug here but it would be a leading-dash slug that
+        # collides with truncation of unrelated inputs (the dash-collision
+        # security property pinned by TestPolishV2_SessionIdRegexRequiresHexFirstChar).
+        # So a leading-dash input goes in the DIVERGENT_TABLE below, not here.
+    ]
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Inputs OUTSIDE the shared alphabet. The Round-3 implementer chose
+    # NOT to fully converge: bash produces a slug (substitutes non-alphabet
+    # chars with `_`), Python raises ValueError. This table documents the
+    # accepted divergence so a future change that ACCIDENTALLY converges
+    # one way without the other is detected. The test asserts the CURRENT
+    # asymmetry holds — if both sides flip to accept-or-reject this needs
+    # an explicit update + a team-lead review.
+    # ─────────────────────────────────────────────────────────────────────
+    DIVERGENT_TABLE = [
+        # (description, session_id, expected_bash_slug, expected_python_slug_or_None)
+        (
+            "contains slash (path traversal attempt)",
+            "abcd/1234/5678",
+            "abcd_1234_56",
+            None,
+        ),
+        (
+            "contains dot (extension attempt)",
+            "abcd.1234.5678",
+            "abcd_1234_56",
+            None,
+        ),
+        ("contains space", "abcd 1234 5678", "abcd_1234_56", None),
+        # Uppercase letters that are NOT hex digits get lowercased first by
+        # bash, so they're already valid lowercase alphanumeric and python
+        # accepts them too (post-Round-3 relaxation). Confirm.
+        ("uppercase Z lowercased to z", "abcdef1234ZZ", "abcdef1234zz", "abcdef1234zz"),
+        ("uppercase G lowercased to g", "abcdef1234GG", "abcdef1234gg", "abcdef1234gg"),
+        ("starts with dash (anchor violation)", "-abcdef123456", "-abcdef12345", None),
+        ("path traversal ..", "../etc/passwd", "___etc_passw", None),
+        ("absolute path", "/etc/passwd00", "_etc_passwd0", None),
+        ("non-ascii unicode", "abcdefÿ12345678", "abcdef_12345", None),
+    ]
+
+    # Inputs that BOTH sides effectively reject (bash via the empty-string
+    # gate `[ -n "$SESSION_ID" ]`, python via ValueError).
+    BOTH_REJECT_TABLE = [
+        ("empty string", "", "", None),  # bash returns "" → fails -n gate
+        ("too short (11 chars)", "0123456789a", "0123456789a", None),
+        ("just one char", "a", "a", None),
+    ]
+
+    def test_shared_alphabet_inputs_produce_same_slug(self):
+        """For inputs in the shared alphabet, bash and python MUST produce
+        byte-equal slugs. Divergence here = C2 regression."""
+        divergences = []
+        for desc, sid, expected in self.SHARED_ALPHABET_TABLE:
+            bash_out = self._bash_hook_slug(sid)
+            py_out = self._python_slug(sid)
+            if bash_out != py_out or py_out != expected:
+                divergences.append(
+                    {
+                        "desc": desc,
+                        "input": sid,
+                        "bash": bash_out,
+                        "python": py_out,
+                        "expected": expected,
+                    }
+                )
+        if divergences:
+            self.fail(
+                f"C2 regression in SHARED alphabet ({len(divergences)}/"
+                f"{len(self.SHARED_ALPHABET_TABLE)}):\n"
+                + "\n".join(repr(d) for d in divergences)
+            )
+
+    def test_divergent_inputs_match_current_round3_intent(self):
+        """For inputs outside the shared alphabet, the Round-3 fix-pack
+        deliberately keeps bash substituting (→ slug) while python rejects
+        (→ ValueError). Pin that contract so a future tightening of bash
+        OR loosening of python OR drift in either is caught explicitly.
+        Any change here requires a team-lead review of the security
+        implications.
+        """
+        divergences = []
+        for desc, sid, expected_bash, expected_py in self.DIVERGENT_TABLE:
+            bash_out = self._bash_hook_slug(sid)
+            py_out = self._python_slug(sid)
+            if bash_out != expected_bash or py_out != expected_py:
+                divergences.append(
+                    {
+                        "desc": desc,
+                        "input": sid,
+                        "bash": bash_out,
+                        "expected_bash": expected_bash,
+                        "python": py_out,
+                        "expected_python": expected_py,
+                    }
+                )
+        if divergences:
+            self.fail(
+                f"DIVERGENT-table contract drift ({len(divergences)}/"
+                f"{len(self.DIVERGENT_TABLE)}):\n"
+                + "\n".join(repr(d) for d in divergences)
+            )
+
+    def test_both_reject_table(self):
+        """Inputs both bash (via empty-string gate) and python (via
+        ValueError) reject. Bash returns a substring; python returns None."""
+        divergences = []
+        for desc, sid, expected_bash, expected_py in self.BOTH_REJECT_TABLE:
+            bash_out = self._bash_hook_slug(sid)
+            py_out = self._python_slug(sid)
+            if bash_out != expected_bash or py_out != expected_py:
+                divergences.append(
+                    {
+                        "desc": desc,
+                        "input": sid,
+                        "bash": bash_out,
+                        "expected_bash": expected_bash,
+                        "python": py_out,
+                        "expected_python": expected_py,
+                    }
+                )
+        if divergences:
+            self.fail(
+                f"BOTH-REJECT contract drift ({len(divergences)}/"
+                f"{len(self.BOTH_REJECT_TABLE)}):\n"
+                + "\n".join(repr(d) for d in divergences)
+            )
+
+    def test_real_hook_json_carries_expected_sanitizer(self):
+        """Drift-detection: read the actual hooks.json shipped in the package
+        and assert the bash side still uses the substitute-pattern
+        ``re.sub(r'[^a-z0-9_-]', '_', s.lower())``. If a future commit
+        retightens bash to use re.match instead, the DIVERGENT_TABLE
+        contract above will silently change shape — this assertion catches
+        the drift at the source-of-truth level.
+        """
+        # cozempic.data is a namespace package — __file__ is None.
+        # Use cozempic.__file__ then walk to the sibling data/ dir.
+        import cozempic
+
+        hooks_path = Path(cozempic.__file__).parent / "data" / "hooks.json"
+        self.assertTrue(
+            hooks_path.exists(),
+            f"hooks.json not found at {hooks_path}",
+        )
+        body = hooks_path.read_text(encoding="utf-8")
+        self.assertIn(
+            r"re.sub(r'[^a-z0-9_-]','_',s)",
+            body,
+            "hooks.json bash sanitiser drifted away from the documented "
+            "substitute-pattern. Re-check Round-3 C2 contract and update "
+            "DIVERGENT_TABLE expectations.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes a 2026-05-18 cozempic guard crash that killed a live Claude Code session via two compounding bugs at the 55% HARD threshold:

- **HARD-loop reload cascade**: when soft prune cannot reduce a context dominated by live tool-result blocks (subagent transcripts), `guard_prune_cycle` returns `saved_bytes=0` indefinitely. Existing mitigation (4× pause every 3 cycles, then counter reset) is not a real back-off — production log shows **265 cycles over 5h21m** (`/tmp/cozempic_guard_5d53e013-32d.log`), the daemon never gives up.
- **Daemon-vs-daemon spawn race**: `start_guard_daemon`'s in-process `threading.Lock` does not span subprocess boundaries. When two SessionStart hooks (resume + auto-compact, or upgrade-chain re-fire) call `cozempic guard --daemon` within milliseconds, both pass the pidfile check, both fork, both Popen. Production crash log shows **2 daemons started 2 ms apart for the same session UUID, same `--claude-pid`** (`/tmp/cozempic_guard_c492ae5e-971.log`).

Both bugs are independent of Wave 1 (v1.8.12 atomic-write hardening) and Wave 2 (v1.8.13 `_ReloadLock`) which target different concurrency surfaces (reload-vs-reload cascade, not daemon-vs-daemon spawn).

Reported and reproduced by independent BMAD investigation team: code audit + log forensics across 43 `/tmp/cozempic_guard_*.log` files + pytest RED reproducers + adversarial review (3 rounds, 14 findings across CRIT/HIGH/MED/LOW, all CRIT closed before submission).

## Fix

### 1. HARD-threshold reload loop bound (`fix(guard): bound HARD-threshold reload loop`)
- Module constants in `guard.py`: `HARD_LOOP_BACKOFF_START=3`, `HARD_LOOP_BACKOFF_CAP_SECONDS=300`, `HARD_LOOP_EXIT_THRESHOLD=10`.
- Exponential back-off: `K < 3` → original interval. `K ≥ 3` → `min(interval * 2 ** (K-2), cap)`. `K ≥ 10` → `sys.exit(0)` with final checkpoint + honest diagnostic ("NO further guard protection in this session. SessionStart fires only on startup/resume/clear, NOT on tool calls or message turns").
- Counter resets to 0 on any prune that frees > 0 bytes.
- Tests: `tests/test_guard_hard_loop_backoff.py` (5 cases pin curve, exit threshold, counter reset, cap).

### 2. Cross-process daemon spawn lock (`fix(guard): cross-process daemon spawn lock via O_CREAT|O_EXCL on PID file`)
- New `src/cozempic/spawn_lock.py` with `DaemonSpawnClaim` context manager using POSIX `O_CREAT|O_EXCL|O_NOFOLLOW` atomic claim on the PID file itself (no separate sentinel — eliminates a flock-unlink race we discovered during validation).
- 5-second freshness gate via `_FRESH_PIDFILE_SECONDS` constant (overrideable by `COZEMPIC_PIDFILE_FRESH_SECONDS` env, clamped to `(0, 300]`).
- Loser path: read existing PID + return `DaemonAlreadyStarting(holder_pid=<real_pid>)`. Caller surfaces `{started: False, already_running: True, pid: <real-live-pid>}` — no `pid=0` undefined state ever observed.
- Symlink TOCTOU defense: `.pid.tmp` write also uses `O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW` (`Path.write_text` follows symlinks — exploitable on any multi-user box per /tmp).
- Atomic real-PID write via `temp + rename` (POSIX atomic, same FS). Broad `except Exception` cleanup of `.pid.tmp` on SIGINT or unexpected failures (not just OSError).
- Bug 1 in-process `threading.Lock` retained as documented fast-path; cross-process flock is now the authoritative gate.
- Tests: `tests/test_spawn_lock.py` (15+ cases including 10-process × 30-iteration stress, no-placeholder-PID-visible, FileNotFoundError recovery, symlink-defense regression).

### 3. Idempotent SessionStart hook template (`fix(hooks): idempotent SessionStart guard daemon spawn`)
- `src/cozempic/data/hooks.json` v6 → v7 schema bump (forces re-init via existing `_maybe_auto_init` on next cozempic subcommand).
- Shell-level fast-path: `if [ -f $GUARD_PID_FILE ] && kill -0 "$(cat ...)" 2>/dev/null; then : ; else <spawn> ; fi`. Skips Python entirely when a healthy daemon exists for the session.
- Permissive slug sanitiser kept for codebase consistency with `reload_lock._slug_for`. Python `_SESSION_ID_RE` relaxed to `^[a-z0-9][a-z0-9_-]{11,}$` to match (preserves dash-collision security via leading-alphanumeric anchor).
- Bash↔Python parity proven by `tests/test_session_id_parity.py`.
- Tests: `tests/test_hook_idempotency_shell.py` (concurrent hook fires assert ≤1 daemon spawned).

## Tests

`PYTHONPATH=src python3 -m pytest tests/ -q --ignore=tests/test_model_detection.py`
**750 passed, 5 subtests passed** (was 608 pre-fix; +142 new tests across 7 new + several modified files).

V4 stress (10 concurrent processes × 30 iterations × 3 runs = **900 single-winner trials, 0 multi-winner**). Cumulative across all rework iterations: ~1900 race trials, 0 failures.

Live smoke: 6:07 elapsed real `cozempic guard --daemon` with new v7 hooks. Exactly 1 `Guard daemon started` line, 0 `Prune deferred — lock held` cascades, clean `Signal 15` shutdown.

C1 symlink TOCTOU PoC: pre-plant symlink at `.pid.tmp` → `~/.zshrc`, attempt spawn, victim file unchanged, daemon refuses with structured failure.

## Adversarial review

3 rounds of independent adversarial review by a dedicated devil's-advocate agent (BMAD protocol). All 3 CRIT and all 7 HIGH findings closed before submission. Remaining MED/LOW deferred as separate follow-ups.

## Test plan

- [ ] `git fetch && git checkout this-branch && PYTHONPATH=src python3 -m pytest tests/ -q --ignore=tests/test_model_detection.py` → 750 passed
- [ ] `cozempic guard --daemon --session <test-uuid> --cwd /tmp/smoke-test` → verify exactly 1 `Guard daemon started` line in log
- [ ] Spike a guard session past 55% with mocked 0-byte prune → verify exit after K=10 cycles with diagnostic, not infinite loop
- [ ] Two concurrent `start_guard_daemon` calls (same session_id) → verify exactly 1 winner, other returns `already_running=True` with real PID (not 0)
- [ ] Verify `cozempic init` upgrades v6 → v7 hook on existing installs without breaking

## Scope

- Zero new required dependencies (`fcntl` is POSIX stdlib, graceful no-op on Windows).
- 608 pre-existing tests remain GREEN (no regression).
- Backward-compatible with v1.8.13 reload_lock and Wave 1 atomic-write hardening — orthogonal concerns.
- Hook schema v7 auto-migrates via `_maybe_auto_init` on first cozempic subcommand call post-upgrade.

## Reported by

Crash documented in handoff `cozempic-guard-crash-2026-05-18.md`. Independent multi-agent investigation (code audit + log forensics + race reproducer + hook architect + adversarial reviewer) confirmed root cause + validated fix-pack across 4 implementation iterations.
