### PR TITLE
fix(init): _SettingsLock cross-platform — Windows msvcrt branch

### DIFF
--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -245,11 +245,17 @@ class _SettingsLock:
             # lock file content is irrelevant — we only use the fd for locking.
             self._fh = open(self.lock_path, "a")
             if _os.name == "nt":
-                # Windows — msvcrt.locking locks bytes from the current file
-                # position. "a" mode on a fresh/empty lock file leaves the
-                # pointer at byte 0, so this locks byte 0. Mirrors the
-                # _HostFileLock pattern in helpers.py.
+                # Windows — msvcrt.locking locks bytes from the CURRENT file
+                # position. "a" (append) mode on Windows leaves the pointer at
+                # EOF: byte 0 on a fresh empty lock file, but >0 if a stale
+                # non-empty lock file was left from a prior crashed run.
+                # __exit__ rewinds to byte 0 before LK_UNLCK, so without
+                # this matching seek(0) before LK_LOCK the two operations
+                # would target different byte ranges and silently fail to
+                # serialize. Mirrors the _HostFileLock pattern in helpers.py
+                # (which has the same defense-in-depth gap — separate fix).
                 import msvcrt
+                self._fh.seek(0)
                 msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
             else:
                 # POSIX — use lockf (record locks) not flock: lockf works

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -227,31 +227,56 @@ class _SettingsLock:
     run a first-init concurrently, or when SessionStart hooks fire for two
     sessions simultaneously) from clobbering each other's additions.
 
-    Best-effort on platforms without fcntl (Windows): degrades to a no-op
-    context manager so we don't crash, we just lose the concurrency guarantee.
+    Cross-platform: POSIX uses fcntl.lockf (chosen over flock for NFS
+    reliability — flock silent-no-ops on NFSv3), Windows uses
+    msvcrt.locking on the first byte of the lock file (same per-byte
+    semantics, sibling pattern to _HostFileLock in helpers.py). Falls
+    back to no-op on platforms missing both fcntl AND msvcrt.
     """
     def __init__(self, settings_path: Path):
         self.lock_path = settings_path.parent / ".cozempic-init.lock"
         self._fh = None
 
     def __enter__(self):
+        import os as _os
         try:
-            import fcntl
             self.lock_path.parent.mkdir(parents=True, exist_ok=True)
             # Append mode so two racing opens don't truncate each other; the
             # lock file content is irrelevant — we only use the fd for locking.
             self._fh = open(self.lock_path, "a")
-            # Use lockf (POSIX record locks) not flock: lockf works reliably
-            # over NFS, whereas flock on NFSv3 historically silent-no-ops
-            # (returns success without actually locking), which would let two
-            # init runs clobber each other on network homes.
-            fcntl.lockf(self._fh.fileno(), fcntl.LOCK_EX)
+            if _os.name == "nt":
+                # Windows — msvcrt.locking locks bytes from the current file
+                # position. "a" mode on a fresh/empty lock file leaves the
+                # pointer at byte 0, so this locks byte 0. Mirrors the
+                # _HostFileLock pattern in helpers.py.
+                import msvcrt
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                # POSIX — use lockf (record locks) not flock: lockf works
+                # reliably over NFS, whereas flock on NFSv3 historically
+                # silent-no-ops (returns success without actually locking),
+                # which would let two init runs clobber each other on
+                # network homes.
+                import fcntl
+                fcntl.lockf(self._fh.fileno(), fcntl.LOCK_EX)
         except ImportError:
-            # Windows — fcntl unavailable. Proceed without locking.
+            # Platform missing both fcntl AND msvcrt (extremely unusual —
+            # e.g. some embedded cpython builds). Degrade to unlocked; we
+            # lose the concurrency guarantee but don't crash.
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                except OSError:
+                    pass
             self._fh = None
         except OSError as exc:
             # Permission error (read-only .claude/), disk full, etc. Degrade to
             # unlocked but warn — silent skipping would hide real setup problems.
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                except OSError:
+                    pass
             self._fh = None
             sys.stderr.write(
                 f"  Cozempic: settings lock unavailable ({exc}); proceeding without concurrency guard.\n"
@@ -259,16 +284,28 @@ class _SettingsLock:
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        if self._fh is not None:
-            try:
+        if self._fh is None:
+            return
+        import os as _os
+        try:
+            if _os.name == "nt":
+                import msvcrt
+                # msvcrt.locking unlocks bytes from the current file
+                # position — seek back to byte 0 to match the lock site.
+                try:
+                    self._fh.seek(0)
+                    msvcrt.locking(self._fh.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
                 import fcntl
                 fcntl.lockf(self._fh.fileno(), fcntl.LOCK_UN)
-            except (ImportError, OSError):
-                pass
-            try:
-                self._fh.close()
-            except OSError:
-                pass
+        except (ImportError, OSError):
+            pass
+        try:
+            self._fh.close()
+        except OSError:
+            pass
 
 
 def wire_hooks(project_dir: str) -> dict:

--- a/tests/test_settings_lock.py
+++ b/tests/test_settings_lock.py
@@ -10,10 +10,13 @@ new behavior:
     Both missing → no-op fallback (no crash)
     OSError on real platform → warn + no-op (settings lock unavailable)
 
-Running on POSIX CI exercises the Windows branch via a `sys.modules`
-shim that fakes `msvcrt` with a per-byte locking model. The reverse —
-exercising the POSIX branch on Windows CI — is covered by the existing
-test_global_init.py suite that hits `wire_hooks` end-to-end.
+The four `test_windows_*` tests monkeypatch `os.name = "nt"` and inject
+a fake `msvcrt` into `sys.modules` so the Windows branch runs
+unconditionally regardless of host OS — on Windows the fake REPLACES
+the real `msvcrt` (we deliberately want to assert on the call shape,
+not exercise the real kernel lock). The POSIX branch is exercised by
+the two `test_posix_*` tests when host OS is POSIX, and by the existing
+`test_global_init.py` suite that hits `wire_hooks` end-to-end.
 """
 from __future__ import annotations
 
@@ -113,12 +116,14 @@ def test_windows_acquires_msvcrt_locking(monkeypatch, settings_path: Path) -> No
 
 
 def test_windows_seek_zero_before_unlock(monkeypatch, settings_path: Path) -> None:
-    """msvcrt.locking is position-relative — __exit__ must seek to 0 before LK_UNLCK.
+    """msvcrt.locking is position-relative — both __enter__ AND __exit__ must seek(0).
 
-    'a' (append) mode leaves the file pointer at end-of-file. For an
-    empty fresh lock file that's byte 0, but defense-in-depth: we MUST
-    seek(0) before unlocking. The test asserts seek is called with 0
-    before the LK_UNLCK call.
+    'a' (append) mode leaves the file pointer at end-of-file. For a fresh
+    empty lock file EOF==0, but for a stale non-empty lock file from a
+    prior crashed run, EOF>0. Without seek(0) before BOTH LK_LOCK (acquire)
+    AND LK_UNLCK (release), the two operations target different byte
+    ranges and silently fail to serialize. The test asserts seek(0) is
+    called at least twice — once around acquire, once around release.
     """
     fake = _FakeMsvcrt()
     _force_windows_mode(monkeypatch, fake)
@@ -143,12 +148,72 @@ def test_windows_seek_zero_before_unlock(monkeypatch, settings_path: Path) -> No
     with _SettingsLock(settings_path):
         pass
 
-    # seek(0) must have been called between the lock and unlock calls.
-    assert 0 in seeks, f"seek(0) not invoked; saw seeks={seeks}"
+    # seek(0) must have been called at least twice: once before LK_LOCK
+    # (defense-in-depth for stale non-empty lock files), once before
+    # LK_UNLCK. If either is missing, the lock/release pair targets
+    # different byte positions on non-empty lock files.
+    assert seeks.count(0) >= 2, (
+        f"expected at least 2 seek(0) calls (before LK_LOCK and before LK_UNLCK), "
+        f"got seeks={seeks}"
+    )
+
+
+def test_windows_acquire_position_normalized_on_stale_lock_file(monkeypatch, settings_path: Path) -> None:
+    """Regression test for the stale-non-empty-lock-file case: the byte locked
+    by LK_LOCK MUST equal the byte unlocked by LK_UNLCK (both byte 0).
+
+    Reproducer: pre-populate the lock file with content so EOF > 0. Without
+    seek(0) before LK_LOCK, the lock would land at byte EOF while the
+    unlock would target byte 0 — different ranges, no mutual exclusion.
+    Asserted by recording the file position at each msvcrt.locking call.
+    """
+    # Pre-populate the lock file so EOF > 0.
+    lock_path = settings_path.parent / ".cozempic-init.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("stale content from prior crashed run\n")
+    assert lock_path.stat().st_size > 0
+
+    # Capture the file position at the moment each msvcrt.locking call fires.
+    position_at_call: list = []
+    captured_fh: list = []
+
+    fake = _FakeMsvcrt()
+    original_locking = fake.locking
+
+    def position_aware_locking(fd, mode, nbytes):
+        # captured_fh[0] is the file handle opened by _SettingsLock
+        if captured_fh:
+            position_at_call.append((mode, captured_fh[0].tell()))
+        return original_locking(fd, mode, nbytes)
+
+    fake.locking = position_aware_locking
+    _force_windows_mode(monkeypatch, fake)
+
+    original_open = open
+
+    def capturing_open(path, *args, **kwargs):
+        fh = original_open(path, *args, **kwargs)
+        captured_fh.append(fh)
+        return fh
+
+    monkeypatch.setattr("builtins.open", capturing_open)
+
+    with _SettingsLock(settings_path):
+        pass
+
+    # Both LK_LOCK and LK_UNLCK must have fired at position 0 — anything
+    # else means the seek(0) before-LK_LOCK or before-LK_UNLCK is missing.
+    assert len(position_at_call) == 2, f"expected 2 locking calls, got {position_at_call}"
+    lock_mode, lock_pos = position_at_call[0]
+    unlock_mode, unlock_pos = position_at_call[1]
+    assert lock_mode == _FakeMsvcrt.LK_LOCK
+    assert unlock_mode == _FakeMsvcrt.LK_UNLCK
+    assert lock_pos == 0, f"LK_LOCK fired at byte {lock_pos}, expected 0 (stale file case)"
+    assert unlock_pos == 0, f"LK_UNLCK fired at byte {unlock_pos}, expected 0"
 
 
 def test_windows_oserror_during_lock_warns_and_degrades(monkeypatch, capsys, settings_path: Path) -> None:
-    """OSError from msvcrt.locking degrades to no-op + stderr warning, no crash."""
+    """OSError from msvcrt.locking degrades to no-op + stderr warning + fh close."""
     fake = _FakeMsvcrt()
 
     def raising_locking(fd, mode, nbytes):
@@ -161,11 +226,28 @@ def test_windows_oserror_during_lock_warns_and_degrades(monkeypatch, capsys, set
     stderr_buf = io.StringIO()
     monkeypatch.setattr(sys, "stderr", stderr_buf)
 
+    # Capture the file handle that was opened-then-abandoned by the OSError
+    # cleanup path, so we can assert it was closed (no fd leak).
+    opened_handles: list = []
+    original_open = open
+
+    def tracking_open(path, *args, **kwargs):
+        fh = original_open(path, *args, **kwargs)
+        opened_handles.append(fh)
+        return fh
+
+    monkeypatch.setattr("builtins.open", tracking_open)
+
     with _SettingsLock(settings_path) as lock:
         # _fh should be None — degraded path
         assert lock._fh is None
 
     assert "settings lock unavailable" in stderr_buf.getvalue()
+    # The file handle that was opened before msvcrt.locking failed MUST have
+    # been closed by the OSError cleanup branch — otherwise the fd leaks
+    # every time a settings lock acquisition fails (read-only mount, etc.).
+    assert opened_handles, "expected open() to have been called"
+    assert opened_handles[0].closed, "fd leak: opened lock file was not closed on OSError"
 
 
 # ─── Missing-both fallback (neither fcntl nor msvcrt) ────────────────────────

--- a/tests/test_settings_lock.py
+++ b/tests/test_settings_lock.py
@@ -1,0 +1,204 @@
+"""Tests for _SettingsLock cross-platform behavior.
+
+The lock is exercised by `wire_hooks` / `uninstall_hooks` during `cozempic
+init`. Until the v1.8.x cross-platform fix it degraded to a silent no-op
+on Windows because `import fcntl` raised ImportError. This file pins the
+new behavior:
+
+    POSIX → fcntl.lockf (record locks, NFS-reliable, unchanged)
+    Windows → msvcrt.locking (per-byte LK_LOCK/LK_UNLCK)
+    Both missing → no-op fallback (no crash)
+    OSError on real platform → warn + no-op (settings lock unavailable)
+
+Running on POSIX CI exercises the Windows branch via a `sys.modules`
+shim that fakes `msvcrt` with a per-byte locking model. The reverse —
+exercising the POSIX branch on Windows CI — is covered by the existing
+test_global_init.py suite that hits `wire_hooks` end-to-end.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from cozempic.init import _SettingsLock
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def settings_path(tmp_path: Path) -> Path:
+    """A settings.json path; the lock sibling lives at .cozempic-init.lock."""
+    return tmp_path / "settings.json"
+
+
+# ─── POSIX path ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only — fcntl unavailable on Windows")
+def test_posix_acquires_fcntl_lockf(settings_path: Path) -> None:
+    """On POSIX the lock issues fcntl.lockf LOCK_EX on enter, LOCK_UN on exit."""
+    import fcntl
+    with mock.patch("fcntl.lockf") as lockf:
+        with _SettingsLock(settings_path):
+            pass
+    assert lockf.call_count == 2
+    enter_args = lockf.call_args_list[0].args
+    exit_args = lockf.call_args_list[1].args
+    assert enter_args[1] == fcntl.LOCK_EX
+    assert exit_args[1] == fcntl.LOCK_UN
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only — needs real fcntl + tmpfs")
+def test_posix_real_lockfile_created(settings_path: Path) -> None:
+    """The actual lock file lands alongside settings.json."""
+    with _SettingsLock(settings_path):
+        assert (settings_path.parent / ".cozempic-init.lock").exists()
+
+
+# ─── Windows path (exercised via fake msvcrt on POSIX) ───────────────────────
+
+
+class _FakeMsvcrt:
+    """In-memory model of msvcrt.locking for cross-platform testing.
+
+    We don't simulate cross-process contention — that's what the real
+    msvcrt.locking would do. We just record the calls so we can assert
+    the right operations happen in the right order with the right args.
+    """
+    LK_LOCK = 1
+    LK_UNLCK = 0
+
+    def __init__(self):
+        self.calls: list[tuple[int, int, int]] = []  # (fd, mode, nbytes)
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        self.calls.append((fd, mode, nbytes))
+
+
+def _force_windows_mode(monkeypatch, fake: _FakeMsvcrt) -> None:
+    """Monkeypatch os.name == 'nt' and inject fake msvcrt module."""
+    monkeypatch.setattr(os, "name", "nt")
+    fake_module = types.ModuleType("msvcrt")
+    fake_module.LK_LOCK = fake.LK_LOCK
+    fake_module.LK_UNLCK = fake.LK_UNLCK
+    fake_module.locking = fake.locking
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_module)
+
+
+def test_windows_acquires_msvcrt_locking(monkeypatch, settings_path: Path) -> None:
+    """On Windows-mode the lock issues msvcrt.locking LK_LOCK at byte 0 on enter, LK_UNLCK on exit."""
+    fake = _FakeMsvcrt()
+    _force_windows_mode(monkeypatch, fake)
+
+    with _SettingsLock(settings_path):
+        pass
+
+    # Exactly two locking calls — lock then unlock — both on 1 byte.
+    assert len(fake.calls) == 2, f"expected 2 calls, got {fake.calls}"
+    enter_fd, enter_mode, enter_n = fake.calls[0]
+    exit_fd, exit_mode, exit_n = fake.calls[1]
+    assert enter_mode == _FakeMsvcrt.LK_LOCK
+    assert exit_mode == _FakeMsvcrt.LK_UNLCK
+    assert enter_n == 1 and exit_n == 1
+    # Same fd used for lock and unlock (otherwise we'd be unlocking a
+    # different file).
+    assert enter_fd == exit_fd
+
+
+def test_windows_seek_zero_before_unlock(monkeypatch, settings_path: Path) -> None:
+    """msvcrt.locking is position-relative — __exit__ must seek to 0 before LK_UNLCK.
+
+    'a' (append) mode leaves the file pointer at end-of-file. For an
+    empty fresh lock file that's byte 0, but defense-in-depth: we MUST
+    seek(0) before unlocking. The test asserts seek is called with 0
+    before the LK_UNLCK call.
+    """
+    fake = _FakeMsvcrt()
+    _force_windows_mode(monkeypatch, fake)
+
+    # Capture seek calls on the file handle.
+    seeks: list[int] = []
+    original_open = open
+
+    def tracking_open(path, *args, **kwargs):
+        fh = original_open(path, *args, **kwargs)
+        original_seek = fh.seek
+
+        def recording_seek(offset, *seek_args, **seek_kwargs):
+            seeks.append(offset)
+            return original_seek(offset, *seek_args, **seek_kwargs)
+
+        fh.seek = recording_seek
+        return fh
+
+    monkeypatch.setattr("builtins.open", tracking_open)
+
+    with _SettingsLock(settings_path):
+        pass
+
+    # seek(0) must have been called between the lock and unlock calls.
+    assert 0 in seeks, f"seek(0) not invoked; saw seeks={seeks}"
+
+
+def test_windows_oserror_during_lock_warns_and_degrades(monkeypatch, capsys, settings_path: Path) -> None:
+    """OSError from msvcrt.locking degrades to no-op + stderr warning, no crash."""
+    fake = _FakeMsvcrt()
+
+    def raising_locking(fd, mode, nbytes):
+        raise OSError("simulated Windows lock failure (e.g. read-only filesystem)")
+
+    fake.locking = raising_locking
+    _force_windows_mode(monkeypatch, fake)
+
+    # Capture stderr
+    stderr_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stderr_buf)
+
+    with _SettingsLock(settings_path) as lock:
+        # _fh should be None — degraded path
+        assert lock._fh is None
+
+    assert "settings lock unavailable" in stderr_buf.getvalue()
+
+
+# ─── Missing-both fallback (neither fcntl nor msvcrt) ────────────────────────
+
+
+def test_missing_both_locking_modules_degrades(monkeypatch, settings_path: Path) -> None:
+    """Platform missing both fcntl and msvcrt → degrade to no-op without crash."""
+    # Force a "windows-shaped" environment but with msvcrt absent (extreme
+    # edge case — captures the defense-in-depth ImportError catch).
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setitem(sys.modules, "msvcrt", None)
+
+    with _SettingsLock(settings_path) as lock:
+        assert lock._fh is None  # Degraded — but no crash.
+
+
+# ─── End-to-end exit safety (re-entry, exception during body) ────────────────
+
+
+def test_lock_releases_on_exception(settings_path: Path) -> None:
+    """If the body raises, the lock is still released (file handle closed)."""
+    captured_fh = []
+
+    class _Spy(_SettingsLock):
+        def __enter__(self):
+            super().__enter__()
+            captured_fh.append(self._fh)
+            return self
+
+    with pytest.raises(ValueError):
+        with _Spy(settings_path):
+            raise ValueError("body failure")
+
+    # File handle should be closed after __exit__ even on exception.
+    if captured_fh and captured_fh[0] is not None:
+        assert captured_fh[0].closed


### PR DESCRIPTION
## Problem

`_SettingsLock` in `src/cozempic/init.py` uses `fcntl.lockf` to serialize concurrent `cozempic init` invocations (two shells running first-init, two SessionStart hooks firing simultaneously, etc.). On Windows `import fcntl` raises `ImportError` and the lock degrades to a silent no-op — two concurrent invocations can silently clobber each other's hook additions in `.claude/settings.json`.

This was the second of three Windows-coverage gaps you listed in the closing comment of issue #80 (2026-04-24):

> If you're interested in contributing more, Windows coverage is our weakest area — a few things that would help: [...] **`_SettingsLock`: uses `fcntl.lockf` which doesn't exist on Windows. Currently degrades to unlocked — a Windows-native lock (`msvcrt.locking`) would close that gap.**

This PR closes exactly that gap. Took us 27 days to circle back — apologies for the delay; we just shipped a universal rule on our side ("verify closing comments for follow-up asks when they accept our PRs") to prevent this class of oversight going forward.

## Fix

Branch on `os.name == "nt"` inside `_SettingsLock.__enter__` and `__exit__`, mirroring the cross-platform pattern already used by `_HostFileLock` in `src/cozempic/helpers.py:59-111`:

- **POSIX**: `fcntl.lockf(fd, LOCK_EX)` — unchanged. The NFS-reliability reason for choosing `lockf` over `flock` is preserved verbatim in the new docstring.
- **Windows**: `msvcrt.locking(fd, LK_LOCK, 1)` after `seek(0)`, paired with `seek(0)` + `LK_UNLCK` on exit.

`seek(0)` before BOTH lock and unlock is defense-in-depth: `msvcrt.locking` is position-relative, and `open(path, "a")` on Windows positions the file pointer at EOF. For a fresh empty lock file EOF==0 so it works accidentally; for a stale non-empty lock file left from a prior crashed run, the lock byte would diverge from the unlock byte and serialization would silently fail. In the standard flow the file is never written to (we only use the fd for locking, no `.write()` ever fires), but the cost of the explicit seek is one line and the gain is robustness against any future code path that does write.

The same defense-in-depth gap exists in `_HostFileLock` at `helpers.py:82` (no `seek(0)` before `LK_LOCK`). Out of scope for this PR — happy to file a separate one-line follow-up patch if you'd like.

### Cleanup on partial failure

Both new `ImportError` and `OSError` handlers in `__enter__` now close `self._fh` before nulling it. Previously the OSError branch nulled without closing (relying on `__exit__` to clean up, but `__exit__` short-circuits on `_fh=None`), which leaked one fd per failure — observable e.g. on a read-only `.claude/` mount.

## Tests

New file: `tests/test_settings_lock.py` (~280 lines, 8 cases).

| # | Test | Platform |
|---|------|----------|
| 1 | `test_posix_acquires_fcntl_lockf` | POSIX (skip on Windows) |
| 2 | `test_posix_real_lockfile_created` | POSIX (skip on Windows) |
| 3 | `test_windows_acquires_msvcrt_locking` | shim (any host) |
| 4 | `test_windows_seek_zero_before_unlock` | shim (any host) |
| 5 | `test_windows_acquire_position_normalized_on_stale_lock_file` | shim (any host) |
| 6 | `test_windows_oserror_during_lock_warns_and_degrades` | shim (any host) |
| 7 | `test_missing_both_locking_modules_degrades` | shim (any host) |
| 8 | `test_lock_releases_on_exception` | platform-agnostic |

The four `test_windows_*` tests monkeypatch `os.name = "nt"` and inject a fake `msvcrt` into `sys.modules` so the Windows branch runs unconditionally — on Windows the fake REPLACES the real `msvcrt` (we want to assert call shape, not exercise the kernel lock). The two `test_posix_*` tests skip on Windows.

Test #5 specifically pins the stale-non-empty-file case: it pre-populates the lock file with `"stale content from prior crashed run\n"` so EOF > 0, then asserts both `LK_LOCK` and `LK_UNLCK` fire at byte 0 (not at EOF). Without `seek(0)` before `LK_LOCK`, that test would catch a lock-byte != unlock-byte divergence.

Local run on Windows (Python 3.12.10, pytest 9.0.3):

```
tests/test_settings_lock.py::test_posix_acquires_fcntl_lockf SKIPPED
tests/test_settings_lock.py::test_posix_real_lockfile_created SKIPPED
tests/test_settings_lock.py::test_windows_acquires_msvcrt_locking PASSED
tests/test_settings_lock.py::test_windows_seek_zero_before_unlock PASSED
tests/test_settings_lock.py::test_windows_acquire_position_normalized_on_stale_lock_file PASSED
tests/test_settings_lock.py::test_windows_oserror_during_lock_warns_and_degrades PASSED
tests/test_settings_lock.py::test_missing_both_locking_modules_degrades PASSED
tests/test_settings_lock.py::test_lock_releases_on_exception PASSED
============================== 6 passed, 2 skipped in 0.04s ==============================
```

Full suite still has the 28 pre-existing Windows test failures across guard/spawn-lock/session/hook areas (unrelated — including the POSIX-only `tests/test_guard_leak.py` collection error from `import resource`), but `test_global_init.py` (where `wire_hooks` exercises `_SettingsLock` end-to-end) passes apart from one unrelated pre-existing `_save_settings` permission test that is sensitive to Windows ACL semantics (0o644 → 0o666 on NTFS) — not touched by this change.

## Commits

- **8e7e906** — `fix(init): _SettingsLock cross-platform — Windows msvcrt branch alongside POSIX fcntl.lockf` — the core implementation.
- **9d03c47** — `fix(init): seek(0) before LK_LOCK + test for stale non-empty lock file` — defense-in-depth + regression test, surfaced by pre-merge consensus review.

Happy to squash into one commit on merge if you prefer.

## Status of your other two Windows asks

- **`#1` — `start_new_session=True` doesn't fully detach on Windows daemon**: held until PRs #93 + #94 land. Your concurrent work in PR #93/#94 touches `guard.py` heavily and a parallel daemon-detach PR would conflict. I'll pick this up after those merge.
- **`#3` — POSIX `/tmp` hardcoding**: covered by PR #91 by @iBoostAI (currently in CONFLICTING state). Not filing a parallel PR.

---

*Disclaimer: this PR's implementation, the reproduction analysis, and the test design were drafted by Kloud AI assistant (kloud@gravya.it) under human review and approval. Human in the loop: @GravyaDev.*