### PR TITLE
fix(tests): isolate test_model_detection from COZEMPIC_CONTEXT_WINDOW env leak

### DIFF
--- a/tests/test_model_detection.py
+++ b/tests/test_model_detection.py
@@ -79,6 +79,22 @@ class TestDetectModel(unittest.TestCase):
 
 class TestDetectContextWindow(unittest.TestCase):
 
+    def setUp(self):
+        # Isolate from inherited COZEMPIC_CONTEXT_WINDOW env var. Some dev
+        # boxes set this globally (e.g., to force a specific window for the
+        # guard daemon). When present, get_context_window_override() returns
+        # the env value and short-circuits the MODEL_CONTEXT_WINDOWS dict
+        # lookup that these tests target — producing "1M != 200K" failures
+        # on model-mapping tests that ARE actually correct in production
+        # code. Tests that exercise the override path explicitly use
+        # patch.dict to set the env var inside their own context.
+        self._prev_env = os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+        self.addCleanup(self._restore_env)
+
+    def _restore_env(self):
+        if self._prev_env is not None:
+            os.environ["COZEMPIC_CONTEXT_WINDOW"] = self._prev_env
+
     def test_opus_47_is_1m(self):
         """Current Opus 4.7 defaults to 1M (standard for Claude Code Max)."""
         messages = [make_assistant_with_model(0, "claude-opus-4-7")]
@@ -155,6 +171,19 @@ class TestGetContextWindowOverride(unittest.TestCase):
 
 
 class TestEstimateSessionTokensWithModel(unittest.TestCase):
+
+    def setUp(self):
+        # Same env-isolation pattern as TestDetectContextWindow — see comment
+        # there. estimate_session_tokens() calls detect_context_window()
+        # internally, which honours COZEMPIC_CONTEXT_WINDOW. Without this
+        # cleanup, test_context_pct_200k_model fails on dev boxes that set
+        # the env var globally.
+        self._prev_env = os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
+        self.addCleanup(self._restore_env)
+
+    def _restore_env(self):
+        if self._prev_env is not None:
+            os.environ["COZEMPIC_CONTEXT_WINDOW"] = self._prev_env
 
     def test_includes_model_in_result(self):
         messages = [make_assistant_with_model(0, "claude-opus-4-6", input_tokens=50000)]


### PR DESCRIPTION
## Summary

3 tests in `tests/test_model_detection.py` fail when `COZEMPIC_CONTEXT_WINDOW` is set in the inherited shell environment, even though the production code is correct. Root-caused to a test-isolation gap; fixed via `setUp` env var cleanup.

## Problem

The failing tests:

- `TestDetectContextWindow.test_haiku_45_is_200k`
- `TestDetectContextWindow.test_older_models_200k`
- `TestEstimateSessionTokensWithModel.test_context_pct_200k_model`

…all assume `detect_context_window()` returns 200K for older / Haiku models, looking up `MODEL_CONTEXT_WINDOWS` dict at `tokens.py:72-87`. They do NOT mock the environment.

`detect_context_window()` at `tokens.py:131` calls `get_context_window_override()` FIRST. If `COZEMPIC_CONTEXT_WINDOW` is set in the env (a common case on dev boxes where the user has it set globally to force a specific window for the cozempic guard daemon), the override returns immediately and the dict lookup is bypassed. With `COZEMPIC_CONTEXT_WINDOW=1000000`, the 3 tests above fail with "1M != 200K" — looks like a code regression but is actually pure test isolation.

Verified via `env -i` clean run: 29/29 PASS without any env var present.

## Fix

Add `setUp` method to both affected classes that pops `COZEMPIC_CONTEXT_WINDOW` from `os.environ` (saving the inherited value) and registers an `addCleanup` to restore it on tearDown. Tests that EXERCISE the override path explicitly use `patch.dict(os.environ, ...)` and remain unaffected.

```python
def setUp(self):
    self._prev_env = os.environ.pop("COZEMPIC_CONTEXT_WINDOW", None)
    self.addCleanup(self._restore_env)

def _restore_env(self):
    if self._prev_env is not None:
        os.environ["COZEMPIC_CONTEXT_WINDOW"] = self._prev_env
```

Pure test-only change. No production code modified. No behavior change.

## Test verification

```
$ env | grep COZEMPIC
COZEMPIC_CONTEXT_WINDOW=1000000

$ PYTHONPATH=src python3 -m pytest tests/test_model_detection.py -v
29 passed in 0.02s

$ env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin PYTHONPATH=src python3 -m pytest tests/test_model_detection.py -v
29 passed in 0.02s

$ PYTHONPATH=src python3 -m pytest tests/ -q
784 passed, 26 subtests passed in 20.10s
```

Both scenarios pass. No regression elsewhere.

## Test plan

- [ ] With the env var set: `COZEMPIC_CONTEXT_WINDOW=1000000 PYTHONPATH=src python3 -m pytest tests/test_model_detection.py -v` → 29 passed
- [ ] With clean env: `env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin PYTHONPATH=src python3 -m pytest tests/test_model_detection.py -v` → 29 passed
- [ ] Full suite no regression: `PYTHONPATH=src python3 -m pytest tests/ -q` → all green

## Scope

- Zero production code changes.
- Test-only diff (~29 lines added, 0 removed).
- Backward-compatible with any inherited env state.
- Independent of PRs #93 and #94 currently in flight (those touch `guard.py` / `spawn_lock.py` / `reload_lock.py` / `hooks.json`; this PR touches only `tests/test_model_detection.py`).
