### PR TITLE
fix(guard): post-merge polish from PR #92 review — dead code + pidfile leaks + agents-active K=10 + metadata parity

### DIFF
--- a/ADVERSARIAL_REVIEW_pr93.md
+++ b/ADVERSARIAL_REVIEW_pr93.md
@@ -1,0 +1,103 @@
+# Adversarial Review — PR #93 (polish-pr92-followups)
+
+Branch: `fix/guard-polish-pr92-followups`, HEAD `8b1fc39`.
+Reviewer: devil-advocate subagent, round 1.
+Methodology: Read-tool on production source for every claim (per FIX DISCIPLINE rule).
+
+Files read (signals):
+- `src/cozempic/guard.py` (lines 40-90, 360-490, 505-740, 1300-1460, 1690-1810, 1920-2060)
+- `src/cozempic/spawn_lock.py` (full, 443 lines)
+- `src/cozempic/data/hooks.json` (line 9, full payload — diffed against plugin/hooks/hooks.json: identical)
+- `src/cozempic/init.py` (lines 30-150)
+- `src/cozempic/cli.py` (lines 1351-1600, 1603-1660)
+- Cross-tree grep: `_spawn_locks`, `_spawn_locks_mu` (zero hits in `src/`, only docs/tests)
+
+## Round 1 — PR #93 (devil-advocate)
+
+### Verdict: **PASS WITH CONDITIONS**
+
+No CRIT findings. 1 HIGH (operator-noise during v8→v9 hook migration window), 2 MED, 2 LOW. All mitigations exist in adjacent code or are acceptable trade-offs. PR is ship-ready for upstream after addressing **H1** with a docs/changelog note.
+
+### Findings ranked
+
+#### HIGH
+
+**H1 — v8→v9 hook migration window: stale hooks reading 3-line pidfiles**
+
+When v1.8.15 (with PR #93) is installed on an operator whose `.claude/settings.json` still carries v8 hooks (no `v9` marker, no `head -n 1`), the v8 hook executes `kill -0 "$(cat $pid_file)"`. The new daemon writes a 3-line pidfile (`pid\ntimestamp\ninitiator\n`). Bash word-splits `cat`'s output into 3 args → `kill -0 <pid> 2026-05-19T... spawn-claim-daemon`. Bash's `kill` parses `2026-05-19T...` as an integer leading digit and either:
+- exits nonzero (good — hook falls through to spawn fresh, but wastes one cycle re-spawning a duplicate that loses on the spawn_lock O_CREAT|O_EXCL race → DaemonAlreadyStarting → benign)
+- exits zero coincidentally if PID 2026 exists on the host (bad — hook sees "daemon alive" but the wrong PID; next cycle re-checks correctly once `_maybe_auto_init` refreshes the hook on the next CLI call)
+
+The window closes on the first cozempic subcommand invocation post-upgrade (auto-init refreshes to v9). But during that window operators may see one spurious "Cozempic: guard active" message AND one extra subprocess that silently fails the spawn claim. Not a crash, but noisy.
+
+**Severity rationale**: production-visible during upgrade, transient, self-healing, no data loss. Net annoyance ~1 hook fire per session post-upgrade. Acceptable to ship if release notes / CHANGELOG mentions: *"On v1.8.15 upgrade, the first SessionStart after upgrade may produce a duplicate-spawn log line — auto-init refreshes hooks on next cozempic CLI call and resolves this."*
+
+**Recommended action**: add a CHANGELOG line (no code change required). The race-handling in `DaemonSpawnClaim._claim` correctly classifies the duplicate as `DaemonAlreadyStarting` so no double daemon survives.
+
+#### MED
+
+**M1 — CAS in `_safe_unlink_session_pidfile` has TOCTOU between `_pid_file_points_to` and `unlink`**
+
+`guard.py:1404-1408`: the check (`_pid_file_points_to`) and the act (`unlink`) are not atomic. A sister process can `os.rename(tmp, pid_path)` between the check and the unlink, and our `unlink(missing_ok=True)` will destroy their fresh claim.
+
+**Mitigation**: this is the SAME pattern used by `reload_self_daemon` (guard.py:2000, 2007, 2021, 2027) and predates PR #93 — sister-module precedent. The blast radius is bounded: a clobbered pidfile only causes the next operation to spawn cleanly (via spawn_lock's O_CREAT|O_EXCL gate). NOT a regression introduced by PR #93.
+
+**Recommended action**: none for PR #93. File a follow-up to consider `renameat2(RENAME_EXCHANGE)` (Linux) or open(O_EXCL) + compare-then-unlink-by-fd as a hardening pass in a future release. Document the known window in `_safe_unlink_session_pidfile`'s docstring (it acknowledges the CAS pattern but does not name the TOCTOU window).
+
+**M2 — Hard cap of 4.17h may cut some BMAD investigations short**
+
+`HARD_LOOP_HARD_EXIT_THRESHOLD=50 × HARD_LOOP_BACKOFF_CAP_SECONDS=300 = 15,000s = 4.17h` worst case. Real BMAD investigations under heavy debate can run 2-4h; an extreme outlier (multi-round adversarial review with 5+ researchers) could brush 5h. At the hard cap, the daemon exits and the diagnostic explicitly does NOT recommend `/clear` (good — line 684-693 reads correctly: *"Subagents are still active; their state may be lost on the next compaction. Consider letting current subagents finish then starting a fresh session."*).
+
+**Mitigation**: `COZEMPIC_GUARD_HARD_EXIT_K` env var allows ops to lift the cap up to 1000 (≈3.5 days). The cap is the circuit breaker, not the primary design.
+
+**Recommended action**: none for PR #93. The default is correct for 95% of sessions; the env var is documented in the docstring (line 65-67).
+
+#### LOW
+
+**L1 — `_parse_pidfile_pid` does not catch UnicodeDecodeError on malformed UTF-8 pidfile content**
+
+`spawn_lock.py:173`: `content = pid_path.read_text()` uses the locale default encoding. On a pidfile with non-UTF-8 bytes (impossible via cozempic-written content, but possible via filesystem corruption or external write), `UnicodeDecodeError` propagates past the `except OSError`. **No realistic path** — cozempic only writes ASCII digits + ISO timestamps + ASCII initiator strings.
+
+**Recommended action**: add `errors="replace"` to the read_text call OR wrap with `try/except (OSError, UnicodeDecodeError)`. One-line hardening, not a blocker.
+
+**L2 — `_pid_file_points_to` does not re-check freshness**
+
+`guard.py:1935-1952`: returns True if the pidfile contains `expected_pid`, but does not verify the pidfile is still fresh (mtime within the fresh window). In an extreme PID-reuse scenario (our PID dies, kernel recycles it to a different process that happens to also write our PID into the pidfile via stale tmp → impossible without cozempic running there), this could match incorrectly. Theoretical, not practical.
+
+**Recommended action**: none. The PID match is already a strong signal; adding mtime would be defense-in-depth with no realistic attack vector.
+
+### Per-commit closure verdict
+
+| Commit | Verdict | Notes |
+|---|---|---|
+| `c631918` (item #2 + #3) | **PASS** | `_spawn_locks` cleanly removed (verified via grep across full worktree). `_safe_unlink_session_pidfile` correctly wired in `finally:` at guard.py:777-798 covering all 6 exit paths. CAS pattern matches sister-module precedent. |
+| `b8e2c39` (item #5 + N3/M1/M2) | **PASS** | 3-line payload parity confirmed at guard.py:1733-1737 (daemon-write) + spawn_lock.py:369-373 (parent-claim-write). `_parse_pidfile_pid` tolerates 1-line + 3-line. Hook v9 schema applied to both `data/hooks.json` and `plugin/hooks/hooks.json` (diff returns empty). fsync(tmp_fd) + fsync(parent_dir) both present. EACCES → True conservative in `_is_pidfile_fresh`. |
+| `8b1fc39` (item #4 K=10 defer) | **PASS** | Defer logic at guard.py:634-740 correctly distinguishes 3 cases: (a) no-agents → original K=10 exit, (b) agents + K<hard_cap → defer + continue prune cycles, (c) agents + K>=hard_cap → hard-cap exit with non-`/clear` diagnostic. `deferred_exit_announced` one-shot prevents log spam. `COZEMPIC_GUARD_HARD_EXIT_K` clamp at (10, 1000] is correct. |
+| `658063c` (RED tests) | **PASS** (out of scope — test code, not production) |
+| `4195228` (docs) | **PASS** (out of scope) |
+
+### Cross-cutting with 86cb258b investigation
+
+**Confirmed**: PR #93 does NOT solve the transient-daemon reload race surfaced by the 86cb258b investigation. The sequence is unchanged:
+1. Reload chain spawns transient daemon for OLD claude-pid
+2. Transient writes pidfile with OLD session_id slug (matches what the NEW Claude's SessionStart hook will compute, because slug is `_slug_for(session_id)[:12]` and the session_id stays the same across reload)
+3. New Claude's SessionStart fires, sees the transient's pidfile → skips spawn → new Claude UNPROTECTED
+4. Transient eventually exits; with PR #93 c631918 it now CLEANS its pidfile in the `finally` block
+5. New Claude remains unprotected for the rest of its session because SessionStart does not re-fire on activity
+
+**Net effect of PR #93 on 86cb258b bug**: marginal NET-POSITIVE — the pidfile no longer persists indefinitely after the transient dies. A SUBSEQUENT operation (e.g., next manual `cozempic` call, or `_maybe_auto_init` from a daemon-spawning subcommand) can now re-spawn cleanly because the pidfile is gone. But the core bug (the race during reload itself) is untouched.
+
+**Recommendation for PR #94 scope**: the fix for 86cb258b is independent of PR #93's surface and should land separately. The two PRs do not conflict.
+
+### Conditions for PASS
+
+1. **CHANGELOG/release notes mention H1**: one line acknowledging that the v8→v9 hook upgrade may cause one spurious "duplicate spawn skipped" log line on the first SessionStart post-upgrade. No code change required.
+
+2. **Optional follow-up (NOT a PR #93 blocker)**: file a future-release ticket for L1 (UnicodeDecodeError hardening) and M1 (CAS TOCTOU documentation).
+
+### Confidence envelope
+
+- Confidence: 92% — PR #93 is ship-ready pending the H1 changelog note.
+- Signals: Read tool on `src/cozempic/guard.py`, `src/cozempic/spawn_lock.py`, `src/cozempic/data/hooks.json`, `plugin/hooks/hooks.json`, `src/cozempic/init.py`, `src/cozempic/cli.py`. Grep across full worktree for `_spawn_locks` (0 hits in src/, only in docs/tests). Diff between data/hooks.json and plugin/hooks/hooks.json (identical, empty diff). Cross-checked exit-path coverage by enumerating all `sys.exit`, `os._exit` (none), `SystemExit` (raised by sys.exit), `KeyboardInterrupt`, and `break` paths in `start_guard`'s main loop.
+- Cross-checked: all 12 attack vectors from the brief, plus cross-cutting analysis with 86cb258b.
+- Not verified: end-to-end live-daemon test (the 786 pytest + 900/900 V4 stress reports are taken at face value from the validator's claim — I did not re-run them).

--- a/AUDIT_REPORT_pr92_followups.md
+++ b/AUDIT_REPORT_pr92_followups.md
@@ -1,0 +1,795 @@
+# PR #93 Architecture Audit — Junaid PR #92 Followups (items 2-5)
+
+**Worktree:** `.claude/worktrees/polish-pr92-followups`
+**Base:** v1.8.14 (commit `4614f16`, merged 2026-05-19)
+**Author:** architect subagent
+**Date:** 2026-05-19
+**Status:** DESIGN ONLY — no production code modified in this commit.
+
+Scope: items 2-5 from Junaid's review. Item 1 (PR body v6→v7 vs actual v8) is documentation-only and is already captured in `LESSONS_LEARNED.md` (root, local-only); not in scope here.
+
+The audit is grounded in direct `Read` of `src/cozempic/guard.py` (1918 lines), `src/cozempic/spawn_lock.py` (360 lines), `src/cozempic/reload_lock.py` (307 lines), `src/cozempic/session.py:103-141` (`_PruneLock`), `src/cozempic/doctor.py:320-336, 1060-1075` (pidfile readers), and `plugin/hooks/hooks.json:9` (bash hook pidfile reader).
+
+---
+
+## Item #2 — Remove dead `_spawn_locks` dict
+
+### Current state (file:line refs)
+
+`src/cozempic/guard.py:35-36` — module-level state:
+
+```python
+_spawn_locks: dict[str, threading.Lock] = {}
+_spawn_locks_mu = threading.Lock()
+```
+
+`src/cozempic/guard.py:1283-1292` — sole consumer, inside `_is_guard_running_for_session` when the pidfile contains `pid <= 0`:
+
+```python
+with _spawn_locks_mu:
+    lock = _spawn_locks.get(norm_sid)
+if lock is not None and not lock.acquire(blocking=False):
+    # Lock is held → spawner is in-flight; placeholder is live.
+    return None
+if lock is not None:
+    lock.release()
+pid_path.unlink(missing_ok=True)
+return None
+```
+
+**No producer exists in the current tree.** `grep -n '_spawn_locks\[' src/cozempic/` returns zero hits — nothing ever assigns into the dict. Junaid's claim is accurate: this is a consumer branch on a dict that is provably empty for the entire process lifetime. `_spawn_locks.get(norm_sid)` always returns `None`, the `if lock is not None` branches are dead, and the only reachable line is `pid_path.unlink(missing_ok=True)`.
+
+Origin: per `tests/test_guard_race_2026_05_18.py:12,123` comments, an earlier iteration populated `_spawn_locks` inside the in-process spawn path. PR #92 replaced that whole mechanism with the kernel-mediated `DaemonSpawnClaim` (see `spawn_lock.py` module docstring + `guard.py:1466-1471`). The dict was retained "as a fast-path for single-process scenarios" (docstring lines 32-34) but no producer was reinstated, so the consumer is a no-op.
+
+### Proposed change
+
+1. Delete `_spawn_locks` and `_spawn_locks_mu` (lines 29-36, including the 7-line comment block).
+2. In `_is_guard_running_for_session` (lines 1283-1293), collapse the `pid <= 0` branch to:
+
+```python
+if pid <= 0:
+    # Pidfile contains a sentinel/placeholder — treat as stale.
+    # Cross-process freshness is enforced by DaemonSpawnClaim's
+    # O_CREAT|O_EXCL + _FRESH_PIDFILE_SECONDS gate, not by this branch.
+    pid_path.unlink(missing_ok=True)
+    return None
+```
+
+3. Also drop the unused `norm_sid` local at line 1269 if no other use remains. (It's currently only consumed by `_spawn_locks.get(norm_sid)`. Grepping for `norm_sid` confirms — its only reference in this function is the deleted lookup.)
+4. Remove the `threading` import if it becomes unused. `grep -n 'threading' src/cozempic/guard.py` shows two other uses (line 391 — `import threading` for the watcher thread, line 409 — `threading.Thread(...)`), so the top-level import at line 25 **stays**.
+
+Net: ~12 LOC deleted (constants + mu + consumer branch + unused local), no logical behaviour change because the dict is empty.
+
+### Test contract
+
+Single RED → GREEN test in `tests/test_guard_polish_pr93.py`:
+
+`TestPolishPR93_SpawnLocksDictRemoved`:
+- RED: `from cozempic import guard; assert not hasattr(guard, '_spawn_locks')` — currently fails (attr exists).
+- GREEN: after deletion, attribute is gone.
+
+Plus a regression test that `_is_guard_running_for_session` still treats `pid <= 0` as stale and unlinks the file (covers the surviving branch):
+
+`TestPolishPR93_PlaceholderPidIsUnlinked` (extends the existing TestR3_1 pattern from `test_guard_hardening.py:1409`):
+- Set up: write `"0\n"` (or `"-1\n"`) into a freshly-created pidfile, call `_is_guard_running_for_session(sid)`, assert returns `None` AND `pid_path.exists()` is False.
+
+### Risks + mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| External caller relies on `_spawn_locks` symbol | LOW — module-private (`_`-prefixed); grep across `src/`, `tests/`, `plugin/`, `packaging/` shows only the two internal sites + test docstrings | None needed; underscore prefix is the contract. Test docstrings (`test_guard_race_2026_05_18.py:12,123`) describe historical behaviour and don't import the symbol. |
+| In-process race re-introduced | LOW — `DaemonSpawnClaim` is process-level via O_CREAT|O_EXCL on the pidfile, which IS cross-process AND cross-thread atomic on POSIX | The kernel claim subsumes the in-process fast-path entirely; no race surface re-opens. |
+| Tests asserting `_spawn_locks` exists | LOW — `grep '_spawn_locks' tests/` shows only descriptive comments, no `assertEqual`/`hasattr` checks | None needed. |
+
+---
+
+## Item #3 — Pidfile unlink on K=10 + `_graceful_shutdown` exits
+
+### Current state
+
+Exhaustive enumeration of `sys.exit` calls in `guard.py` + `spawn_lock.py` (grep evidence: zero `sys.exit` in spawn_lock.py, three in guard.py):
+
+| File:Line | Caller | Exit code | Pidfile unlinked? |
+|---|---|---|---|
+| `guard.py:340` | `start_guard` — session-not-found early-out | `sys.exit(1)` | YES (line 334: `_pid_file_for_session(session_id).unlink(missing_ok=True)`) |
+| `guard.py:420` | `_graceful_shutdown` — SIGTERM signal handler | `sys.exit(0)` | **NO** ← leak |
+| `guard.py:612` | HARD-loop K=10 voluntary exit | `sys.exit(0)` | **NO** ← leak (new in PR #92) |
+
+`_graceful_shutdown` leak was already known and parked: see `TODO.md:55` ("Post-PR#88 validator findings: `_graceful_shutdown` does NOT unlink pidfile on SIGTERM. Pre-existing, not a regression vs main."). PR #92 added the K=10 path with the same leak, which is exactly the **class-of-bug fold rule violation** the new CLAUDE.md FIX DISCIPLINE explicitly calls out (lines 120-122):
+
+> "PR #92 added a NEW sys.exit(0) path (K=10) without unlinking pidfile, while the pre-existing `_graceful_shutdown` had the same leak. The right call was to fold the 1-line fix into both paths — not introduce a SECOND leak surface while leaving the first."
+
+So this item MUST fix BOTH paths in the same commit per the fold rule.
+
+Why the leak is not catastrophic: next spawn's stale-detection (`DaemonSpawnClaim._claim` → `_is_pidfile_fresh` + alive-PID check at `spawn_lock.py:271-289`) will clean it up. But `/tmp` accumulates one pidfile per dead session until next spawn for that specific session-id slug runs — for long-running operators with hundreds of distinct sessions, this is real cruft. More importantly, `doctor.py` enumerates `/tmp/cozempic_guard_*.pid` (line 322) and any stale entry becomes a confusing "stale pidfile" line in `cozempic doctor` output.
+
+Third path candidate examined and ruled out: `start_guard:332-340` already unlinks BEFORE exit — no fold needed there.
+
+### Proposed change (BOTH exit paths)
+
+**Helper introduction** (avoid two ad-hoc try/except blocks):
+
+Add at module level near `_pid_file_for_session` (~line 1230):
+
+```python
+def _safe_unlink_session_pidfile(session_id: str | None) -> None:
+    """Best-effort pidfile unlink on daemon exit paths.
+
+    Used by every daemon shutdown path (SIGTERM handler, K=10 voluntary
+    exit, future panic exits). Swallows ValueError (malformed session_id)
+    and OSError (pidfile already gone, /tmp unwritable). Never raises —
+    the daemon is mid-shutdown; nothing useful to do on failure.
+
+    Class-of-bug fold (PR #93): consolidates the unlink so adding a new
+    sys.exit path requires touching ONE callsite, not N.
+    """
+    if not session_id:
+        return
+    try:
+        _pid_file_for_session(session_id).unlink(missing_ok=True)
+    except (ValueError, OSError):
+        pass
+```
+
+**Path 1 — `_graceful_shutdown` (line 415-421):**
+
+```python
+def _graceful_shutdown(signum, frame):
+    print(f"\n  [{_now()}] Signal {signum} received — final checkpoint...")
+    checkpoint_team(session_path=session_path, quiet=False)
+    if overflow_watcher:
+        overflow_watcher.stop()
+    _safe_unlink_session_pidfile(sess["session_id"])  # new
+    sys.exit(0)
+```
+
+`sess` is in closure scope from `start_guard` line 330 — accessible.
+
+**Path 2 — K=10 voluntary exit (line 590-612):**
+
+```python
+if consecutive_empty_hard_prunes >= HARD_LOOP_EXIT_THRESHOLD:
+    try:
+        checkpoint_team(session_path=session_path, quiet=True)
+    except Exception:
+        pass
+    print(
+        f"  [{_now()}] Guard powerless against live-context "
+        # ... existing diagnostic message ...
+        flush=True,
+    )
+    _safe_unlink_session_pidfile(sess["session_id"])  # new
+    sys.exit(0)
+```
+
+### Test contract (RED + GREEN)
+
+`tests/test_guard_polish_pr93.py::TestPolishPR93_PidfileUnlinkedOnExit`:
+
+1. **`test_graceful_shutdown_unlinks_pidfile`** — write a fake pidfile via `_pid_file_for_session(sid)`, monkeypatch `checkpoint_team` to no-op, simulate SIGTERM by invoking the registered handler directly (`signal.getsignal(signal.SIGTERM)(15, None)`), catch the `SystemExit`, assert pidfile no longer exists. RED on current `main`.
+
+2. **`test_k10_exit_unlinks_pidfile`** — drive `start_guard` with mocked `guard_prune_cycle` returning `saved_mb=0` ten times, catch `SystemExit(0)`, assert pidfile is gone. RED on current `main`.
+
+3. **`test_safe_unlink_swallows_invalid_session_id`** — call `_safe_unlink_session_pidfile("not-a-uuid")`, assert no exception. Guards against the leak helper itself raising on malformed input during a shutdown path (worst possible time for an exception).
+
+4. **`test_safe_unlink_handles_missing_pidfile`** — call helper when the file doesn't exist, assert no exception (uses `missing_ok=True`).
+
+5. **Regression**: existing `TestPolishPR93_PlaceholderPidIsUnlinked` (item #2 above) must still pass — same path.
+
+### Class-of-bug fold check
+
+Per FIX DISCIPLINE class-of-bug fold rule, before merging I must verify:
+
+**Q: Are there OTHER `sys.exit` / `os._exit` / `raise SystemExit` paths in the daemon process that would leak a pidfile?**
+
+Audit:
+- `guard.py:340` (`start_guard` session-not-found): ALREADY unlinks at line 334. ✅
+- `guard.py:420` (`_graceful_shutdown` SIGTERM): leaks → this PR fixes.
+- `guard.py:612` (K=10 voluntary): leaks → this PR fixes.
+- `spawn_lock.py`: zero `sys.exit` calls. Cleanup is via `__exit__` + `handed_off` flag, not exit.
+- `cli.py`, `overflow.py`, `watcher.py`: not the daemon process — they run in the parent Claude process or threads inside the daemon but don't terminate the daemon.
+
+**Q: Other process-exit paths** (not `sys.exit` but equivalent)?
+
+- KeyboardInterrupt (line 664): currently does NOT unlink. **This is a third leak surface.** Caught only by `cozempic guard` running in foreground (interactive). When the operator hits Ctrl-C on a foreground daemon, pidfile lingers. Lower priority than SIGTERM (SIGTERM is what tools/init systems send; Ctrl-C is rare against a backgrounded daemon) but per the fold rule, **fix in same commit** to avoid leaving the third surface for PR #94.
+- `break` paths inside the main loop (lines 446-447, 467-468, 528, 575): these fall through to the `finally` at line 672 → return from `start_guard` → daemon process terminates with exit 0. Same leak — pidfile is never explicitly unlinked. The `finally` only stops the overflow watcher.
+- `_cleanup_legacy_pid` exception paths: write to legacy CWD-keyed file, not session pidfile — unrelated.
+
+**Decision**: Fold ALL daemon-exit surfaces in this PR. Concretely:
+
+- Add `_safe_unlink_session_pidfile(sess["session_id"])` calls at:
+  - Line 420 (`_graceful_shutdown` before `sys.exit(0)`)
+  - Line 612 (K=10 voluntary exit before `sys.exit(0)`)
+  - Inside the `KeyboardInterrupt` block at line 664 (after the checkpoint)
+  - In the `finally` block at line 672, AFTER the overflow_watcher stop — as the belt-and-braces cleanup so EVERY `break` path is covered
+
+The `finally` cleanup makes the call site list shorter and more defensible — it's the single guaranteed exit path for `start_guard`. With that, the explicit calls at SIGTERM/K=10/KeyboardInterrupt are redundant for normal flow (the finally runs after them), but I keep them anyway because:
+1. `sys.exit(0)` raises `SystemExit`, which DOES trigger the `try/finally` — so the finally WILL run. Verified.
+2. But the signal handler `_graceful_shutdown` runs in a signal context. Calling `sys.exit(0)` from a signal handler raises `SystemExit` in the main thread on its next bytecode boundary — the `try/finally` at line 435/672 catches it.
+3. So technically a single `finally` cleanup is sufficient. The explicit calls are defense-in-depth (clearer intent at each callsite for code-review + class-of-bug fold tests).
+
+**Final recommendation: helper + finally-only call.** Cleaner, single source of truth, covers all six exit paths. Explicit calls at SIGTERM/K=10/KeyboardInterrupt are optional documentation but not required for correctness.
+
+```python
+finally:
+    if overflow_watcher:
+        try:
+            overflow_watcher.stop()
+        except Exception:
+            pass
+    _safe_unlink_session_pidfile(sess["session_id"])  # NEW: covers all 6 exit paths
+```
+
+Add the dedicated tests for the K=10 and SIGTERM paths anyway (they're the regression tests for what Junaid called out), plus one explicit test for the KeyboardInterrupt path and one for each `break` (file disappeared, claude exited).
+
+### Risks + mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Daemon crashes during checkpoint and `finally` runs before checkpoint completes, leaving stale pidfile but no checkpoint | LOW — finally always runs LAST | Order: checkpoint, then watcher stop, then unlink. Existing order preserved. |
+| Reload-spawn race: helper unlinks pidfile while a fresh SessionStart hook is mid-spawn for the same session | LOW — `DaemonSpawnClaim` uses O_CREAT|O_EXCL on the same path; if we unlink ours after our exit AND a peer is mid-spawn, their claim either already won (file exists → we unlink theirs! bug) or hasn't fired yet | **CAS-style guard**: only unlink if pidfile still contains OUR PID. Use existing `_pid_file_points_to(session_id, os.getpid())` (line 1743) as the gate. Without this, we could destroy a peer's just-completed claim during their startup window. |
+| Helper called twice (signal handler runs, then `finally` runs) | LOW — `unlink(missing_ok=True)` is idempotent | Already handled. |
+| `sess["session_id"]` shape changes (becomes path) | LOW — `start_guard` normalizes via `_resolve_session_by_id` which returns `{session_id: <stem>}` for path inputs | Helper accepts both via `_pid_file_for_session` which calls `_normalize_session_id`. |
+
+**Refined design**: use `_pid_file_points_to` as the unlink gate.
+
+```python
+def _safe_unlink_session_pidfile(session_id: str | None) -> None:
+    if not session_id:
+        return
+    try:
+        if _pid_file_points_to(session_id, os.getpid()):
+            _pid_file_for_session(session_id).unlink(missing_ok=True)
+    except (ValueError, OSError):
+        pass
+```
+
+This is the same CAS pattern `reload_self_daemon` uses at lines 1802, 1809, 1823, 1829 (sister-module precedent — bonus parity). Test contract gains `test_safe_unlink_skips_when_pid_mismatch` for this case.
+
+---
+
+## Item #4 — agents-active K=10 deferral + hard cap (ARCHITECTURAL)
+
+### Current state
+
+`src/cozempic/guard.py:498-636` — the full HARD1+HARD2+SOFT phase decision tree.
+
+The relevant K=10 sub-branch is inside the HARD1 phase (line 535-636). HARD1 is the only path that increments `consecutive_empty_hard_prunes`. HARD2 (line 498-533) ALWAYS reloads, regardless of `agents_active` — it explicitly states "EMERGENCY THRESHOLD" and "WARNING: Agents are active but compaction is imminent — reload required" (line 509).
+
+`agents_active` is computed at line 491-496 from the live `state.subagents` — True if any subagent is in `("running", "unknown")`.
+
+When `agents_active=True` at HARD1 (line 542-554):
+- Prune runs WITHOUT reload (`auto_reload=False`)
+- No process kill
+- Returns to top of loop
+- If `saved_mb == 0`, `consecutive_empty_hard_prunes += 1` (line 582)
+- At K >= 10, `sys.exit(0)` (line 612) — **DAEMON DIES even though agents are mid-task**
+
+This is the BMAD-with-subagents reproducer Junaid flagged AND the exact scenario the handoff at `~/sanofi/silc-data/.claude/handoffs/cozempic-guard-crash-2026-05-18.md` documents:
+
+> "Spawn 4 parallel subagents in background, each producing 80–120K-token transcripts... Within 30s of the 4th completion, the guard's HARD THRESHOLD (55%) line appears... the lead process exits."
+
+The handoff describes the v1.8.11 cascade (double-daemon race) which PR #92 fixed. But the K=10 exit BEHAVIOUR was added by PR #92 itself, and the new failure mode is: at K=10, `sys.exit(0)` fires, daemon dies, agents still running, no protection. The diagnostic message (line 599-611) tells the user to `/clear` — but `/clear` discards subagent state entirely. That advice is wrong for the agents_active case.
+
+### Design decision: skip-K-increment vs defer-exit vs hybrid
+
+#### Option A — Skip K-increment when agents_active
+
+When `agents_active=True` AND prune returns `saved_mb=0`, do **NOT** increment `consecutive_empty_hard_prunes`. The counter only advances on cycles where we genuinely tried-and-failed, not on cycles where we couldn't try (because reload was suppressed for agent safety).
+
+**Pros:**
+- Trivial implementation (one `if` branch around the increment).
+- Preserves K=10 semantics for the no-agents case (legitimate "daemon powerless" scenario).
+- No new state to manage.
+
+**Cons:**
+- Agents could legitimately run for hours; daemon stays in exponential-backoff sleep forever, wasting cycles polling.
+- No upper bound — if a session has perma-running agents, daemon never exits, never clears the K-state, never resets.
+- Doesn't fix the underlying issue: at the next agent-quiesce moment, K still doesn't increment because we now have a 5-minute backoff and the counter is stuck.
+- Doesn't actually defer the exit problem so much as defer the recognition of it.
+
+#### Option B — Defer exit when agents_active
+
+At K=10, instead of `sys.exit(0)`, check `agents_active`:
+- If False → exit (current behaviour).
+- If True → don't exit, but keep the backoff at the cap, log a one-time "deferred exit pending agent quiesce" message, re-check on every subsequent cycle.
+
+When agents go quiet, **then** the normal K=10 exit fires.
+
+**Pros:**
+- Preserves the K=10 contract (daemon eventually exits when truly powerless) but respects the agents.
+- Maps to the user's intuition: "don't kill the daemon while my subagents are working".
+- Reuses the existing `agents_active` signal — no new computation.
+
+**Cons:**
+- Unbounded — if agents NEVER quiesce (perma-running BMAD that lasts the whole session), daemon never exits. /tmp pidfile sticks. But this is the same surface as a normal session that never crosses K=10 at all, so not a NEW leak.
+- Diagnostic message must change to NOT say "type /clear" when agents are active.
+
+#### Option C — Hybrid: defer-exit + hard cap at K=N
+
+Combine B with an upper bound. Default: defer exit while agents_active, BUT after K reaches a HARD cap (e.g., HARD_LOOP_HARD_EXIT_THRESHOLD = 50, i.e., ~50 × cap_sleep = ~4 hours), exit regardless. The hard cap prevents the unbounded sleep loop from outliving the operator's intent.
+
+**Pros:**
+- Bounded — guarantees daemon eventually exits on truly stuck sessions.
+- Respects in-flight agents for a reasonable window (4h is well past any normal subagent batch).
+- Operator can override via env var if their use case is exotic (long-running BMAD spanning days).
+
+**Cons:**
+- Two constants instead of one; slightly more cognitive load.
+- The hard-cap exit IS the same crash the user originally reported — just postponed. Doesn't fundamentally solve the problem, just buys time.
+
+#### Recommended: **Option C (hybrid)** with conservative defaults
+
+Rationale grounded in FIX DISCIPLINE (propre + long-term, not simple):
+
+- **Option A alone** silently defers detection of a truly hung daemon. Operator never knows the K-state is wedged. Anti-pattern: "papers over" the problem.
+- **Option B alone** has no upper bound. A bug in subagent state tracking (e.g., `state.subagents` perma-stale at `"unknown"`) would wedge the daemon forever. That's a real risk: `_is_team_message` / `extract_team_state` is heuristic and has had edge cases (BUG-G15 noted in TODO.md:86: "in-band mutation sentinel leaks to pruned messages").
+- **Option C** gives us the agent-respectful behaviour Junaid asked for AND a guaranteed exit. The hard cap acts as a circuit breaker against agent-detection bugs.
+
+Concretely, the recommended logic at the K-check (replacing `sys.exit(0)` at line 612):
+
+```python
+if consecutive_empty_hard_prunes >= HARD_LOOP_EXIT_THRESHOLD:
+    # Wedge detection: check if subagents are still running. If so, defer
+    # exit — killing the daemon while agents are mid-task would destroy
+    # their work and tell the operator to /clear (which also destroys it).
+    # Hard cap at HARD_LOOP_HARD_EXIT_THRESHOLD ensures we eventually exit
+    # even if agents perma-run (defensive against extract_team_state bugs).
+    if agents_active and consecutive_empty_hard_prunes < HARD_LOOP_HARD_EXIT_THRESHOLD:
+        # Defer: stay alive, keep backoff at cap, emit one-time notice.
+        if not deferred_exit_announced:
+            print(
+                f"  [{_now()}] K={consecutive_empty_hard_prunes} reached "
+                f"normal exit threshold ({HARD_LOOP_EXIT_THRESHOLD}) but "
+                f"{sum(1 for s in state.subagents if s.status in ('running', 'unknown'))} "
+                f"subagents are still active. Deferring daemon exit until "
+                f"agents quiesce or K reaches hard cap "
+                f"({HARD_LOOP_HARD_EXIT_THRESHOLD}).",
+                flush=True,
+            )
+            deferred_exit_announced = True
+        # Continue to backoff sleep (already at cap by now); do NOT exit.
+    else:
+        # Normal K=10 exit, OR K=50 hard-cap exit even with agents.
+        # The diagnostic message conditionally adapts.
+        try:
+            checkpoint_team(session_path=session_path, quiet=True)
+        except Exception:
+            pass
+        if agents_active:
+            # Hard cap reached with agents still active — different message.
+            print(
+                f"  [{_now()}] Guard hard-cap exit (K="
+                f"{consecutive_empty_hard_prunes}, agents still active). "
+                f"Subagent state will be lost on next compaction. Consider "
+                f"finishing current subagents and starting a fresh session.",
+                flush=True,
+            )
+        else:
+            # Original K=10 message (existing text).
+            print(...)
+        _safe_unlink_session_pidfile(sess["session_id"])  # item #3
+        sys.exit(0)
+```
+
+### Proposed constant values
+
+```python
+HARD_LOOP_EXIT_THRESHOLD = 10            # unchanged — normal exit when no agents
+HARD_LOOP_HARD_EXIT_THRESHOLD = 50       # new — exit even with agents at K=50
+```
+
+Defaults reasoning:
+- K=10 reached at: interval=30s, K=3-6 cap at 300s. Cumulative wall time to K=10 ≈ 30+30+60+120+240+300+300+300+300 ≈ 28 minutes. So K=10 is "the daemon has been useless for ~half an hour".
+- K=50 reached at ≈ 28min + (40 × 300s) = ≈ 3.5 hours additional ≈ 4 hours total. Long enough for any reasonable subagent batch; short enough that a stuck session doesn't outlive an operator's coffee break + workday.
+- Configurable via env var (sister-module precedent: `COZEMPIC_PIDFILE_FRESH_SECONDS` at `spawn_lock.py:106-115`). Add `COZEMPIC_GUARD_HARD_EXIT_K` with same clamp pattern (positive int, ≤ 1000, default 50).
+
+### Test contract — MUST include reproducer-scenario walk
+
+`tests/test_guard_polish_pr93.py::TestPolishPR93_K10AgentsActiveDefer`:
+
+1. **`test_k10_exits_when_no_agents`** (regression of current v1.8.14 behaviour) — drive `start_guard` to K=10 with `state.subagents == []`, assert `SystemExit(0)`.
+
+2. **`test_k10_defers_when_subagents_running`** — drive to K=10 with `state.subagents = [Subagent(status="running")]`, assert daemon does NOT exit, assert one-time "deferring daemon exit" log line emitted, assert K continues to increment, assert backoff stays at cap.
+
+3. **`test_hard_cap_exits_with_agents_active`** — extend to K=50 (or env-var-overridden lower cap for test speed) with agents still running, assert `SystemExit(0)`, assert different diagnostic message ("hard-cap exit") that does NOT recommend `/clear`.
+
+4. **`test_resumes_normal_after_agents_quiesce`** — at K=15 with deferred exit, transition `subagents[0].status = "completed"` on next cycle, assert exit fires immediately (no extra K cycles needed).
+
+5. **`test_k_counter_resets_on_nonzero_prune`** (existing behaviour regression) — drive to K=8, return `saved_mb=10`, assert K resets to 0, no exit at next cycle.
+
+6. **`test_env_var_overrides_hard_cap`** — set `COZEMPIC_GUARD_HARD_EXIT_K=20`, assert hard-cap fires at K=20.
+
+7. **`test_env_var_invalid_falls_back_to_default`** — set `COZEMPIC_GUARD_HARD_EXIT_K=not-a-number`, assert default 50 still applies (matches `_read_fresh_window_seconds` failsafe).
+
+**BMAD-with-subagents reproducer walk** (manual / integration-style, may be xfail on CI):
+
+`tests/test_guard_polish_pr93_reproducer.py::TestReproducerBMAD`:
+
+Simulates the handoff scenario:
+1. Build a synthetic JSONL with 4 large subagent transcripts (each ~100KB of tool_use+tool_result blocks).
+2. Mark all 4 subagents as `running` in the in-memory `TeamState`.
+3. Set `threshold_tokens=550_000`, current tokens ≥ 550K (HARD1 hit).
+4. Mock `guard_prune_cycle` to return `saved_mb=0` (immutable tool-result blocks dominate).
+5. Run `start_guard` (with patched `time.sleep` to compress time).
+6. Assert: at K=10, daemon does NOT exit (`agents_active=True`); at K=50, daemon exits with hard-cap message.
+7. Also assert: pidfile is unlinked at the hard-cap exit (item #3 fold).
+
+This is the test that catches the exact failure Junaid described.
+
+### Cross-lock matrix check
+
+For each lock the daemon process holds or interacts with, verify the new defer-exit logic does not deadlock or starve:
+
+| Lock | Held during defer? | Risk | Verdict |
+|---|---|---|---|
+| `_ReloadLock` (`reload_lock.py:160`) | NO — only acquired inside `guard_prune_cycle` (line 817) for the duration of `_terminate_and_resume`. Released before returning to main loop. | The defer happens AFTER `guard_prune_cycle` returns. No overlap. | SAFE |
+| `_PruneLock` (`session.py:103`) | NO — acquired inside `guard_prune_cycle` via `with _PruneLock(session_path)` (line 717). Released before main loop continues. | Same as above. | SAFE |
+| `_HostFileLock` (`helpers.py:59`) | Used by `record_savings` inside `guard_prune_cycle` (line 786). Released within that call. | No overlap with defer logic. | SAFE |
+| `_SettingsLock` (`init.py:223`) | Used by `cozempic init` flow, not the daemon loop. | Not on daemon hot path. | SAFE |
+| `DaemonSpawnClaim` (`spawn_lock.py:201`) | Held by the daemon's PARENT (the SessionStart hook process that spawned us) during the few-ms window of `start_guard_daemon`. Released BEFORE `start_guard` body runs. | Defer logic is inside `start_guard` body. No overlap. | SAFE |
+| `_spawn_locks` (`guard.py:35`) | DELETED in item #2. | N/A | N/A |
+
+**Conclusion**: defer-exit holds no locks across the deferred cycles. The daemon process sleeps in `time.sleep(backoff)` at line 633 between cycles, holding nothing. The only persistent resource is the pidfile (which is the daemon's own identity, not a lock per se — its presence signals "this PID owns this session").
+
+**Bonus check**: does deferring the exit prevent a new SessionStart hook from spawning a replacement? Yes — `_is_guard_running_for_session` will return our PID, `start_guard_daemon` returns `already_running=True`, no second spawn. That's the desired behaviour during defer (we ARE still alive and responsible for the session).
+
+### Risks + mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `agents_active` stays True forever due to a bug in `extract_team_state` (BUG-G15 type) | MED | HARD cap at K=50 ensures eventual exit. |
+| Hard cap fires while operator IS finishing subagents (false alarm) | LOW — 4h window is generous | Env var override + clearer "hard-cap exit, subagents may lose state" message. |
+| Operator confused by "deferring" message — thinks daemon is hung | LOW | One-time print, includes current K and the hard cap target. |
+| Defer logic interacts with backoff sleep (over-sleeps or under-sleeps) | LOW | Backoff already capped at 300s; defer just keeps cycling at that cap. No new sleep added. |
+| New `deferred_exit_announced` state variable leaks across daemon restarts | NONE — module-local, dies with the process | N/A |
+| Test fixtures (mocking `time.sleep`) hit recursion / hang | MED | Use `unittest.mock.patch('time.sleep')` to no-op + `cycle_count` limit in test driver. Standard pattern, already used in `tests/test_guard_*.py`. |
+
+---
+
+## Item #5 — DaemonSpawnClaim metadata parity with `_ReloadLock`
+
+### Current state (DaemonSpawnClaim writes PID only)
+
+`src/cozempic/spawn_lock.py:295-298` — claim write:
+
+```python
+try:
+    os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+finally:
+    os.close(fd)
+```
+
+`src/cozempic/guard.py:1567-1576` — daemon-pid hand-off:
+
+```python
+_tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
+try:
+    os.write(_tmp_fd, f"{proc.pid}\n".encode("utf-8"))
+finally:
+    os.close(_tmp_fd)
+os.rename(str(tmp_path), str(pid_path))
+```
+
+Both write a single line: `<pid>\n`. No timestamp, no initiator. Triage on operator boxes is hard: when you see `/tmp/cozempic_guard_abc123def456.pid` with PID 12345, you have no idea whether it was claimed by a SessionStart hook (normal), an in-process `reload_self_daemon` call (post-upgrade), or a stale crash artifact from yesterday. You must `ps -p 12345 -o lstart=` to recover the timestamp, and there's no record of WHO claimed it.
+
+### Sister-module precedent
+
+`src/cozempic/reload_lock.py:222-227` — `_ReloadLock._try_create` payload:
+
+```python
+payload = (
+    f"{os.getpid()}\n"
+    f"{datetime.now().isoformat(timespec='seconds')}\n"
+    f"{self.initiator}\n"
+)
+os.write(fd, payload.encode("utf-8"))
+```
+
+Three lines: PID, ISO timestamp, initiator string (one of `cli-reload`, `guard-hard1`, `guard-hard2`, `overflow` — `reload_lock.py:48-51`).
+
+Parser at `reload_lock.py:130-157` (`_read_lock_metadata`) handles arbitrary trailing metadata: splits on `\n`, takes first token as PID via `int(content[0].strip())`. Tolerates extra lines.
+
+This is the convention to mirror.
+
+### Proposed payload format
+
+**Payload (3 lines, identical structure to `_ReloadLock`)**:
+
+```
+<pid>\n
+<iso-timestamp>\n
+<initiator>\n
+```
+
+Where `initiator` for `DaemonSpawnClaim` is one of:
+- `spawn-claim-parent` — the SessionStart hook parent process writing its own PID at `_claim` time
+- `spawn-claim-daemon` — the atomic rename hand-off writing the daemon's PID
+
+These names follow `_ReloadLock`'s `INIT_*` constants pattern. Add to `spawn_lock.py`:
+
+```python
+# Initiator strings — mirrored from reload_lock.INIT_* conventions for
+# operator-triage parity. The parent-vs-daemon distinction is the only
+# meaningful split for spawn-claim payloads.
+INIT_SPAWN_PARENT = "spawn-claim-parent"
+INIT_SPAWN_DAEMON = "spawn-claim-daemon"
+```
+
+**Backward compatibility — pidfile readers MUST tolerate extra lines.**
+
+Exhaustive enumeration of pidfile readers (grep evidence above):
+
+| Reader | File:Line | Current parse | Safe with multi-line? |
+|---|---|---|---|
+| `guard._is_guard_running_for_session` | guard.py:1279, 1855 | `int(pid_path.read_text().strip())` | **NO** — `int("12345\n2026-05-19...\nspawn-claim-parent")` raises ValueError. Already-caught by `except ValueError` (line 1318), would treat the file as stale and likely unlink it. **BREAKS the claim.** |
+| `guard._pid_file_points_to` | guard.py:1752 | `int(path.read_text().strip())` | Same — would return False (the existing `except` block catches it), causing CAS-unlink logic to skip cleanup. Less severe but wrong. |
+| `DaemonSpawnClaim._read_existing_pid` | spawn_lock.py:315-330 | `first = content.split()[0]` → `int(first)` | ✅ ALREADY safe — splits and takes first token. |
+| `doctor._is_live_guard_pid` caller path | doctor.py:1068 | `int(_Path(pidf).read_text().strip())` | **NO** — same break as `_is_guard_running_for_session`. Would treat the live daemon as dead and skip it in doctor's "live guards" tally. |
+| `doctor._collect_pid_entries` | doctor.py:327 | `int(pid_path.read_text().strip())` | **NO** — would classify the file as stale and offer to remove it via `doctor --fix`. **Could destroy a live claim.** |
+| `tests/test_hook_idempotency_shell.py:151` | tests | `int(self.pid_file.read_text().strip())` | NO — test would break. |
+| `plugin/hooks/hooks.json:9` (bash) | hooks | `kill -0 "$(cat \"$GUARD_PID_FILE\" 2>/dev/null)"` | **NO** — `kill -0 12345\n2026-...\nspawn-claim-parent` is a multi-arg call: `kill -0` would be invoked with multiple args and likely succeed on the first valid PID, but the behaviour is shell-implementation-defined. **HIGH RISK.** |
+
+**Conclusion**: I CANNOT change the pidfile format without updating ALL these readers. Every reader except `DaemonSpawnClaim._read_existing_pid` does `int(read_text().strip())` and would break or misclassify.
+
+**Two implementation options:**
+
+#### Option 5a — Add metadata, update all readers
+
+Touch every reader (5 Python sites + 1 bash hook + N tests) to use `content.split()[0]` or `splitlines()[0]` semantics. Pidfile becomes the 3-line format.
+
+Pros: True parity with `_ReloadLock`. Operator triage parity is real.
+Cons: 6+ site touch. Bash hook is in `plugin/hooks/hooks.json` — that's a STRING inside JSON, error-prone to edit; also requires schema bump `cozempic-hook-schema=v8` → `v9` (PR #92 just took v8), with `cozempic init` migration. Three test files to update.
+
+#### Option 5b — Sidecar metadata file (parity-equivalent without format change)
+
+Keep the pidfile as `<pid>\n` (single line, all existing readers continue to work unchanged). Write metadata to a SIDECAR file `cozempic_guard_<slug>.pid.meta` containing the timestamp + initiator. Operator triage tools (and `doctor`) read the sidecar.
+
+Pros:
+- Zero risk to existing readers — they keep working.
+- No hook schema bump.
+- No test updates for the int-parse paths.
+- Sidecar can be ignored safely (orphan if pidfile is gone — `doctor` already enumerates and cleans `/tmp/cozempic_guard_*` artifacts).
+
+Cons:
+- Two files instead of one.
+- Metadata can drift from pidfile (sidecar write fails, race during rename, etc.) — needs to be best-effort and tolerated-stale.
+- "Parity" is approximate, not literal — `_ReloadLock` carries metadata IN the lock file itself.
+
+#### Recommended: **Option 5a** (true parity), gated behind the FIX DISCIPLINE pre-PR audit
+
+Per FIX DISCIPLINE "Grep for sister-module parity": adopt the sister-module convention unless documented reason to diverge. Option 5b's "diverge" reason is "fewer sites to touch", which is exactly the "simple short-term" anti-pattern FIX DISCIPLINE forbids.
+
+Pros for 5a beyond parity:
+- Single source of truth — metadata cannot drift from pidfile.
+- Doctor can show timestamp + initiator in `doctor` output without extra file lookups.
+- Operator running `cat /tmp/cozempic_guard_*.pid` gets the full triage info immediately.
+
+Implementation:
+
+1. **Update `DaemonSpawnClaim._claim` (spawn_lock.py:295)**:
+   ```python
+   from datetime import datetime
+   payload = (
+       f"{os.getpid()}\n"
+       f"{datetime.now().isoformat(timespec='seconds')}\n"
+       f"{INIT_SPAWN_PARENT}\n"
+   )
+   os.write(fd, payload.encode("utf-8"))
+   ```
+
+2. **Update daemon-pid hand-off (guard.py:1573)**:
+   ```python
+   from datetime import datetime
+   payload = (
+       f"{proc.pid}\n"
+       f"{datetime.now().isoformat(timespec='seconds')}\n"
+       f"spawn-claim-daemon\n"
+   )
+   os.write(_tmp_fd, payload.encode("utf-8"))
+   ```
+
+3. **Helper `_parse_pidfile_pid(pidfile)` in spawn_lock.py** (new public-ish helper, mirrors `_read_lock_metadata` in reload_lock.py):
+   ```python
+   def _parse_pidfile_pid(pid_path: Path) -> int:
+       """Read PID from a cozempic guard pidfile (1-line or 3-line format).
+
+       Tolerates both legacy single-line `<pid>\\n` and the new 3-line
+       `<pid>\\n<timestamp>\\n<initiator>\\n` format. Returns 0 on any
+       parse failure (consistent with DaemonSpawnClaim._read_existing_pid).
+
+       Bash callers (hooks.json) should keep using `awk 'NR==1'` or
+       `head -1` — they only need line 1.
+       """
+       try:
+           content = pid_path.read_text().strip()
+       except OSError:
+           return 0
+       if not content:
+           return 0
+       first = content.splitlines()[0].strip()
+       try:
+           return int(first)
+       except ValueError:
+           return 0
+   ```
+
+4. **Migrate readers** to use the helper:
+   - `guard.py:1279` (`_is_guard_running_for_session`): `pid = _parse_pidfile_pid(pid_path)` instead of `int(pid_path.read_text().strip())`.
+   - `guard.py:1752` (`_pid_file_points_to`): same.
+   - `guard.py:1855` (`reload_self_daemon` retry path): same.
+   - `doctor.py:327` (`_collect_pid_entries`): same.
+   - `doctor.py:1068` (`pids_alive`): same.
+   - `DaemonSpawnClaim._read_existing_pid` (spawn_lock.py:315-330): already does first-token logic; either delegate to `_parse_pidfile_pid` for DRY, or leave it (slightly different first-token-vs-first-line behaviour, both correct here).
+
+5. **Update bash hook (plugin/hooks/hooks.json:9)** — currently:
+   ```bash
+   kill -0 "$(cat \"$GUARD_PID_FILE\" 2>/dev/null)"
+   ```
+
+   Change to:
+   ```bash
+   kill -0 "$(head -1 \"$GUARD_PID_FILE\" 2>/dev/null)"
+   ```
+
+   `head -1` extracts the first line (POSIX; works in dash, bash, zsh). Bash-side change is minimal and zero-risk for v1.8.14 single-line files (the first line IS the whole file). Bump `cozempic-hook-schema=v8` → `v9` and add migration in `cozempic init` to rewrite installed `settings.json` hook commands.
+
+6. **Test fixtures (tests/test_hook_idempotency_shell.py:151)** — update to `head -1`-equivalent or use `_parse_pidfile_pid`. Inventory all `int(...read_text().strip())` patterns in tests/ and update them.
+
+Note on the hook schema bump: PR #92 already bumped v7→v8 for an unrelated reason (the SessionStart probe-before-spawn). The schema constants are documented in the in-line hook comment `# cozempic-hook-schema=v8`. v9 bump is a normal incremental change, `cozempic init` already has the migration scaffolding (see `init.py`).
+
+### Test contract
+
+`tests/test_guard_polish_pr93.py::TestPolishPR93_PidfileMetadataParity`:
+
+1. **`test_spawn_claim_writes_3_line_payload`** — call `DaemonSpawnClaim(sid, path).__enter__()`, read file, assert 3 lines, assert line 1 parses as `os.getpid()`, line 2 parses as `datetime.fromisoformat`, line 3 == `INIT_SPAWN_PARENT`.
+
+2. **`test_daemon_handoff_writes_3_line_payload`** — drive `start_guard_daemon` (with mocked Popen), assert post-rename pidfile is 3 lines, line 1 == daemon PID, line 3 == `"spawn-claim-daemon"`.
+
+3. **`test_parse_pidfile_handles_legacy_1_line`** — write `"12345\n"`, assert `_parse_pidfile_pid(path) == 12345` (backward compat with already-installed v1.8.14 pidfiles).
+
+4. **`test_parse_pidfile_handles_new_3_line`** — write `"12345\n2026-05-19T10:00:00\nspawn-claim-parent\n"`, assert `_parse_pidfile_pid(path) == 12345`.
+
+5. **`test_parse_pidfile_handles_garbage`** — write `"not-a-number\nfoo\n"`, assert returns `0`.
+
+6. **`test_parse_pidfile_handles_empty`** — write `""`, assert returns `0`.
+
+7. **`test_is_guard_running_uses_new_parser`** — write a 3-line pidfile with a live PID (use `os.getpid()` of the test runner, which we know is alive), assert `_is_guard_running_for_session` returns the right PID (not None due to parse failure).
+
+8. **`test_doctor_collect_uses_new_parser`** — write a 3-line pidfile, run `doctor._collect_pid_entries`, assert the entry is classified correctly (live vs stale based on PID liveness, not on parse failure).
+
+9. **`test_bash_hook_head1_extracts_pid`** — shell test (or string-equivalent Python test): write a 3-line pidfile, run `bash -c "head -1 $path"`, assert output is just the PID line.
+
+10. **`test_hook_schema_v9_in_settings`** (migration test, sister to existing `test_init_*` tests): after `cozempic init`, installed `settings.json` hook command contains `cozempic-hook-schema=v9` AND uses `head -1` rather than `cat`.
+
+### Risks + mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Reader I missed — silently breaks on multi-line | LOW (I enumerated all 6 sites via grep) | The shared `_parse_pidfile_pid` helper makes it easy to audit; tests cover all known sites. Adversarial round should re-grep to catch additions. |
+| Bash hook `head -1` not POSIX-portable | LOW — POSIX since 1992, all macOS / Linux / WSL shells support it | Documented; no fallback needed. |
+| Hook schema migration breaks existing installs | LOW — `cozempic init` migration is well-tested (PRs #84, #92) | Adversarial round should test the migration path. |
+| Operator manually inspects a pre-migration pidfile after `cozempic` upgrade and the daemon was started by the OLD version | LOW — `_parse_pidfile_pid` handles 1-line legacy format | Tested explicitly (test 3). |
+| Metadata write fails partially (e.g., ENOSPC mid-write) | LOW — write is to a single `os.write` call which is atomic for small payloads on local FS | Existing exception path in `_claim` already unlinks the pidfile on raised exceptions (line 297 close in try/finally; FileExistsError handled). |
+| Race: reader sees pidfile mid-write between parent's `os.write` and `os.close` | EXISTS in current code too (single-byte writes are not visible until close), the atomic guarantee comes from the O_CREAT|O_EXCL ordering — file is created BEFORE any read attempt because the kernel materializes the directory entry on open | Same as today; no new race. |
+| Operator's external tooling parses pidfile as single PID | MED — third parties may have scripts | Documented in CHANGELOG that pidfile is now 3 lines; first line remains the PID (forward-compatible for scripts using `head -1` or `awk 'NR==1'`). |
+
+---
+
+## FIX DISCIPLINE compliance check (per `~/Algo/cozempic/CLAUDE.md`)
+
+### Class-of-bug fold rule
+
+**Q: Are there OTHER instances of "sys.exit without pidfile unlink" beyond `_graceful_shutdown` + K=10?**
+
+Exhaustive grep + audit (item #3 above): 3 `sys.exit` sites in `guard.py`, 0 in `spawn_lock.py`.
+- `guard.py:340` — already unlinks. ✅
+- `guard.py:420` — leaks. → fix in PR #93.
+- `guard.py:612` — leaks. → fix in PR #93.
+
+PLUS adjacent process-exit surfaces I found while auditing:
+- `KeyboardInterrupt` block at `guard.py:664` — falls through to `finally` block (line 672), which currently does NOT unlink. → fix in PR #93 via the `finally`-based helper.
+- 4 `break` paths inside main loop (file disappeared, claude exited, hard2 reload break, hard1 reload break) — same fall-through. → fix via the same `finally`-based helper.
+
+All 6 daemon-exit paths get covered by ONE `_safe_unlink_session_pidfile` call in the `finally` block, gated by `_pid_file_points_to(session_id, os.getpid())` CAS to prevent destroying a peer's claim.
+
+**Q: Are there OTHER instances of "dead code claimed as fast-path retained" beyond `_spawn_locks`?**
+
+Grep for "fast-path", "retained", "kept": three hits.
+- `guard.py:32` — `_spawn_locks` "kept as a fast-path" → item #2 deletes it.
+- `digest.py:41` — `_DEBUG` "kept as a module-level attribute for test monkeypatching" → legitimate, monkeypatched in tests. KEEP.
+- `spawn_lock.py:151` — `_spawn_lock_path` "Kept as a separate helper for diagnostics + the legacy `daemon_spawn_lock` ctx-manager test surface" → used by `daemon_spawn_lock` (line 344) AND by tests. Legitimate. KEEP.
+- `spawn_lock.py:323` — comment about "legacy formats in reload_lock.py have trailing metadata" → describes the parser tolerance, not dead code. KEEP.
+
+Only `_spawn_locks` is genuinely dead. No further folds needed.
+
+### Sister-module parity grep
+
+For each new payload format or constant introduced:
+
+| New thing in PR #93 | Sister module | Convention adopted |
+|---|---|---|
+| `_safe_unlink_session_pidfile` helper | `reload_lock._ReloadLock.__exit__` (`reload_lock.py:193-199`) unlinks lock file on exit | YES — similar try/except OSError pattern. |
+| CAS guard via `_pid_file_points_to` | `guard.reload_self_daemon` (lines 1802, 1809, 1823, 1829) | YES — same CAS pattern. |
+| `HARD_LOOP_HARD_EXIT_THRESHOLD` constant | `reload_lock.WEDGE_TTL_SECONDS` (line 45) — "wedge" threshold for an upper bound | YES — same "circuit breaker on upper bound" pattern. |
+| `COZEMPIC_GUARD_HARD_EXIT_K` env var | `spawn_lock._read_fresh_window_seconds` env var pattern (lines 105-115) | YES — same clamp + fallsafe pattern. |
+| `INIT_SPAWN_PARENT` / `INIT_SPAWN_DAEMON` constants | `reload_lock.INIT_CLI_RELOAD` / `INIT_GUARD_HARD1` etc. (lines 48-51) | YES — same naming convention. |
+| 3-line pidfile payload | `reload_lock._try_create` payload (lines 222-227) | YES — identical structure. |
+| `_parse_pidfile_pid` helper | `reload_lock._read_lock_metadata` (lines 130-157) | YES — same tolerant-parse pattern, returns 0 on failure. |
+
+All proposed new APIs follow existing conventions. No invented patterns.
+
+### Pre-existing items folded
+
+From `TODO.md` sweep against files touched in PR #93:
+
+| TODO item | File/class touched | Fold decision |
+|---|---|---|
+| TODO.md:55 — `_graceful_shutdown` does NOT unlink pidfile | `guard.py:_graceful_shutdown` | **FOLD** — exactly item #3 scope. Mark DONE in TODO.md post-merge. |
+| TODO.md:23 — FIX-O1: fail-closed at `guard.py:398` when `claude_pid=None` after re-check → `sys.exit()` | `guard.py:398` (close to K=10 path) | **DO NOT fold** — different scope (orphan reaper PR). The K=10 sys.exit addition is OK to coexist; mention in FIX-O1 note that it must be aware of the K=10 exit path (already noted in TODO). |
+| TODO.md:31 — N3: `COZEMPIC_PIDFILE_FRESH_SECONDS` docstring should clarify "requires daemon restart" | `spawn_lock.py:101-115` | **Consider folding** — touching `spawn_lock.py` in item #5 anyway. 2-line docstring tweak. Low cost, fits the FIX DISCIPLINE "fold if touching" rule. **YES, fold.** |
+| TODO.md:32 — M1: `os.rename(.pid.tmp, .pid)` lacks `os.fsync` on parent dir | `guard.py:1576` | **Consider folding** — touching this exact rename in item #5 (hand-off payload). Adding `os.fsync(os.open(parent_dir, O_RDONLY))` is ~3 LOC. **YES, fold** — durability + fresh edit in same hunk is cleaner. |
+| TODO.md:33 — M2: `_is_pidfile_fresh` returns False on `stat()` EACCES | `spawn_lock.py:309-313` | **Consider folding** — touching `spawn_lock.py` anyway. Change `except OSError: return False` to `except PermissionError: return True` + keep `except OSError: return False`. 2 LOC. **YES, fold.** |
+| TODO.md:34 — M3: `_is_cozempic_guard_process` ProcessLookupError ambiguity | `guard.py:1617-1662` | **DO NOT fold** — different file area, larger refactor (return tri-state), best done as its own audited change. Out of scope. |
+| TODO.md:35 — M5: macOS without `brew install flock` documentation | hook docs | **DO NOT fold** — docs-only, separate. |
+| TODO.md:56 — CLI `cmd_guard --daemon` invalid session_id prints nothing + exits 0 | `cli.py` | **DO NOT fold** — different file, different concern (CLI UX). |
+| TODO.md:57 — `_digest_session` literal-path vs session ID | `cli.py:971-983` | **DO NOT fold** — different file, different concern. |
+
+**Total folded**: 4 items (item #3 + N3 + M1 + M2 from the deferred-DA-findings list).
+
+This aligns with "When introducing a new instance of a known bug class, the same PR MUST also fix the pre-existing known instances" — TODO.md:55 is the pre-existing leak that the K=10 leak added a second instance of. Folding it is mandatory per the rule.
+
+---
+
+## Commit ordering
+
+| Commit | Item | Scope | Risk |
+|---|---|---|---|
+| 1 | RED tests | `tests/test_guard_polish_pr93.py` + `tests/test_guard_polish_pr93_reproducer.py` (all 4 items: spawn-locks deletion, pidfile unlink, K=10 defer, metadata parity). All tests RED on current `4614f16`. | LOW — tests only. |
+| 2 | Item #2 + Item #3 | Mechanical: delete dead `_spawn_locks`, add `_safe_unlink_session_pidfile` helper + CAS gate + wire into `finally`. RED tests #2, #3 (item #2 + #3 paths) flip GREEN. | LOW — mechanical, narrow blast radius. |
+| 3 | Item #5 + folded TODO items | `spawn_lock.py` payload + `guard.py` hand-off payload + new `_parse_pidfile_pid` helper + migrate all 5 Python readers + bash hook `head -1` + schema v8→v9 + `cozempic init` migration + folded N3 (docstring) + M1 (fsync) + M2 (stat EACCES). RED tests for item #5 flip GREEN. | MED — touches hook surface + init migration. Requires adversarial round. |
+| 4 | Item #4 (architectural) | `HARD_LOOP_HARD_EXIT_THRESHOLD` + env var + `agents_active` defer logic + diagnostic message variants. RED tests for item #4 + reproducer scenario flip GREEN. | MED — new behaviour on a hot path. Most reviewable concern. Requires reproducer-scenario walk per FIX DISCIPLINE "Behavior verification on reproducer scenario". |
+
+**Rationale for ordering** (per FIX DISCIPLINE "Multi-PR sequencing: trust-building order: mechanical → defensive → architectural"):
+
+- Tests first (commit 1): standard RED-then-GREEN cadence (proven pattern on PR #92 6-step pipeline).
+- Mechanical cleanup (commit 2): zero-risk dead code + leak fix. Easy to verify in review.
+- Format change (commit 3): touches more sites + hook schema. Riskier, but constrained to format-change semantics. Verify with adversarial round.
+- Architectural change (commit 4): only one behaviour-change commit, isolates the BMAD-with-subagents reproducer test. Architects can focus their review here.
+
+**Total: 4 commits.** Well under the FIX DISCIPLINE 6-commit threshold for multi-PR splitting. One PR (PR #93) is correct; no split required.
+
+Each commit is independently shippable in principle (could revert commit 4 if architectural concern surfaces; commits 1-3 stand on their own).
+
+---
+
+## Verification envelope (architect)
+
+- **Confidence**: 90% (design is fully grounded; risk is in implementation drift during impl + adversarial discovery of a sister-module convention I missed).
+- **Signals**:
+  - Read tool on `src/cozempic/guard.py` (full file, 1918 lines, in 4 chunks)
+  - Read tool on `src/cozempic/spawn_lock.py` (full file, 360 lines)
+  - Read tool on `src/cozempic/reload_lock.py` (full file, 307 lines)
+  - Read tool on `src/cozempic/session.py:90-141` (`_PruneLock` for cross-lock matrix)
+  - Read tool on `src/cozempic/doctor.py:320-335, 1060-1075` (pidfile readers enumeration)
+  - Read tool on `~/sanofi/silc-data/.claude/handoffs/cozempic-guard-crash-2026-05-18.md` (full BMAD-with-subagents reproducer)
+  - Read tool on `~/Algo/cozempic/CLAUDE.md` (FIX DISCIPLINE rule full text)
+  - Read tool on `~/Algo/cozempic/TODO.md` (full file — fold candidates enumeration)
+  - Grep for `sys\.exit|os\._exit|SystemExit` in `guard.py` + `spawn_lock.py` (3 hits, all classified)
+  - Grep for `_spawn_locks` across `src/` + `tests/` (zero producer hits, confirms dead code)
+  - Grep for `pid_path\.read_text|pid_file\.read_text|_pid_file_for_session|_pid_file_for_cwd` across `src/` + `tests/` (6 reader sites enumerated)
+  - Grep for `class _.*Lock|class .*Claim` across `src/` (5 sister-module classes for parity grep)
+  - Grep for `fast-path|fast path|retained|kept as|legacy` across `src/` (4 hits, only `_spawn_locks` confirmed dead)
+- **Cross-checked**:
+  - Class-of-bug fold: enumerated ALL sys.exit paths, not just K=10 + _graceful_shutdown — found 4 additional process-exit surfaces (`KeyboardInterrupt` + 4 `break`s) that the `finally`-based helper covers.
+  - Sister-module parity: every new constant, helper, payload format mirrors an existing convention (no inventions).
+  - BMAD reproducer: walked the exact sequence from the handoff against Option C — verified the daemon stays alive while subagents are running, then exits hard-cap if they perma-run.
+  - Pidfile reader enumeration: bash hook (`plugin/hooks/hooks.json:9`) inclusion is critical — would have been silently broken by Option 5a without the `head -1` migration. Caught.
+  - TODO.md sweep: 4 pre-existing items folded into the PR scope (per FIX DISCIPLINE pre-PR audit gate).
+- **Not verified** (left for implementer / validator / adversarial):
+  - Test fixture mechanics for `time.sleep` mocking on the K=50 reproducer test (might need `freezegun` or a manual cycle-driver — implementer's call).
+  - Hook schema v9 migration on a real `settings.json` with non-default keys (the migration code in `init.py` has handled v6→v7→v8 before, so the path is well-traveled, but adversarial should test on a corrupted/partial schema).
+  - Whether the new `head -1` hook line interacts with existing `flock` invocations in the same command string (the bash command is one giant pipeline — needs eyes-on validation).
+  - Whether any third-party tooling parses cozempic pidfiles externally (low probability, but a sweep of `~/.claude*/hooks/*.sh` on the operator's box is recommended pre-merge).
+  - Empirical: does the BMAD-with-subagents reproducer in `tests/test_guard_polish_pr93_reproducer.py` actually replay the handoff's failure mode under the new code? Needs a live-daemon smoke similar to PR #92's V4-V6 validators.
+  - Whether `extract_team_state` reliably classifies in-flight subagents as `running` vs `unknown` vs `completed` in the BMAD-with-subagents path — the defer logic depends on it. If there's a known fluke (BUG-G15-adjacent), the hard cap saves us, but adversarial should probe this.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v8"
+            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v8"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v8"
+            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       }

--- a/src/cozempic/data/hooks.json
+++ b/src/cozempic/data/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(cat \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v8"
+            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v8"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v8"
+            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v9"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v8"
+            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v9"
           }
         ]
       }

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -319,13 +319,16 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path]]:
     except OSError:
         entries = []
 
+    from .spawn_lock import _parse_pidfile_pid
     for pid_path in entries:
         if _is_protected_tmp_artifact(pid_path.name):
             continue
         slug = pid_path.stem[len("cozempic_guard_"):]  # strip prefix, keep before .pid
-        try:
-            pid = int(pid_path.read_text().strip())
-        except (OSError, ValueError):
+        # Tolerant parse: handles both legacy 1-line and new 3-line
+        # pidfile formats (PR #93 item #5). Returns 0 on garble → we
+        # classify as stale.
+        pid = _parse_pidfile_pid(pid_path)
+        if pid <= 0:
             stale_pids.append(pid_path)
             continue
         if _is_live_guard_pid(pid):
@@ -1062,12 +1065,17 @@ def check_cozempic_daemon_running() -> CheckResult:
     from pathlib import Path as _Path
     import os as _os, glob as _glob
     from .guard import _is_cozempic_guard_process
+    from .spawn_lock import _parse_pidfile_pid
     pids_alive: list[int] = []
     for pidf in _glob.glob("/tmp/cozempic_guard_*.pid"):
+        # Tolerant parse: handles both legacy 1-line and new 3-line
+        # pidfile formats (PR #93 item #5). Returns 0 on garble.
+        pid = _parse_pidfile_pid(_Path(pidf))
+        if pid <= 0:
+            continue
         try:
-            pid = int(_Path(pidf).read_text().strip())
             _os.kill(pid, 0)
-        except (OSError, ValueError):
+        except OSError:
             continue
         # Verify this PID is actually our guard (not a PID-reused stranger)
         if _is_cozempic_guard_process(pid):

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -26,16 +26,6 @@ import threading
 import time
 from pathlib import Path
 
-# Per-session spawn lock: prevents a concurrent _is_guard_running_for_session
-# from treating a live O_CREAT placeholder as a stale file (within the same
-# process). Keyed by session_id to avoid false contention across sessions.
-# Kept as a fast-path for single-process scenarios; the authoritative gate
-# is now ``spawn_lock.daemon_spawn_lock`` (kernel-mediated flock) which
-# spans process boundaries — see start_guard_daemon below.
-_spawn_locks: dict[str, threading.Lock] = {}
-_spawn_locks_mu = threading.Lock()
-
-
 # ── HARD-threshold back-off + exit constants ────────────────────────────────
 # When ``guard_prune_cycle`` keeps returning saved_bytes == 0 at the HARD
 # threshold (because the live conversation is dominated by immutable tool-
@@ -680,6 +670,17 @@ def start_guard(
                 overflow_watcher.stop()
             except Exception:
                 pass
+        # Unlink session pidfile on EVERY daemon-exit path (PR #93 commit 2,
+        # class-of-bug fold). Covers SIGTERM, K=10 voluntary exit,
+        # KeyboardInterrupt, and the four `break` paths above. The helper
+        # CAS-checks ``_pid_file_points_to(session_id, os.getpid())`` so we
+        # never destroy a peer's just-completed claim during a hot reload.
+        # ``sys.exit(0)`` raises ``SystemExit`` which DOES run try/finally,
+        # so this single call site is sufficient for all 6 surfaces.
+        try:
+            _safe_unlink_session_pidfile(sess["session_id"])
+        except Exception:
+            pass
 
 
 def guard_prune_cycle(
@@ -1256,6 +1257,42 @@ def _cleanup_legacy_pid(cwd: str) -> None:
     legacy_sess.unlink(missing_ok=True)
 
 
+def _safe_unlink_session_pidfile(session_id: str | None) -> None:
+    """Best-effort pidfile unlink on daemon exit paths.
+
+    Used by every daemon shutdown surface (SIGTERM handler, K=10
+    voluntary exit, KeyboardInterrupt, the four `break` paths in
+    ``start_guard``'s main loop). Wired through the ``finally`` block
+    of ``start_guard`` so a single call site covers all 6 exit paths.
+
+    CAS gate: only unlinks if the pidfile currently contains OUR PID
+    (``_pid_file_points_to(session_id, os.getpid())``). This prevents
+    destroying a peer's just-completed claim during the brief window
+    where a concurrent SessionStart hook may have already spawned a
+    replacement daemon and rewritten the pidfile with its PID. Mirrors
+    the CAS pattern in ``reload_self_daemon`` (sister-module precedent
+    at lines 1802, 1809, 1823, 1829).
+
+    Swallows ValueError (malformed session_id passed in via stale
+    closure capture) and OSError (pidfile already gone, /tmp unwritable,
+    EACCES). Never raises — the daemon is mid-shutdown; nothing useful
+    to do on failure.
+
+    Class-of-bug fold (PR #93 commit 2): consolidates the unlink so
+    adding a new ``sys.exit`` path requires touching ONE callsite, not
+    N. Covers the pre-existing ``_graceful_shutdown`` leak (TODO:55,
+    pre-PR-#88) AND the K=10 leak PR #92 introduced — both daemon-exit
+    surfaces now reach the same ``finally`` block in ``start_guard``.
+    """
+    if not session_id:
+        return
+    try:
+        if _pid_file_points_to(session_id, os.getpid()):
+            _pid_file_for_session(session_id).unlink(missing_ok=True)
+    except (ValueError, OSError):
+        pass
+
+
 def _is_guard_running_for_session(session_id: str) -> int | None:
     """Check if a guard daemon is already running for this specific session.
 
@@ -1266,7 +1303,6 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
     (hooks, pytest, third-party integrations) should get a safe default
     instead of a ValueError propagating up from `_pid_file_for_session`.
     """
-    norm_sid = _normalize_session_id(session_id)
     try:
         pid_path = _pid_file_for_session(session_id)
     except ValueError:
@@ -1278,17 +1314,12 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
     try:
         pid = int(pid_path.read_text().strip())
         if pid <= 0:
-            # Guard against PID-reuse footgun: os.kill(0, sig) broadcasts to
-            # the caller's process group rather than targeting a sentinel.
-            # If a concurrent start_guard_daemon in THIS process holds the
-            # session spawn lock, the placeholder is live — skip the unlink.
-            with _spawn_locks_mu:
-                lock = _spawn_locks.get(norm_sid)
-            if lock is not None and not lock.acquire(blocking=False):
-                # Lock is held → spawner is in-flight; placeholder is live.
-                return None
-            if lock is not None:
-                lock.release()
+            # Pidfile contains a sentinel/placeholder — treat as stale.
+            # Guards against the PID-reuse footgun where os.kill(0, sig)
+            # broadcasts to the caller's process group rather than
+            # targeting a sentinel. Cross-process freshness for in-flight
+            # claims is enforced by DaemonSpawnClaim's O_CREAT|O_EXCL +
+            # _FRESH_PIDFILE_SECONDS gate, not by an in-process dict.
             pid_path.unlink(missing_ok=True)
             return None
         os.kill(pid, 0)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1312,7 +1312,14 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
         return None
 
     try:
-        pid = int(pid_path.read_text().strip())
+        # Tolerant parse: handles both legacy 1-line and new 3-line
+        # pidfile formats (PR #93 item #5). Returns 0 on garbled/empty
+        # content — caller's `if pid <= 0` branch then unlinks the stale
+        # file. Replaces `int(read_text().strip())` which would raise
+        # ValueError on 3-line content and (via the except below) skip
+        # the unlink, leaking the stale file.
+        from .spawn_lock import _parse_pidfile_pid
+        pid = _parse_pidfile_pid(pid_path)
         if pid <= 0:
             # Pidfile contains a sentinel/placeholder — treat as stale.
             # Guards against the PID-reuse footgun where os.kill(0, sig)
@@ -1596,15 +1603,54 @@ def start_guard_daemon(
             # non-OSError between write_text and rename used to leak the
             # .pid.tmp orphan; we now unlink it on every failure path.
             try:
+                from .spawn_lock import INIT_SPAWN_DAEMON
+                from datetime import datetime as _dt
                 _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
                 if hasattr(os, "O_NOFOLLOW"):
                     _tmp_flags |= os.O_NOFOLLOW
                 _tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
                 try:
-                    os.write(_tmp_fd, f"{proc.pid}\n".encode("utf-8"))
+                    # 3-line payload: pid + iso-timestamp + initiator.
+                    # Mirrors DaemonSpawnClaim._claim and
+                    # reload_lock._ReloadLock._try_create. Operators
+                    # cat-ing the pidfile see immediately who wrote it
+                    # (parent vs daemon) and when (PR #93 item #5).
+                    payload = (
+                        f"{proc.pid}\n"
+                        f"{_dt.now().isoformat(timespec='seconds')}\n"
+                        f"{INIT_SPAWN_DAEMON}\n"
+                    )
+                    os.write(_tmp_fd, payload.encode("utf-8"))
+                    # Fsync the payload to disk BEFORE rename so a power
+                    # loss between rename and parent-dir-fsync can't
+                    # produce a renamed-but-empty pidfile that readers
+                    # then misclassify as garbled (DA round 1 M1).
+                    try:
+                        os.fsync(_tmp_fd)
+                    except OSError:
+                        pass
                 finally:
                     os.close(_tmp_fd)
                 os.rename(str(tmp_path), str(pid_path))
+                # Fsync the parent directory so the rename itself is
+                # durable across abrupt power loss (DA round 1 M1).
+                # Without this, the rename is in the kernel's metadata
+                # journal but not yet on stable storage — a crash
+                # between rename and the next fs commit could roll the
+                # filesystem back to pre-rename state, leaving an
+                # orphan .pid.tmp and no .pid (next spawn would see no
+                # pidfile and start a duplicate daemon).
+                try:
+                    parent_dir = os.path.dirname(str(pid_path)) or "."
+                    _dir_fd = os.open(parent_dir, os.O_RDONLY)
+                    try:
+                        os.fsync(_dir_fd)
+                    finally:
+                        os.close(_dir_fd)
+                except OSError:
+                    # Some filesystems (network FS, tmpfs on certain
+                    # kernels) reject directory fsync — best-effort.
+                    pass
             except Exception:
                 # Unlink any partial .pid.tmp we may have created so a
                 # retry can succeed. unlink is symlink-safe (operates on
@@ -1775,12 +1821,18 @@ def _pid_file_points_to(session_id: str, expected_pid: int) -> bool:
     """CAS helper: return True if the session pid file currently contains
     `expected_pid`. Used before unlink() to avoid clobbering a fresh pid
     file written by a concurrent SessionStart hook.
+
+    Uses ``_parse_pidfile_pid`` so both legacy 1-line and new 3-line
+    pidfile formats parse correctly (PR #93 item #5). A garbled file
+    returns 0 from the parser, which won't match any expected_pid (>0),
+    so the CAS skips the unlink — the conservative behaviour.
     """
     try:
+        from .spawn_lock import _parse_pidfile_pid
         path = _pid_file_for_session(session_id)
         if not path.exists():
             return False
-        return int(path.read_text().strip()) == expected_pid
+        return _parse_pidfile_pid(path) == expected_pid
     except (ValueError, OSError):
         return False
 
@@ -1883,9 +1935,15 @@ def reload_self_daemon(
         pid_path = _pid_file_for_session(session_id)
         try:
             if pid_path.exists():
-                stale_pid = int(pid_path.read_text().strip())
+                from .spawn_lock import _parse_pidfile_pid
+                stale_pid = _parse_pidfile_pid(pid_path)
+                if stale_pid <= 0:
+                    # Garbled or empty — treat as stale and unlink.
+                    pid_path.unlink(missing_ok=True)
+                    stale_pid = 0
                 try:
-                    os.kill(stale_pid, 0)
+                    if stale_pid > 0:
+                        os.kill(stale_pid, 0)
                     # Still alive — leave the pid file alone and let
                     # start_guard_daemon below return already_running.
                 except (ProcessLookupError, PermissionError):

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -47,6 +47,48 @@ HARD_LOOP_BACKOFF_START = 3
 HARD_LOOP_BACKOFF_CAP_SECONDS = 300
 HARD_LOOP_EXIT_THRESHOLD = 10
 
+
+# ── Hard cap: K=10 exit deferral when agents_active (PR #93 item #4) ────────
+# When K reaches HARD_LOOP_EXIT_THRESHOLD (=10) AND `agents_active=True`,
+# the daemon used to `sys.exit(0)` mid-task, killing the subagents'
+# protection AND telling the operator to `/clear` (which destroys
+# subagent state). PR #93 defers the exit while agents are running and
+# only exits at the HARD cap below — giving subagents a chance to
+# finish before context dies.
+#
+# Default cap K=50 ≈ 4 hours wall time at the backoff cap (300s/cycle),
+# well past any normal subagent batch but short enough that a stuck
+# session doesn't outlive an operator's workday.
+#
+# Override via env var COZEMPIC_GUARD_HARD_EXIT_K (sister-module
+# precedent: spawn_lock._read_fresh_window_seconds clamps + falls back
+# on garbage). Read EXACTLY ONCE at module import time — requires a
+# daemon restart to take effect (same convention as
+# COZEMPIC_PIDFILE_FRESH_SECONDS).
+def _read_hard_exit_threshold() -> int:
+    """Read COZEMPIC_GUARD_HARD_EXIT_K env var. Clamps to (10, 1000].
+
+    Read at module import time only — restart the daemon to apply
+    a new value. Invalid values (non-numeric, <=K=10, > 1000) fall
+    back to the default 50.
+    """
+    raw = os.environ.get("COZEMPIC_GUARD_HARD_EXIT_K")
+    if raw is None:
+        return 50
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return 50
+    # Must be strictly > HARD_LOOP_EXIT_THRESHOLD (otherwise no defer
+    # window). Cap at 1000 to prevent absurd values (~3.5 days at 5min
+    # cap) from silently disabling the circuit breaker.
+    if val <= HARD_LOOP_EXIT_THRESHOLD or val > 1000:
+        return 50
+    return val
+
+
+HARD_LOOP_HARD_EXIT_THRESHOLD = _read_hard_exit_threshold()
+
 from ._validation import ConfigError
 from .executor import run_prescription
 from .helpers import is_ssh_session, shell_quote
@@ -421,6 +463,9 @@ def start_guard(
     cycle_count = 0
     last_team_hash = ""
     consecutive_empty_hard_prunes = 0
+    # PR #93 item #4: one-shot flag so the "deferring K=10 exit" log
+    # line only emits once per defer-window, not every cycle.
+    deferred_exit_announced = False
 
     try:
         while True:
@@ -577,29 +622,95 @@ def start_guard(
                     # in production). Exit gracefully and let the SessionStart
                     # hook respawn on next activity. Do NOT change reload-trigger
                     # gating in guard_prune_cycle — that's not the right escape.
+                    #
+                    # PR #93 item #4: defer the exit when `agents_active=True`.
+                    # Killing the daemon mid-task destroys subagent protection
+                    # AND the diagnostic recommends `/clear` (which also
+                    # destroys subagent state). Hard cap at
+                    # HARD_LOOP_HARD_EXIT_THRESHOLD (default 50, override via
+                    # COZEMPIC_GUARD_HARD_EXIT_K) ensures eventual exit so a
+                    # stuck `extract_team_state` (BUG-G15 family) can't wedge
+                    # the daemon forever.
                     if consecutive_empty_hard_prunes >= HARD_LOOP_EXIT_THRESHOLD:
-                        try:
-                            checkpoint_team(session_path=session_path, quiet=True)
-                        except Exception:
-                            # Checkpoint failure must not prevent exit — final
-                            # checkpoint is best-effort here; the SOFT loop above
-                            # has been writing checkpoints every cycle for the
-                            # entire run, so on-disk state is already current.
-                            pass
-                        print(
-                            f"  [{_now()}] Guard powerless against live-context "
-                            f"dominance ({HARD_LOOP_EXIT_THRESHOLD} consecutive "
-                            f"0-byte HARD prunes). Exiting — NO further guard "
-                            f"protection in this session. SessionStart fires only "
-                            f"on startup/resume/clear, NOT on tool calls or "
-                            f"message turns, so the daemon will NOT auto-respawn "
-                            f"while the session continues. To re-enable cozempic: "
-                            f"type /clear or restart the session. Recommended: "
-                            f"split work across fresh sessions to avoid >55% "
-                            f"context dominance by immutable tool-result blocks.",
-                            flush=True,
-                        )
-                        sys.exit(0)
+                        if (
+                            agents_active
+                            and consecutive_empty_hard_prunes < HARD_LOOP_HARD_EXIT_THRESHOLD
+                        ):
+                            # Defer: stay alive, keep cycling at backoff cap.
+                            if not deferred_exit_announced:
+                                running_count = sum(
+                                    1 for s in state.subagents
+                                    if s.status in ("running", "unknown")
+                                )
+                                worst_case_min = (
+                                    HARD_LOOP_HARD_EXIT_THRESHOLD
+                                    * HARD_LOOP_BACKOFF_CAP_SECONDS
+                                    // 60
+                                )
+                                print(
+                                    f"  [{_now()}] K={consecutive_empty_hard_prunes} "
+                                    f"reached normal exit threshold "
+                                    f"({HARD_LOOP_EXIT_THRESHOLD}) but "
+                                    f"{running_count} subagent(s) still active. "
+                                    f"Deferring daemon exit until agents quiesce "
+                                    f"or K reaches hard cap "
+                                    f"({HARD_LOOP_HARD_EXIT_THRESHOLD}, "
+                                    f"~{worst_case_min} min worst case).",
+                                    flush=True,
+                                )
+                                deferred_exit_announced = True
+                            # Fall through to the back-off sleep below.
+                            # We do NOT sys.exit while agents are working.
+                        else:
+                            # Either no agents (original K=10 exit) OR hard
+                            # cap reached even with agents (circuit breaker).
+                            try:
+                                checkpoint_team(session_path=session_path, quiet=True)
+                            except Exception:
+                                # Checkpoint failure must not prevent exit —
+                                # final checkpoint is best-effort here; the
+                                # SOFT loop above has been writing checkpoints
+                                # every cycle for the entire run, so on-disk
+                                # state is already current.
+                                pass
+                            if (
+                                agents_active
+                                and consecutive_empty_hard_prunes >= HARD_LOOP_HARD_EXIT_THRESHOLD
+                            ):
+                                # Hard cap fired with agents still active —
+                                # different diagnostic. Do NOT tell the
+                                # operator to `/clear` (that destroys
+                                # subagent state too).
+                                print(
+                                    f"  [{_now()}] Guard hard-cap exit "
+                                    f"(K={consecutive_empty_hard_prunes} >= "
+                                    f"{HARD_LOOP_HARD_EXIT_THRESHOLD}). "
+                                    f"Subagents are still active; their state "
+                                    f"may be lost on the next compaction. "
+                                    f"Consider letting current subagents "
+                                    f"finish then starting a fresh session.",
+                                    flush=True,
+                                )
+                            else:
+                                # Original K=10 exit (no agents — operator
+                                # can safely `/clear`).
+                                print(
+                                    f"  [{_now()}] Guard powerless against live-context "
+                                    f"dominance ({HARD_LOOP_EXIT_THRESHOLD} consecutive "
+                                    f"0-byte HARD prunes). Exiting — NO further guard "
+                                    f"protection in this session. SessionStart fires only "
+                                    f"on startup/resume/clear, NOT on tool calls or "
+                                    f"message turns, so the daemon will NOT auto-respawn "
+                                    f"while the session continues. To re-enable cozempic: "
+                                    f"type /clear or restart the session. Recommended: "
+                                    f"split work across fresh sessions to avoid >55% "
+                                    f"context dominance by immutable tool-result blocks.",
+                                    flush=True,
+                                )
+                            # _safe_unlink_session_pidfile is called via the
+                            # finally block (PR #93 commit 2) — covers this
+                            # sys.exit path automatically.
+                            sys.exit(0)
 
                     # Back-off path: replace the original fixed-cadence sleep at
                     # the bottom of the loop with an exponentially growing one.
@@ -623,6 +734,10 @@ def start_guard(
                         time.sleep(backoff)
                 else:
                     consecutive_empty_hard_prunes = 0
+                    # Reset the defer announcement so a fresh K-cycle that
+                    # reaches K=10-with-agents will emit the notice again
+                    # (PR #93 item #4 — operator-friendly).
+                    deferred_exit_announced = False
                 print()
 
             # ── Phase 2: SOFT (25%) — gentle, no reload (file maintenance only) ──

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -39,7 +39,7 @@ def _c(args: str) -> str:
 # at the end of every canonical hook command (e.g. "# cozempic-hook-schema=v2")
 # is what `_is_current_cozempic_hook` looks for — old hooks without the current
 # marker are treated as stale and get refreshed on next init.
-HOOK_SCHEMA_VERSION = "v8"
+HOOK_SCHEMA_VERSION = "v9"
 HOOK_SCHEMA_MARKER = f"cozempic-hook-schema={HOOK_SCHEMA_VERSION}"
 
 

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -71,6 +71,7 @@ import re
 import tempfile
 import time
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Iterator
 
@@ -103,6 +104,23 @@ _FRESH_MAX = 300.0
 
 
 def _read_fresh_window_seconds() -> float:
+    """Read the COZEMPIC_PIDFILE_FRESH_SECONDS env var and clamp.
+
+    IMPORTANT: this value is read EXACTLY ONCE at module import time
+    and cached in module-level ``_FRESH_PIDFILE_SECONDS``. Changing
+    the env var at runtime has NO effect on an already-running daemon
+    — the daemon must be restarted (or the module re-imported via
+    ``importlib.reload``) to pick up the new value. This mirrors the
+    "config frozen at process start" convention used for other
+    cozempic env vars (e.g. ``COZEMPIC_GUARD_HARD_EXIT_K`` in guard.py).
+    Operators tuning the fresh window for a fleet should set the env
+    var in their shell rc BEFORE launching Claude Code, not after.
+
+    Clamps to ``(0, _FRESH_MAX]``. Invalid values (non-numeric, NaN,
+    inf, ≤0, > _FRESH_MAX) silently fall back to the default — keeps
+    the daemon working rather than failing at startup over a
+    misconfigured env var. (DA round 1 N3 docstring fold.)
+    """
     raw = os.environ.get("COZEMPIC_PIDFILE_FRESH_SECONDS")
     if raw is None:
         return _DEFAULT_FRESH
@@ -116,6 +134,58 @@ def _read_fresh_window_seconds() -> float:
 
 
 _FRESH_PIDFILE_SECONDS = _read_fresh_window_seconds()
+
+
+# Initiator strings — mirrored from ``reload_lock.INIT_*`` conventions
+# for operator-triage parity. The parent-vs-daemon split is the only
+# meaningful distinction for spawn-claim payloads:
+#
+#   spawn-claim-parent  — written by ``DaemonSpawnClaim._claim`` when
+#                         the SessionStart hook (parent process) wins
+#                         the O_CREAT|O_EXCL race
+#   spawn-claim-daemon  — written by the atomic ``os.rename`` hand-off
+#                         in ``start_guard_daemon`` after Popen
+#
+# Operators inspecting a stale pidfile can ``cat /tmp/cozempic_guard_*.pid``
+# and see immediately who wrote it and when (PR #93 commit 3, item #5).
+INIT_SPAWN_PARENT = "spawn-claim-parent"
+INIT_SPAWN_DAEMON = "spawn-claim-daemon"
+
+
+def _parse_pidfile_pid(pid_path: Path) -> int:
+    """Read PID from a cozempic guard pidfile (1-line or 3-line format).
+
+    Tolerates both:
+      - legacy single-line ``<pid>\\n`` (v1.8.14 and earlier)
+      - new 3-line ``<pid>\\n<iso-timestamp>\\n<initiator>\\n``
+        (v1.8.15+, parity with ``reload_lock._ReloadLock``)
+
+    Returns 0 on any parse failure (missing file, empty file, garbled
+    first line, OSError on read). Callers treat 0 as "no live pid here".
+    Mirrors ``DaemonSpawnClaim._read_existing_pid`` semantics and
+    ``reload_lock._read_lock_metadata``'s tolerant parsing.
+
+    Bash callers (``hooks.json``) should use ``head -n 1 $path`` — they
+    only need line 1 and ``cat`` would feed multi-token output to
+    ``kill -0``, which is undefined-behaviour across shells.
+    """
+    try:
+        content = pid_path.read_text()
+    except OSError:
+        return 0
+    if not content:
+        return 0
+    lines = content.splitlines()
+    if not lines:
+        return 0
+    first = lines[0].strip()
+    if not first:
+        return 0
+    try:
+        pid = int(first)
+    except ValueError:
+        return 0
+    return pid if pid > 0 else 0
 
 
 # Round-3 C2 (Option B) alignment: char class kept relaxed (mirrors
@@ -288,12 +358,20 @@ class DaemonSpawnClaim:
                 holder_pid = self._read_existing_pid()
                 raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
 
-        # Won the claim. Write our parent PID so concurrent readers see a
-        # real, alive PID (not a placeholder) until we hand off the real
-        # daemon PID via tmp+rename. This is the inverse of the prior
-        # placeholder "0" pattern: we publish a meaningful pid immediately.
+        # Won the claim. Write our parent PID + timestamp + initiator
+        # so concurrent readers see a real, alive PID (not a placeholder)
+        # AND operators inspecting the pidfile have triage metadata.
+        # Three-line payload mirrors ``reload_lock._ReloadLock._try_create``
+        # (PR #93 commit 3, item #5 — operator-triage parity). Readers
+        # use ``_parse_pidfile_pid`` which tolerates both 1-line legacy
+        # and 3-line new formats.
         try:
-            os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+            payload = (
+                f"{os.getpid()}\n"
+                f"{datetime.now().isoformat(timespec='seconds')}\n"
+                f"{INIT_SPAWN_PARENT}\n"
+            )
+            os.write(fd, payload.encode("utf-8"))
         finally:
             os.close(fd)
         self.owned = True
@@ -305,29 +383,34 @@ class DaemonSpawnClaim:
         that just wrote a real PID may have that PID die between the
         write and our read (test mock, fast crash, PID reuse). A fresh
         file with a dead PID is still a peer claim, not a stale file.
+
+        EACCES handling (DA round 1 M2): if we can't stat() the file
+        (PermissionError — e.g. multi-user /tmp with restrictive
+        permissions, SELinux), return True. Conservative: treat an
+        unreadable pidfile as a live peer claim rather than re-claiming
+        over what might be a real peer's slot. Returning False would
+        race the peer and let two daemons spawn for the same session.
+        Other OSErrors (ENOENT — file vanished between exists() and
+        stat() — most likely) return False so we can re-claim cleanly.
         """
         try:
             mtime = self.pid_file.stat().st_mtime
+        except PermissionError:
+            # EACCES: can't read mtime → assume fresh (don't race a
+            # potentially-live peer claim).
+            return True
         except OSError:
             return False
         return (time.time() - mtime) < _FRESH_PIDFILE_SECONDS
 
     def _read_existing_pid(self) -> int:
-        """Best-effort read of the PID currently in the file."""
-        try:
-            content = self.pid_file.read_text().strip()
-        except OSError:
-            return 0
-        if not content:
-            return 0
-        # File may carry a single PID, or PID + extra lines (legacy formats
-        # in reload_lock.py have trailing metadata). Take the first token.
-        first = content.split()[0] if content.split() else ""
-        try:
-            pid = int(first)
-        except ValueError:
-            return 0
-        return pid if pid > 0 else 0
+        """Best-effort read of the PID currently in the file.
+
+        Delegates to module-level ``_parse_pidfile_pid`` for DRY parity
+        with all other pidfile readers (guard.py, doctor.py). Tolerates
+        both legacy 1-line and new 3-line payload formats.
+        """
+        return _parse_pidfile_pid(self.pid_file)
 
 
 @contextmanager

--- a/tests/test_atomic_writes_wave1.py
+++ b/tests/test_atomic_writes_wave1.py
@@ -289,24 +289,28 @@ class TestHostFileLockWindows(unittest.TestCase):
                             "Expected lock to degrade to no-op when msvcrt unavailable")
 
 
-# ─── Hook schema bump v7 → v8 (round 3 — C2 slug convergence, Option B) ─────
+# ─── Hook schema bump v8 → v9 (PR #93 — pidfile 3-line format + head -1) ────
 
-class TestHookSchemaV8(unittest.TestCase):
-    """v8 converges the bash hook slug rules with Python's
-    ``_pid_file_for_session`` (round 3 — C2 fix). Per code-auditor's
-    Option B sign-off (2026-05-18): the existing bash sanitiser
-    ``re.sub(r'[^a-z0-9_-]','_', s.lower())`` is kept as the codebase
-    convention (already used in ``reload_lock._slug_for`` and
-    ``spawn_lock._slug_for``); Python's previously stricter
-    ``^[0-9a-f][0-9a-f-]{11,}$`` is RELAXED to
-    ``^[a-z0-9][a-z0-9_-]{11,}$`` so both sides accept the same character
-    set. The leading-alphanumeric anchor is preserved as a security
-    property (dash-collision defense, see
-    ``TestPolishV2_SessionIdRegexRequiresHexFirstChar``)."""
+class TestHookSchemaV9(unittest.TestCase):
+    """v9 migrates the bash hook's PID liveness probe from
+    ``cat "$GUARD_PID_FILE"`` to ``head -n 1 "$GUARD_PID_FILE"`` to
+    handle the new 3-line pidfile format introduced in PR #93 (item #5)
+    for operator-triage metadata parity with ``_ReloadLock``.
+
+    Without ``head -n 1``, the multi-line pidfile content would be
+    passed to ``kill -0`` as multiple whitespace-separated arguments,
+    producing shell-implementation-defined behaviour (the multi-arg
+    ``kill -0`` syntax exists but tries each PID — likely succeeds on
+    the first valid line, but the timestamp/initiator lines would emit
+    confusing errors). Using ``head -n 1`` extracts only line 1 (the
+    PID) cleanly across all POSIX shells.
+
+    v8's C2 slug convergence is preserved verbatim (kept as the
+    codebase convention); v9 only changes the PID-reading mechanism."""
 
     def test_schema_marker_bumped(self):
         from cozempic.init import HOOK_SCHEMA_VERSION
-        self.assertEqual(HOOK_SCHEMA_VERSION, "v8")
+        self.assertEqual(HOOK_SCHEMA_VERSION, "v9")
 
     def test_no_unflocked_foreground_guard_daemon_call(self):
         """The unflocked foreground `cozempic guard --daemon` call stays removed.

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -335,9 +335,13 @@ class TestG4_PidfileWriteIsAtomic(unittest.TestCase):
 
         on_disk_pid = None
         if self.pid_path.exists():
+            # PR #93 item #5: pidfile is now 3-line (pid + ts + initiator).
+            # Parse first line only — mirrors the tolerant production
+            # parser in spawn_lock._parse_pidfile_pid.
             try:
-                on_disk_pid = int(self.pid_path.read_text().strip())
-            except (ValueError, OSError):
+                first_line = self.pid_path.read_text().splitlines()[0].strip()
+                on_disk_pid = int(first_line)
+            except (ValueError, OSError, IndexError):
                 on_disk_pid = None
         return results, on_disk_pid
 

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -1,0 +1,663 @@
+"""RED tests for PR #93 (Junaid PR #92 followups items 2-5).
+
+Items covered:
+  #2 — Dead `_spawn_locks` dict + dead consumer branch in
+       `_is_guard_running_for_session` must be removed.
+  #3 — Session pidfile must be unlinked on ALL daemon-exit paths
+       (SIGTERM, K=10, KeyboardInterrupt, every `break` in main loop).
+       Class-of-bug fold: also covers pre-existing TODO:55 leak in
+       `_graceful_shutdown` (PR #92 added the K=10 leak alongside it).
+  #4 — At K=10, when `agents_active=True`, the daemon must DEFER exit
+       (keep cycling at backoff cap) rather than `sys.exit(0)`. A hard
+       cap (default K=50, configurable via COZEMPIC_GUARD_HARD_EXIT_K)
+       ensures eventual exit even if agents perma-run.
+  #5 — `DaemonSpawnClaim` + daemon hand-off must write the same 3-line
+       payload as `_ReloadLock` (pid + iso-timestamp + initiator) for
+       operator-triage parity. Helper `_parse_pidfile_pid` tolerates
+       both legacy 1-line and new 3-line formats. Bash hook reads with
+       `head -1`. Hook schema bumps v8 → v9.
+
+These tests are RED on HEAD `4195228` (architect doc commit, no impl
+changes). They flip GREEN incrementally across commits 2, 3, 4.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ─── Item #2 — Dead _spawn_locks dict removed ────────────────────────────────
+
+
+class TestPolishPR93_SpawnLocksDictRemoved(unittest.TestCase):
+    """The `_spawn_locks` dict + `_spawn_locks_mu` lock in guard.py are
+    consumer-only (no producer exists in the tree). PR #92 replaced the
+    in-process fast-path with `DaemonSpawnClaim` (cross-process O_CREAT|
+    O_EXCL). The dict must be removed to eliminate dead code that the
+    consumer branch in `_is_guard_running_for_session` keys on.
+    """
+
+    def test_spawn_locks_dict_attribute_gone(self):
+        from cozempic import guard
+        self.assertFalse(
+            hasattr(guard, "_spawn_locks"),
+            "`_spawn_locks` dict must be removed (dead code — no producer "
+            "exists). The cross-process kernel claim in spawn_lock.py "
+            "subsumes the in-process fast-path entirely.",
+        )
+
+    def test_spawn_locks_mu_attribute_gone(self):
+        from cozempic import guard
+        self.assertFalse(
+            hasattr(guard, "_spawn_locks_mu"),
+            "`_spawn_locks_mu` must be removed alongside `_spawn_locks` — "
+            "the lock guards an empty dict.",
+        )
+
+
+class TestPolishPR93_PlaceholderPidIsUnlinked(unittest.TestCase):
+    """Regression test: even after the dead consumer branch is removed,
+    a placeholder-valued pidfile (pid <= 0) must still resolve to None
+    AND be unlinked. Mirrors TestR3_1 pattern but exercises the path
+    that survives the deletion."""
+
+    SESSION_ID = "pr93pl00-0000-0000-0000-000000000093"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+
+    def test_zero_pid_resolves_to_none_and_unlinks(self):
+        from cozempic.guard import _is_guard_running_for_session
+        self.pid_path.write_text("0\n")
+        result = _is_guard_running_for_session(self.SESSION_ID)
+        self.assertIsNone(result, "placeholder pid 0 must resolve to None")
+        self.assertFalse(self.pid_path.exists(), "placeholder pidfile must be unlinked")
+
+    def test_negative_pid_resolves_to_none_and_unlinks(self):
+        from cozempic.guard import _is_guard_running_for_session
+        self.pid_path.write_text("-1\n")
+        result = _is_guard_running_for_session(self.SESSION_ID)
+        self.assertIsNone(result, "negative pid must resolve to None")
+        self.assertFalse(self.pid_path.exists(), "placeholder pidfile must be unlinked")
+
+
+# ─── Item #3 — Pidfile unlinked on ALL daemon-exit paths ────────────────────
+
+
+class TestPolishPR93_SafeUnlinkHelper(unittest.TestCase):
+    """`_safe_unlink_session_pidfile(session_id)` is the shared helper
+    used by all daemon-exit paths. It MUST:
+      - Skip on falsy/empty session_id (no-op).
+      - Swallow ValueError (malformed session_id) and OSError.
+      - Use CAS via `_pid_file_points_to(session_id, os.getpid())` so it
+        doesn't destroy a peer's just-completed claim during reload.
+    """
+
+    SESSION_ID = "pr93un00-0000-0000-0000-000000000093"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+
+    def test_helper_exists(self):
+        from cozempic import guard
+        self.assertTrue(
+            hasattr(guard, "_safe_unlink_session_pidfile"),
+            "guard._safe_unlink_session_pidfile helper must exist",
+        )
+
+    def test_helper_unlinks_when_pid_matches(self):
+        from cozempic.guard import _safe_unlink_session_pidfile
+        # Write our own PID — CAS gate should pass.
+        self.pid_path.write_text(f"{os.getpid()}\n")
+        _safe_unlink_session_pidfile(self.SESSION_ID)
+        self.assertFalse(self.pid_path.exists())
+
+    def test_helper_skips_when_pid_mismatch(self):
+        """CAS gate: if pidfile contains another PID (peer's fresh claim),
+        we must NOT unlink — that would destroy the peer's claim."""
+        from cozempic.guard import _safe_unlink_session_pidfile
+        # Write a foreign PID (not ours) — CAS gate should skip the unlink.
+        foreign_pid = os.getpid() + 12345
+        self.pid_path.write_text(f"{foreign_pid}\n")
+        _safe_unlink_session_pidfile(self.SESSION_ID)
+        self.assertTrue(
+            self.pid_path.exists(),
+            "helper must NOT unlink when pidfile contains a foreign PID "
+            "(would destroy a peer's fresh claim)",
+        )
+
+    def test_helper_swallows_invalid_session_id(self):
+        from cozempic.guard import _safe_unlink_session_pidfile
+        # Must not raise on malformed session_id (shutdown path — worst
+        # possible time for an exception).
+        try:
+            _safe_unlink_session_pidfile("not-a-uuid")
+        except Exception as exc:
+            self.fail(f"helper must swallow invalid session_id, raised {exc!r}")
+
+    def test_helper_swallows_none_and_empty(self):
+        from cozempic.guard import _safe_unlink_session_pidfile
+        # Falsy inputs must no-op.
+        _safe_unlink_session_pidfile(None)
+        _safe_unlink_session_pidfile("")
+
+    def test_helper_handles_missing_pidfile(self):
+        from cozempic.guard import _safe_unlink_session_pidfile
+        # Pidfile already gone → must not raise.
+        self.pid_path.unlink(missing_ok=True)
+        _safe_unlink_session_pidfile(self.SESSION_ID)
+
+
+class TestPolishPR93_PidfileUnlinkedOnExit(unittest.TestCase):
+    """Drive start_guard through each exit path and assert the session
+    pidfile is unlinked via the finally-block helper."""
+
+    SESSION_ID = "pr93ex00-0000-0000-0000-000000000093"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        # Write OUR pid so the CAS gate in the helper accepts it.
+        self.pid_path.write_text(f"{os.getpid()}\n")
+
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmpdir, ignore_errors=True))
+        self.session_path = Path(self.tmpdir) / "fake_session.jsonl"
+        self.session_path.write_text('{"type":"user","message":{"content":"hi"}}\n')
+        self.fake_session = {"session_id": self.SESSION_ID, "path": self.session_path}
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+
+    def _drive_start_guard_until_exit(self, prune_returns_zero=True, agents_active=False):
+        """Helper: drive start_guard and trigger K=10 exit. Returns whether
+        SystemExit was raised."""
+        from cozempic import guard as guard_mod
+
+        class _FakeState:
+            def __init__(self, has_agents):
+                self.has_agents = has_agents
+                self.subagents = []
+                if has_agents:
+                    sub = type("S", (), {"status": "running"})()
+                    self.subagents = [sub]
+                self.tasks = []
+                self.message_count = 0
+
+            def is_empty(self):
+                return not self.has_agents
+
+        fake_state = _FakeState(agents_active)
+
+        def fake_prune_cycle(**kwargs):
+            return {
+                "saved_mb": 0.0 if prune_returns_zero else 10.0,
+                "original_tokens": 600_000,
+                "final_tokens": 600_000,
+                "team_name": None,
+                "team_messages": 0,
+                "checkpoint_path": None,
+                "backup_path": None,
+                "reloading": False,
+            }
+
+        sleep_count = {"n": 0}
+
+        def fake_sleep(_):
+            sleep_count["n"] += 1
+            if sleep_count["n"] > 200:
+                raise RuntimeError("test sleep limit exceeded — loop did not exit")
+
+        with (
+            patch.object(guard_mod.time, "sleep", side_effect=fake_sleep),
+            patch.object(guard_mod, "_resolve_session_by_id", return_value=self.fake_session),
+            patch.object(guard_mod, "find_current_session", return_value=self.fake_session),
+            patch.object(guard_mod, "find_claude_pid", return_value=None),
+            patch.object(guard_mod, "checkpoint_team", return_value=fake_state),
+            patch.object(guard_mod, "guard_prune_cycle", side_effect=fake_prune_cycle),
+            patch.object(guard_mod, "quick_token_estimate", return_value=600_000),
+            patch.object(guard_mod, "load_messages", return_value=[]),
+            patch("cozempic.session.record_session"),
+            patch.object(guard_mod, "_cleanup_stale_watchers"),
+            patch.object(guard_mod, "ping_install_if_new"),
+            patch.object(guard_mod, "maybe_auto_update"),
+            patch.object(guard_mod, "cleanup_old_backups"),
+            patch("cozempic.tokens.detect_context_window", return_value=1_000_000),
+        ):
+            try:
+                guard_mod.start_guard(
+                    cwd=self.tmpdir,
+                    threshold_mb=100.0,
+                    soft_threshold_mb=50.0,
+                    rx_name="standard",
+                    interval=30,
+                    auto_reload=False,
+                    reactive=False,
+                    threshold_tokens=500_000,
+                    soft_threshold_tokens=250_000,
+                    session_id=self.SESSION_ID,
+                )
+                return False  # No exit raised
+            except SystemExit:
+                return True
+
+    def test_k10_exit_unlinks_pidfile(self):
+        """K=10 voluntary exit path must unlink the session pidfile via the
+        finally-block helper."""
+        exited = self._drive_start_guard_until_exit(prune_returns_zero=True, agents_active=False)
+        self.assertTrue(exited, "K=10 should have triggered SystemExit")
+        self.assertFalse(
+            self.pid_path.exists(),
+            "pidfile must be unlinked after K=10 SystemExit "
+            "(architect spec: finally block in start_guard wraps "
+            "_safe_unlink_session_pidfile)",
+        )
+
+
+# ─── Item #4 — agents_active K=10 deferral + hard cap ───────────────────────
+
+
+class TestPolishPR93_K10DeferWhenAgentsActive(unittest.TestCase):
+    """When K reaches HARD_LOOP_EXIT_THRESHOLD (=10) but agents are still
+    running, the daemon MUST defer exit. A hard cap at
+    HARD_LOOP_HARD_EXIT_THRESHOLD (default 50, configurable via
+    COZEMPIC_GUARD_HARD_EXIT_K) ensures eventual exit.
+    """
+
+    SESSION_ID = "pr93k10a-0000-0000-0000-000000000093"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+        self.pid_path.write_text(f"{os.getpid()}\n")
+
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmpdir, ignore_errors=True))
+        self.session_path = Path(self.tmpdir) / "fake_session.jsonl"
+        self.session_path.write_text('{"type":"user","message":{"content":"hi"}}\n')
+        self.fake_session = {"session_id": self.SESSION_ID, "path": self.session_path}
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+
+    def test_hard_exit_threshold_constant_exists(self):
+        from cozempic import guard
+        self.assertTrue(
+            hasattr(guard, "HARD_LOOP_HARD_EXIT_THRESHOLD"),
+            "guard.HARD_LOOP_HARD_EXIT_THRESHOLD constant must exist "
+            "(architectural defer + hard cap)",
+        )
+        # Default is 50 per architect spec.
+        self.assertEqual(guard.HARD_LOOP_HARD_EXIT_THRESHOLD, 50)
+
+    def _run_loop(self, agents_active=True, max_cycles=80):
+        """Run start_guard with prune=0 forever and the given agents_active
+        state. Returns (exited, cycle_count)."""
+        from cozempic import guard as guard_mod
+
+        class _FakeState:
+            def __init__(self, has_agents):
+                self.has_agents = has_agents
+                sub = type("S", (), {"status": "running"})()
+                self.subagents = [sub] if has_agents else []
+                self.tasks = []
+                self.message_count = 0
+
+            def is_empty(self):
+                return not self.has_agents
+
+        fake_state = _FakeState(agents_active)
+
+        def fake_prune_cycle(**kwargs):
+            return {
+                "saved_mb": 0.0,
+                "original_tokens": 600_000,
+                "final_tokens": 600_000,
+                "team_name": None,
+                "team_messages": 0,
+                "checkpoint_path": None,
+                "backup_path": None,
+                "reloading": False,
+            }
+
+        sleep_calls = {"n": 0}
+
+        def fake_sleep(_):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= max_cycles:
+                raise RuntimeError(f"max_cycles={max_cycles} reached")
+
+        exited = False
+        with (
+            patch.object(guard_mod.time, "sleep", side_effect=fake_sleep),
+            patch.object(guard_mod, "_resolve_session_by_id", return_value=self.fake_session),
+            patch.object(guard_mod, "find_current_session", return_value=self.fake_session),
+            patch.object(guard_mod, "find_claude_pid", return_value=None),
+            patch.object(guard_mod, "checkpoint_team", return_value=fake_state),
+            patch.object(guard_mod, "guard_prune_cycle", side_effect=fake_prune_cycle),
+            patch.object(guard_mod, "quick_token_estimate", return_value=600_000),
+            patch.object(guard_mod, "load_messages", return_value=[]),
+            patch("cozempic.session.record_session"),
+            patch.object(guard_mod, "_cleanup_stale_watchers"),
+            patch.object(guard_mod, "ping_install_if_new"),
+            patch.object(guard_mod, "maybe_auto_update"),
+            patch.object(guard_mod, "cleanup_old_backups"),
+            patch("cozempic.tokens.detect_context_window", return_value=1_000_000),
+        ):
+            try:
+                guard_mod.start_guard(
+                    cwd=self.tmpdir,
+                    threshold_mb=100.0,
+                    soft_threshold_mb=50.0,
+                    rx_name="standard",
+                    interval=30,
+                    auto_reload=False,
+                    reactive=False,
+                    threshold_tokens=500_000,
+                    soft_threshold_tokens=250_000,
+                    session_id=self.SESSION_ID,
+                )
+            except SystemExit:
+                exited = True
+            except RuntimeError:
+                exited = False
+        return exited, sleep_calls["n"]
+
+    def test_k10_exits_when_no_agents(self):
+        """Regression: with no agents active, K=10 exit still fires (current
+        v1.8.14 behaviour preserved)."""
+        exited, _ = self._run_loop(agents_active=False, max_cycles=80)
+        self.assertTrue(
+            exited,
+            "K=10 should trigger SystemExit when no agents are active "
+            "(current v1.8.14 behaviour)",
+        )
+
+    def test_k10_defers_when_subagents_running(self):
+        """With agents_active=True at K=10, the daemon must NOT exit. The
+        loop should keep cycling at backoff cap until either agents quiesce
+        or the hard cap is reached."""
+        # 40 cycles is well past K=10 but well below the hard cap of 50.
+        exited, n = self._run_loop(agents_active=True, max_cycles=40)
+        self.assertFalse(
+            exited,
+            f"K=10 must NOT exit when agents_active=True (deferred). "
+            f"Got exited=True after {n} cycles.",
+        )
+
+    def test_hard_cap_exits_with_agents_active(self):
+        """Even with agents perma-running, the hard cap must fire eventually.
+        Use a low override via env var to keep the test fast."""
+        with patch.dict(os.environ, {"COZEMPIC_GUARD_HARD_EXIT_K": "15"}):
+            # Re-import to pick up env override at module load time, BUT the
+            # constant is read at module import. The architect spec says
+            # `int(os.environ.get(...))` is evaluated at module load. To
+            # actually exercise the override, we patch the module attribute.
+            import importlib
+            import cozempic.guard as guard_mod
+            importlib.reload(guard_mod)
+            try:
+                self.assertEqual(guard_mod.HARD_LOOP_HARD_EXIT_THRESHOLD, 15)
+                # Restore session_path resolution since we reloaded
+                exited, n = self._run_loop(agents_active=True, max_cycles=40)
+                self.assertTrue(
+                    exited,
+                    f"Hard cap K=15 should fire even with agents_active=True. "
+                    f"Got exited=False after {n} cycles.",
+                )
+            finally:
+                importlib.reload(guard_mod)
+
+
+# ─── Item #5 — DaemonSpawnClaim metadata parity with _ReloadLock ────────────
+
+
+class TestPolishPR93_SpawnClaimMetadataParity(unittest.TestCase):
+    """`DaemonSpawnClaim._claim` and the daemon hand-off in
+    `start_guard_daemon` must write a 3-line payload (pid + iso-timestamp
+    + initiator) matching `reload_lock._ReloadLock`'s convention."""
+
+    SESSION_ID = "pr93md00-0000-0000-0000-000000000093"
+
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.pid_path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self.pid_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+
+    def test_init_constants_exist(self):
+        from cozempic import spawn_lock
+        self.assertTrue(
+            hasattr(spawn_lock, "INIT_SPAWN_PARENT"),
+            "spawn_lock.INIT_SPAWN_PARENT constant must exist",
+        )
+        self.assertTrue(
+            hasattr(spawn_lock, "INIT_SPAWN_DAEMON"),
+            "spawn_lock.INIT_SPAWN_DAEMON constant must exist",
+        )
+        self.assertEqual(spawn_lock.INIT_SPAWN_PARENT, "spawn-claim-parent")
+        self.assertEqual(spawn_lock.INIT_SPAWN_DAEMON, "spawn-claim-daemon")
+
+    def test_spawn_claim_writes_3_line_payload(self):
+        """DaemonSpawnClaim writes pid + timestamp + 'spawn-claim-parent'."""
+        from cozempic.spawn_lock import DaemonSpawnClaim, INIT_SPAWN_PARENT
+
+        claim = DaemonSpawnClaim(self.SESSION_ID, self.pid_path)
+        try:
+            claim.__enter__()
+            content = self.pid_path.read_text()
+            lines = content.strip().split("\n")
+            self.assertEqual(
+                len(lines), 3,
+                f"pidfile must be 3 lines (pid, timestamp, initiator); got {lines!r}",
+            )
+            self.assertEqual(int(lines[0]), os.getpid())
+            # Line 2 must parse as ISO timestamp.
+            try:
+                datetime.fromisoformat(lines[1])
+            except ValueError:
+                self.fail(f"line 2 must be ISO timestamp; got {lines[1]!r}")
+            self.assertEqual(lines[2], INIT_SPAWN_PARENT)
+        finally:
+            claim.__exit__(None, None, None)
+
+    def test_parse_pidfile_handles_legacy_single_line(self):
+        from cozempic.spawn_lock import _parse_pidfile_pid
+        self.pid_path.write_text("12345\n")
+        self.assertEqual(_parse_pidfile_pid(self.pid_path), 12345)
+
+    def test_parse_pidfile_handles_new_3_line(self):
+        from cozempic.spawn_lock import _parse_pidfile_pid
+        self.pid_path.write_text("12345\n2026-05-19T10:00:00\nspawn-claim-parent\n")
+        self.assertEqual(_parse_pidfile_pid(self.pid_path), 12345)
+
+    def test_parse_pidfile_handles_garbage(self):
+        from cozempic.spawn_lock import _parse_pidfile_pid
+        self.pid_path.write_text("not-a-number\nfoo\n")
+        self.assertEqual(_parse_pidfile_pid(self.pid_path), 0)
+
+    def test_parse_pidfile_handles_empty(self):
+        from cozempic.spawn_lock import _parse_pidfile_pid
+        self.pid_path.write_text("")
+        self.assertEqual(_parse_pidfile_pid(self.pid_path), 0)
+
+    def test_parse_pidfile_handles_missing(self):
+        from cozempic.spawn_lock import _parse_pidfile_pid
+        self.pid_path.unlink(missing_ok=True)
+        self.assertEqual(_parse_pidfile_pid(self.pid_path), 0)
+
+    def test_is_guard_running_uses_tolerant_parser(self):
+        """Write a 3-line pidfile with the test runner's PID and force the
+        guard-identity gate to True. Confirm `_is_guard_running_for_session`
+        returns the PID — proving the parser extracted line 1 correctly.
+
+        Under the OLD `int(read_text().strip())` parser, the multi-line
+        content stripped is "PID\n2026...\nspawn-claim-parent" which
+        raises ValueError → result is None → assertion fails. Under the
+        NEW `_parse_pidfile_pid`, line 1 is extracted as PID → result is
+        the live PID."""
+        from cozempic.guard import _is_guard_running_for_session
+        my_pid = os.getpid()
+        self.pid_path.write_text(
+            f"{my_pid}\n2026-05-19T10:00:00\nspawn-claim-parent\n"
+        )
+        # Force the guard-identity gate to True so we exercise the parse
+        # path through to a positive return rather than the fresh-window
+        # fallback at line 1314.
+        with patch("cozempic.guard._is_cozempic_guard_process", return_value=True):
+            result = _is_guard_running_for_session(self.SESSION_ID)
+        self.assertEqual(
+            result, my_pid,
+            f"_is_guard_running_for_session must use a tolerant parser "
+            f"(first-line only) on 3-line pidfile. Got {result!r}, "
+            f"expected {my_pid} (live PID).",
+        )
+
+
+class TestPolishPR93_HookSchemaV9(unittest.TestCase):
+    """Hook schema bumps v8 → v9 because the bash hook's `cat | kill -0`
+    pattern would break on the new 3-line pidfile format. Migrated to
+    `head -1` which is POSIX and extracts only line 1 (the PID)."""
+
+    def test_hook_schema_version_v9(self):
+        from cozempic.init import HOOK_SCHEMA_VERSION
+        self.assertEqual(
+            HOOK_SCHEMA_VERSION, "v9",
+            "HOOK_SCHEMA_VERSION must bump v8 → v9 for the head -1 hook change",
+        )
+
+    def test_hooks_json_uses_head_minus_1(self):
+        """The bash hook MUST use `head -n 1` (or `head -1`) to read the PID,
+        not `cat`. With the new 3-line pidfile, `cat` returns multiple
+        whitespace-separated tokens to `kill -0`, which is undefined."""
+        for hooks_rel in (
+            "plugin/hooks/hooks.json",
+            "src/cozempic/data/hooks.json",
+        ):
+            hooks_path = Path(__file__).parent.parent / hooks_rel
+            with self.subTest(path=hooks_rel):
+                hooks = json.loads(hooks_path.read_text())
+                ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+                # Must use head, not cat, for the GUARD_PID_FILE liveness probe.
+                self.assertIn(
+                    "head -n 1 \"$GUARD_PID_FILE\"",
+                    ss_cmd,
+                    f"{hooks_rel}: bash hook must use `head -n 1` to read "
+                    f"the PID from GUARD_PID_FILE (3-line format compat)",
+                )
+                # Must NOT still use the old cat pattern for GUARD_PID_FILE.
+                self.assertNotIn(
+                    "cat \"$GUARD_PID_FILE\"",
+                    ss_cmd,
+                    f"{hooks_rel}: bash hook must not use `cat` "
+                    f"on GUARD_PID_FILE (breaks on 3-line pidfile)",
+                )
+
+    def test_hooks_json_marker_v9(self):
+        for hooks_rel in (
+            "plugin/hooks/hooks.json",
+            "src/cozempic/data/hooks.json",
+        ):
+            hooks_path = Path(__file__).parent.parent / hooks_rel
+            with self.subTest(path=hooks_rel):
+                body = hooks_path.read_text()
+                self.assertIn(
+                    "cozempic-hook-schema=v9",
+                    body,
+                    f"{hooks_rel}: schema marker must be v9",
+                )
+                self.assertNotIn(
+                    "cozempic-hook-schema=v8",
+                    body,
+                    f"{hooks_rel}: v8 marker must be migrated to v9",
+                )
+
+
+# ─── DA round 1 folded items (N3, M1, M2 — folded into commit 3) ────────────
+
+
+class TestPolishPR93_FreshWindowDocstring(unittest.TestCase):
+    """N3: `_read_fresh_window_seconds` docstring must clarify that the
+    env var COZEMPIC_PIDFILE_FRESH_SECONDS is read at module import time
+    and requires a daemon restart (not just env-var update) to take effect.
+    """
+
+    def test_docstring_mentions_import_time(self):
+        from cozempic.spawn_lock import _read_fresh_window_seconds
+        doc = _read_fresh_window_seconds.__doc__ or ""
+        self.assertTrue(
+            "import" in doc.lower() or "restart" in doc.lower(),
+            "docstring must clarify env var is read at import / requires restart",
+        )
+
+
+class TestPolishPR93_PidfileFsync(unittest.TestCase):
+    """M1: After `os.rename(.pid.tmp, .pid)`, the parent directory must
+    be fsynced for durability. Best verified by inspecting the source for
+    the explicit fsync call near the rename."""
+
+    def test_start_guard_daemon_fsyncs_parent_after_rename(self):
+        import inspect
+        from cozempic.guard import start_guard_daemon
+        src = inspect.getsource(start_guard_daemon)
+        # The hand-off block uses os.rename(tmp_path, pid_path). After
+        # that rename we must fsync the parent dir (or the .pid fd) to
+        # make the rename durable across an abrupt power loss.
+        self.assertTrue(
+            "fsync" in src,
+            "start_guard_daemon must call os.fsync on the parent dir "
+            "after the .pid.tmp → .pid rename (durability)",
+        )
+
+
+class TestPolishPR93_PidfileEACCES(unittest.TestCase):
+    """M2: `DaemonSpawnClaim._is_pidfile_fresh` must return True on EACCES
+    (PermissionError from stat) — a conservative-fresh classification.
+    A pidfile we can't stat could still be a live peer claim; returning
+    False would let us treat it as stale and re-claim, racing the peer."""
+
+    def test_is_pidfile_fresh_returns_true_on_permission_error(self):
+        from cozempic.spawn_lock import DaemonSpawnClaim
+        from unittest.mock import MagicMock, patch as _patch
+
+        claim = DaemonSpawnClaim("any-session-12345", Path("/tmp/x.pid"))
+
+        with _patch.object(
+            Path, "stat", side_effect=PermissionError("EACCES")
+        ):
+            result = claim._is_pidfile_fresh()
+        self.assertTrue(
+            result,
+            "EACCES on stat must classify pidfile as fresh (conservative — "
+            "DA round 1 M2 recommendation)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -410,26 +410,37 @@ class TestPolishPR93_K10DeferWhenAgentsActive(unittest.TestCase):
 
     def test_hard_cap_exits_with_agents_active(self):
         """Even with agents perma-running, the hard cap must fire eventually.
-        Use a low override via env var to keep the test fast."""
-        with patch.dict(os.environ, {"COZEMPIC_GUARD_HARD_EXIT_K": "15"}):
-            # Re-import to pick up env override at module load time, BUT the
-            # constant is read at module import. The architect spec says
-            # `int(os.environ.get(...))` is evaluated at module load. To
-            # actually exercise the override, we patch the module attribute.
-            import importlib
-            import cozempic.guard as guard_mod
-            importlib.reload(guard_mod)
-            try:
-                self.assertEqual(guard_mod.HARD_LOOP_HARD_EXIT_THRESHOLD, 15)
-                # Restore session_path resolution since we reloaded
-                exited, n = self._run_loop(agents_active=True, max_cycles=40)
-                self.assertTrue(
-                    exited,
-                    f"Hard cap K=15 should fire even with agents_active=True. "
-                    f"Got exited=False after {n} cycles.",
-                )
-            finally:
-                importlib.reload(guard_mod)
+        Patch the constant directly rather than env-var-reloading the module
+        so we don't pollute other tests with a leftover overridden value."""
+        import cozempic.guard as guard_mod
+        with patch.object(guard_mod, "HARD_LOOP_HARD_EXIT_THRESHOLD", 15):
+            self.assertEqual(guard_mod.HARD_LOOP_HARD_EXIT_THRESHOLD, 15)
+            exited, n = self._run_loop(agents_active=True, max_cycles=40)
+            self.assertTrue(
+                exited,
+                f"Hard cap K=15 should fire even with agents_active=True. "
+                f"Got exited=False after {n} cycles.",
+            )
+        # After patch exits, constant is restored to module default (50).
+        self.assertEqual(guard_mod.HARD_LOOP_HARD_EXIT_THRESHOLD, 50)
+
+    def test_env_var_overrides_hard_cap(self):
+        """Module-import env var COZEMPIC_GUARD_HARD_EXIT_K is read by
+        _read_hard_exit_threshold and clamped. Test the helper directly
+        (not via importlib.reload which is hard to clean up reliably)."""
+        import cozempic.guard as guard_mod
+        with patch.dict(os.environ, {"COZEMPIC_GUARD_HARD_EXIT_K": "25"}):
+            self.assertEqual(guard_mod._read_hard_exit_threshold(), 25)
+
+    def test_env_var_invalid_falls_back_to_default(self):
+        import cozempic.guard as guard_mod
+        for bad in ("not-a-number", "0", "-5", "10", "9", "10000"):
+            with self.subTest(value=bad):
+                with patch.dict(os.environ, {"COZEMPIC_GUARD_HARD_EXIT_K": bad}):
+                    self.assertEqual(
+                        guard_mod._read_hard_exit_threshold(), 50,
+                        f"invalid value {bad!r} must fall back to default 50",
+                    )
 
 
 # ─── Item #5 — DaemonSpawnClaim metadata parity with _ReloadLock ────────────

--- a/tests/test_hook_idempotency_shell.py
+++ b/tests/test_hook_idempotency_shell.py
@@ -148,9 +148,12 @@ class TestHookSpawnIdempotency(unittest.TestCase):
         if not self.pid_file.exists():
             return
         try:
-            pid = int(self.pid_file.read_text().strip())
+            # PR #93 item #5: pidfile may be 1-line legacy or 3-line new.
+            # Parse first line only for forward-compat.
+            first_line = self.pid_file.read_text().splitlines()[0].strip()
+            pid = int(first_line)
             os.kill(pid, 9)
-        except (ValueError, ProcessLookupError, OSError):
+        except (ValueError, ProcessLookupError, OSError, IndexError):
             pass
 
     def _run_hook_once(self, hook_cmd: str) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

Post-merge polish addressing the 5 followup items from your PR #92 review comment ([#92 review by @junaidtitan](https://github.com/Ruya-AI/cozempic/pull/92#issuecomment-4484949050)).

Per Junaid's invitation: items 2-5 closed in this PR with code changes. Item 1 (PR body said v6→v7 but actual code is v8) is documentation-only and not worth editing the merged PR body.

Architect subagent enforced our internal class-of-bug fold rule, so this PR also closes 4 pre-existing items in the same files (TODO graceful_shutdown leak + DA round 1 MED/LOW deferred N3/M1/M2) plus 4 additional `start_guard` exit paths (KeyboardInterrupt + 4 `break` paths) that had the same pidfile leak shape as Junaid item #3.

## Fix per commit

### `fix(guard): remove dead _spawn_locks dict + unlink pidfile on all daemon-exit paths` (Junaid items #2 + #3)

- **Item #2** — `_spawn_locks: dict[str, threading.Lock]` at `guard.py:35-36` had zero producers in the tree (PR #92's `DaemonSpawnClaim` replaced the in-process spawn fast-path with kernel-mediated `O_CREAT|O_EXCL`). The remaining consumer in `_is_guard_running_for_session` was dead code. Removed dict + mutex + consumer branch. ~12 LOC delete, no behavioral change.
- **Item #3** — New helper `_safe_unlink_session_pidfile(session_id)` uses the existing `_pid_file_points_to(session_id, os.getpid())` CAS pattern (sister-module precedent from `reload_self_daemon`) so it won't destroy a peer's just-completed claim. Wired into the `finally` block of `start_guard` which covers ALL six daemon-exit paths: `_graceful_shutdown` SIGTERM handler, K=10 sys.exit(0), KeyboardInterrupt, and the 4 `break` paths in the main loop. The pre-existing `_graceful_shutdown` leak (tracked in our internal TODO since PR #88 validator) is folded in via the same helper.

### `fix(guard,spawn_lock,hooks): metadata parity with _ReloadLock + hook v9 schema` (Junaid item #5 + folded N3/M1/M2)

- **Item #5** — `DaemonSpawnClaim._claim` now writes the 3-line payload format matching `_ReloadLock`: `{pid}\n{iso-timestamp}\n{initiator}\n`. New initiator constants `INIT_SPAWN_PARENT` / `INIT_SPAWN_DAEMON` mirror the `INIT_CLI_RELOAD` / `INIT_GUARD_HARD1` / `INIT_OVERFLOW` convention. New `_parse_pidfile_pid` tolerant first-line parser handles both legacy 1-line and new 3-line formats gracefully (returns 0 on malformed).
- **Critical bash hook change** — `plugin/hooks/hooks.json:9` and `src/cozempic/data/hooks.json:9`: `kill -0 "$(cat "$GUARD_PID_FILE")"` → `kill -0 "$(head -n 1 "$GUARD_PID_FILE")"`. The legacy `cat` reader would word-split the new 3-line content and pass `pid timestamp initiator` to `kill -0`, returning nonzero and triggering a spurious dup-spawn attempt that would lose on `O_CREAT|O_EXCL` (benign but noisy).
- **Hook schema bump** — `HOOK_SCHEMA_VERSION` v8 → v9 in `src/cozempic/init.py`. Existing v8 installs auto-refresh via `_maybe_auto_init` on first cozempic CLI invocation. **One-cycle migration window** described below.
- Folded items: N3 (env var runtime-export docstring), M1 (fsync on rename — implementer added BOTH inner fd fsync AND parent-dir fsync, strictly stronger than spec), M2 (`_is_pidfile_fresh` returns True conservatively on stat() EACCES).

### `fix(guard): defer K=10 exit when agents_active + hard cap` (Junaid item #4 — architectural)

- New constant `HARD_LOOP_HARD_EXIT_THRESHOLD = 50` (default ~4.17h max wall-clock at backoff cap 300s). Env-overridable via `COZEMPIC_GUARD_HARD_EXIT_K` with a strict `>10` floor and finite-positive validation.
- At K=10 with `agents_active=True` (from `extract_team_state`): defer exit, log a one-time "K=10 reached but agents_active=true, deferring exit until K>=50 (~4h worst case)" message, continue cycling at backoff cap. When agents quiesce, the normal K=10 exit fires.
- At K=50 regardless of `agents_active`: exit. The diagnostic correctly does NOT recommend `/clear` at hard cap (would lose mid-task agent state).
- Reproducer-scenario walk: traced through the BMAD-with-subagents scenario from our internal handoff that triggered the original PR #92 crash. With this defer logic, daemon stays alive while subagents finish; K resets to 0 the moment any prune succeeds.

## Hook v8 → v9 migration window (H1, benign)

First SessionStart hook firing post-upgrade may still execute the user's installed v8 hook command (`cat $pid_file` reader) against a new v1.8.15 daemon writing a 3-line pidfile. Bash word-splits the cat output → `kill -0 pid timestamp initiator` returns nonzero (or coincidentally zero from sigfile-style 3-arg kill) → one spurious duplicate-spawn attempt that loses on `DaemonSpawnClaim`'s `O_CREAT|O_EXCL`. Net effect: benign, one wasted spawn attempt, no daemon corruption, no log spam beyond a single line.

The user's settings.json hook auto-refreshes to v9 on the first cozempic subcommand invocation (any `cozempic checkpoint` / `cozempic digest inject` from existing Stop/PostCompact/PostToolUse hooks), so the window closes after the first post-upgrade session activity.

Adding a one-line CHANGELOG / release notes mention would be courteous for operators reading the upgrade log; flagged for your release process.

## Tests

`PYTHONPATH=src python3 -m pytest tests/ -q --ignore=tests/test_model_detection.py`
**786 passed, 36 subtests passed** (was 755 on PR #92 branch baseline; +31 net new tests in `tests/test_guard_polish_pr93.py` + 1 class rename `TestHookSchemaV8` → `TestHookSchemaV9` in `tests/test_atomic_writes_wave1.py`).

V4 stress regression (10 concurrent processes × 30 iterations × 3 consecutive runs): **900/900 single-winner** (no regression vs PR #92's stress floor).

Live smoke test 60s: daemon spawned, 3-line pidfile observed on disk (`pid\ntimestamp\nspawn-claim-daemon\n`), SIGTERM handled, pidfile unlinked cleanly per item #3 fix.

3-round internal adversarial review by independent agents: PASS WITH CONDITIONS (1 HIGH = the H1 changelog cosmetic above, 2 MED out of scope for this PR, 2 LOW nits).

## Test plan

- [ ] `git fetch && git checkout this-branch && PYTHONPATH=src python3 -m pytest tests/ -q --ignore=tests/test_model_detection.py` → 786 passed
- [ ] Stress: 3 consecutive runs of the V4 10-process race (script in commit message) → all 0/30 failures
- [ ] Spawn a real daemon, kill -TERM it, verify pidfile is unlinked: `cozempic guard --daemon --session test-uuid-1 --cwd /tmp/smoke &; sleep 2; cat /tmp/cozempic_guard_test-uuid-1.pid # should be 3 lines; kill -TERM $(head -n1 /tmp/cozempic_guard_test-uuid-1.pid); sleep 2; ls /tmp/cozempic_guard_test-uuid-1.pid # should be absent`
- [ ] Verify hook bash migration: install fresh, force a SessionStart, confirm `_maybe_auto_init` refreshes v8 hook to v9 in user's settings.json after first cozempic subcommand call

## Scope

- Zero new required dependencies (`math.isfinite` is stdlib).
- All 786 pre-existing tests stay GREEN (no regression).
- Backward-compatible with v1.8.14 daemon: `_parse_pidfile_pid` reads both legacy 1-line and new 3-line formats.
- Hook schema v9 auto-migrates via existing `_maybe_auto_init` flow.
- This PR does NOT address the transient-daemon-vs-SessionStart race surfaced in our internal investigation of a v1.8.14 session that lost its guard after reload — that's a separate concern queued for a follow-up PR with its own design (3 options under consideration: transient marker, self-unlink before exit, abandon transient daemon).

## Reported by

Junaid's PR #92 review comment ([#92 review](https://github.com/Ruya-AI/cozempic/pull/92#issuecomment-4484949050)). Our internal architect subagent enforced class-of-bug fold rule per our project's FIX DISCIPLINE — every known instance of "pidfile leak on daemon exit" fixed in one commit, every known instance of "asymmetric metadata between sister modules" closed.
