### PR TITLE
fix(guard): PID start-time tracking — close recycled-live-PID resurrection vector (PR #94 follow-up)

### DIFF
--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2196,7 +2196,12 @@ def _get_pid_start_time_linux(pid: int) -> float | None:
         stat_text = Path(f"/proc/{pid}/stat").read_text()
         # comm field may contain spaces and ')'; rfind(")") finds end of comm safely.
         # After "pid (comm) ", fields are 0-indexed: index 19 = starttime (field 22).
-        after_comm = stat_text[stat_text.rfind(")") + 2:]
+        # Guard malformed /proc (fuse / WSL1 / BSD emulation); kernel /proc always
+        # has parens but the slice would silently misalign on no-parens input.
+        close_paren = stat_text.rfind(")")
+        if close_paren < 0:
+            return None
+        after_comm = stat_text[close_paren + 2:]
         starttime_ticks = int(after_comm.split()[19])
         btime_line = next(
             line for line in Path("/proc/stat").read_text().splitlines()

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -498,6 +498,10 @@ def start_guard(
     # Resolve Claude before daemonization or other reparenting can obscure it.
     if claude_pid is None:
         claude_pid = find_claude_pid()
+    # Record PID + start_time NOW — earliest point where both claude_pid and
+    # session_id are known and Claude's identity is confirmed by find_claude_pid.
+    if claude_pid and session_id:
+        _record_claude_identity(session_id, claude_pid)
     claude_alive = True
 
     prune_count = 0
@@ -538,12 +542,16 @@ def start_guard(
                     # PID reuse (daemon started hours ago; original Claude exited and
                     # kernel recycled its PID to an unrelated process).
                     try:
-                        if not _is_claude_process(claude_pid, session_path=session_path):
+                        if not _pid_identity_match(claude_pid, session_id) \
+                                or not _is_claude_process(claude_pid, session_path=session_path):
                             claude_alive = False
                     except ProcessLookupError:
                         claude_alive = False
                 if not claude_alive:
                     print(f"  [{_now()}] Claude process exited (PID {claude_pid}). Final checkpoint...")
+                    # Clear start-time record: this session's Claude is gone.
+                    if session_id:
+                        _CLAUDE_IDENTITY.pop(session_id, None)
                     # Option (b) defense-in-depth: unlink pidfile IMMEDIATELY so a
                     # concurrent SessionStart for the new Claude doesn't see a stale
                     # transient-daemon slot. The finally-block call is a no-op after
@@ -1287,6 +1295,14 @@ def _terminate_and_resume(
     # mtime fallback can misreport a dead Claude as alive. os.kill is not fooled.
     if not _pid_is_alive(claude_pid):
         print(f"  PID {claude_pid} is gone — skipping terminate+resume (no resurrection).")
+        return
+    # Start-time identity gate: if the PID was recycled to a different process
+    # after Claude died, the start_time recorded at startup will differ. This
+    # closes the residual resurrection vector left by the mtime fallback even
+    # after Junaid's mtime-immune liveness gate (06f91c3) — a recycled PID IS
+    # alive but is NOT the same Claude. Fails-OPEN when psutil is absent.
+    if not _pid_identity_match(claude_pid, session_id):
+        print(f"  PID {claude_pid} start-time mismatch — PID was recycled, skipping terminate+resume.")
         return
     # Identity (anti-PID-reuse): is this still actually Claude, not a recycled
     # PID? Per-block checks re-verify before each kill; this is the fail-fast.

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2190,17 +2190,74 @@ _MTIME_LIVENESS_WINDOW_SEC = 60
 _CLAUDE_IDENTITY: dict[str, tuple[int, float]] = {}
 
 
-def _get_pid_start_time(pid: int) -> float | None:
-    """Return process creation time in seconds since epoch via psutil, or None."""
+def _get_pid_start_time_linux(pid: int) -> float | None:
+    """Linux: read start_time from /proc/<pid>/stat + /proc/stat btime. No subprocess."""
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text()
+        # comm field may contain spaces and ')'; rfind(")") finds end of comm safely.
+        # After "pid (comm) ", fields are 0-indexed: index 19 = starttime (field 22).
+        after_comm = stat_text[stat_text.rfind(")") + 2:]
+        starttime_ticks = int(after_comm.split()[19])
+        btime_line = next(
+            line for line in Path("/proc/stat").read_text().splitlines()
+            if line.startswith("btime ")
+        )
+        btime = int(btime_line.split()[1])
+        return float(btime + starttime_ticks / os.sysconf("SC_CLK_TCK"))
+    except Exception:
+        return None
+
+
+def _get_pid_start_time_macos(pid: int) -> float | None:
+    """macOS: parse ps -o lstart= output. 1-second resolution; LC_ALL=C for locale safety."""
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True, text=True, timeout=2.0, check=False,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        # Normalize whitespace: single-digit days produce double-space ("May  1").
+        normalized = re.sub(r"\s+", " ", result.stdout.strip()).strip()
+        return float(time.mktime(time.strptime(normalized, "%a %b %d %H:%M:%S %Y")))
+    except Exception:
+        return None
+
+
+def _get_pid_start_time_psutil(pid: int) -> float | None:
+    """psutil fallback: microsecond precision; lazy-import (no required dep)."""
     try:
         import psutil
         return psutil.Process(pid).create_time()
     except ImportError:
         return None
     except Exception:
-        # psutil.Error subclasses, OSError, and platform-specific oddities all
-        # land here. Match the broad-except pattern used in _is_claude_process.
         return None
+
+
+def _get_pid_start_time(pid: int) -> float | None:
+    """Return process creation time in seconds since epoch, or None.
+
+    Platform-ordered chain (zero required deps):
+      Linux  → /proc/<pid>/stat  (10ms resolution, no subprocess)
+      macOS  → ps -p <pid> -o lstart=  (1s resolution, subprocess)
+      psutil → lazy-import fallback    (microsecond precision, all platforms)
+
+    Falls through to psutil if the platform-native backend fails (e.g.,
+    restricted /proc on containerised Linux, ps absent, permission error).
+    Returns None only when all backends fail → _pid_identity_match fails-OPEN.
+    """
+    _sys = platform.system()
+    if _sys == "Linux":
+        result = _get_pid_start_time_linux(pid)
+        if result is not None:
+            return result
+    elif _sys == "Darwin":
+        result = _get_pid_start_time_macos(pid)
+        if result is not None:
+            return result
+    return _get_pid_start_time_psutil(pid)
 
 
 def _record_claude_identity(session_id: str, pid: int) -> None:
@@ -2222,7 +2279,7 @@ def _pid_identity_match(pid: int, session_id: str | None) -> bool:
     Returns True conservatively when:
     - session_id is None (no session context — backward compat)
     - no identity has been recorded for this session_id (daemon restarted)
-    - psutil is unavailable (can't get start_time — degrade gracefully)
+    - all start-time backends fail (can't get start_time — degrade gracefully)
 
     Fail-OPEN rationale: in all these cases we fall through to the existing
     _pid_is_alive + _is_claude_process layers. No regression vs v1.8.16.
@@ -2237,7 +2294,7 @@ def _pid_identity_match(pid: int, session_id: str | None) -> bool:
         return False
     current_start_time = _get_pid_start_time(pid)
     if current_start_time is None:
-        return True  # psutil unavailable — degrade gracefully
+        return True  # all backends failed — degrade gracefully (fail-OPEN)
     # 0.1s tolerance absorbs float-precision noise across psutil's kernel-clock
     # conversion; real PID-recycle gaps are seconds-to-hours, never sub-second.
     return abs(current_start_time - recorded_start_time) < 0.1

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2197,12 +2197,20 @@ def _get_pid_start_time(pid: int) -> float | None:
         return psutil.Process(pid).create_time()
     except ImportError:
         return None
-    except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+    except Exception:
+        # psutil.Error subclasses, OSError, and platform-specific oddities all
+        # land here. Match the broad-except pattern used in _is_claude_process.
         return None
 
 
 def _record_claude_identity(session_id: str, pid: int) -> None:
-    """Record (pid, start_time) for the anti-recycling gate. Call once at startup."""
+    """Record (pid, start_time) for the anti-recycling gate. Call once at startup.
+
+    Validates pid is actually Claude (argv check) before recording — defense
+    in depth in case a future caller bypasses find_claude_pid's identity gate.
+    """
+    if not _is_claude_process(pid):
+        return
     start_time = _get_pid_start_time(pid)
     if start_time is not None and session_id:
         _CLAUDE_IDENTITY[session_id] = (pid, start_time)
@@ -2230,6 +2238,8 @@ def _pid_identity_match(pid: int, session_id: str | None) -> bool:
     current_start_time = _get_pid_start_time(pid)
     if current_start_time is None:
         return True  # psutil unavailable — degrade gracefully
+    # 0.1s tolerance absorbs float-precision noise across psutil's kernel-clock
+    # conversion; real PID-recycle gaps are seconds-to-hours, never sub-second.
     return abs(current_start_time - recorded_start_time) < 0.1
 
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2165,6 +2165,57 @@ def _is_cozempic_guard_process(pid: int) -> bool:
 
 _MTIME_LIVENESS_WINDOW_SEC = 60
 
+# ── PID start-time identity store (anti-recycling gate) ─────────────────────
+# Keyed by session_id → (expected_pid, expected_start_time_float).
+# Populated once at start_guard startup after Claude PID is confirmed.
+# Cleared when Claude exits (watchdog break path).
+# In-memory is sufficient: the recycled-PID race occurs within one daemon
+# lifecycle. Daemon restart → fresh find_claude_pid() → fresh recording.
+_CLAUDE_IDENTITY: dict[str, tuple[int, float]] = {}
+
+
+def _get_pid_start_time(pid: int) -> float | None:
+    """Return process creation time in seconds since epoch via psutil, or None."""
+    try:
+        import psutil
+        return psutil.Process(pid).create_time()
+    except ImportError:
+        return None
+    except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+        return None
+
+
+def _record_claude_identity(session_id: str, pid: int) -> None:
+    """Record (pid, start_time) for the anti-recycling gate. Call once at startup."""
+    start_time = _get_pid_start_time(pid)
+    if start_time is not None and session_id:
+        _CLAUDE_IDENTITY[session_id] = (pid, start_time)
+
+
+def _pid_identity_match(pid: int, session_id: str | None) -> bool:
+    """True if pid matches the recorded identity (same PID + same start_time).
+
+    Returns True conservatively when:
+    - session_id is None (no session context — backward compat)
+    - no identity has been recorded for this session_id (daemon restarted)
+    - psutil is unavailable (can't get start_time — degrade gracefully)
+
+    Fail-OPEN rationale: in all these cases we fall through to the existing
+    _pid_is_alive + _is_claude_process layers. No regression vs v1.8.16.
+    """
+    if not session_id:
+        return True
+    identity = _CLAUDE_IDENTITY.get(session_id)
+    if identity is None:
+        return True
+    recorded_pid, recorded_start_time = identity
+    if pid != recorded_pid:
+        return False
+    current_start_time = _get_pid_start_time(pid)
+    if current_start_time is None:
+        return True  # psutil unavailable — degrade gracefully
+    return abs(current_start_time - recorded_start_time) < 0.1
+
 
 def _pid_is_alive(pid: int) -> bool:
     """Bare process-liveness probe — does NOT consult the JSONL mtime.

--- a/tests/test_guard_pid_recycling.py
+++ b/tests/test_guard_pid_recycling.py
@@ -271,3 +271,227 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
 
         self.assertEqual(len(calls), 1, "_record_claude_identity must be called exactly once")
         self.assertEqual(calls[0], (fake_session_id, fake_pid))
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Linux /proc backend (skipUnless Linux)
+# ---------------------------------------------------------------------------
+@unittest.skipUnless(sys.platform.startswith("linux"), "Linux /proc only")
+class TestLinuxStdlibStartTime(unittest.TestCase):
+    """Verify _get_pid_start_time_linux returns a plausible float for self PID."""
+
+    def test_returns_float_for_self(self):
+        import cozempic.guard as g
+
+        result = g._get_pid_start_time_linux(os.getpid())
+        self.assertIsInstance(result, float, "should return float on Linux")
+        self.assertGreater(result, 0.0, "epoch timestamp must be positive")
+
+    def test_result_is_before_current_time(self):
+        import cozempic.guard as g
+
+        now = time.time()
+        result = g._get_pid_start_time_linux(os.getpid())
+        self.assertIsNotNone(result)
+        # Process can't have started in the future.
+        self.assertLess(result, now + 1.0)
+        # Process started within the last 24h (generous bound for CI).
+        self.assertGreater(result, now - 86400)
+
+    def test_nonexistent_pid_returns_none(self):
+        import cozempic.guard as g
+
+        # PID 0 is the idle/swapper process and its stat is not accessible.
+        result = g._get_pid_start_time_linux(0)
+        self.assertIsNone(result, "invalid/unreachable PID should return None")
+
+    def test_same_pid_repeated_call_stable(self):
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        r1 = g._get_pid_start_time_linux(pid)
+        r2 = g._get_pid_start_time_linux(pid)
+        self.assertIsNotNone(r1)
+        self.assertIsNotNone(r2)
+        # deterministic int arithmetic → exact equality
+        self.assertEqual(r1, r2, "/proc start_time must be stable across repeated reads")
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — macOS ps lstart= backend (skipUnless Darwin)
+# ---------------------------------------------------------------------------
+@unittest.skipUnless(sys.platform == "darwin", "macOS ps lstart= only")
+class TestMacosStdlibStartTime(unittest.TestCase):
+    """Verify _get_pid_start_time_macos returns a plausible float for self PID."""
+
+    def test_returns_float_for_self(self):
+        import cozempic.guard as g
+
+        result = g._get_pid_start_time_macos(os.getpid())
+        self.assertIsInstance(result, float, "should return float on macOS")
+        self.assertGreater(result, 0.0, "epoch timestamp must be positive")
+
+    def test_result_is_before_current_time(self):
+        import cozempic.guard as g
+
+        now = time.time()
+        result = g._get_pid_start_time_macos(os.getpid())
+        self.assertIsNotNone(result)
+        self.assertLess(result, now + 1.0)
+        # Allow up to 24h of process age for CI runners.
+        self.assertGreater(result, now - 86400)
+
+    def test_nonexistent_pid_returns_none(self):
+        import cozempic.guard as g
+
+        # Use a definitively-dead PID (spawn + reap).
+        proc = subprocess.Popen([sys.executable, "-c", ""])
+        proc.wait()
+        dead_pid = proc.pid
+        result = g._get_pid_start_time_macos(dead_pid)
+        self.assertIsNone(result, "dead PID should return None")
+
+    def test_same_pid_repeated_call_stable(self):
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        r1 = g._get_pid_start_time_macos(pid)
+        r2 = g._get_pid_start_time_macos(pid)
+        self.assertIsNotNone(r1)
+        self.assertIsNotNone(r2)
+        # lstart is a fixed epoch second → exact equality on repeated calls.
+        self.assertEqual(r1, r2, "ps lstart must be stable across repeated reads")
+
+    def test_identity_match_uses_macos_backend(self):
+        """End-to-end: _pid_identity_match uses the macOS backend when no psutil."""
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        session_id = "macostest1111222233334444aaaabbbb"
+        g._CLAUDE_IDENTITY.clear()
+
+        # Record using the real macOS backend (no psutil mock needed).
+        with patch("cozempic.guard._is_claude_process", return_value=True):
+            g._record_claude_identity(session_id, pid)
+
+        self.assertIn(session_id, g._CLAUDE_IDENTITY,
+                      "identity should be recorded via macOS ps backend")
+
+        # Verify the match works without touching psutil at all.
+        with patch("cozempic.guard._get_pid_start_time_psutil",
+                   side_effect=AssertionError("psutil must not be called")):
+            result = g._pid_identity_match(pid, session_id)
+
+        self.assertTrue(result, "macOS backend identity match must return True for same PID")
+        g._CLAUDE_IDENTITY.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — Full stdlib fallthrough (all backends fail → None → fail-OPEN)
+# ---------------------------------------------------------------------------
+class TestStdlibFallthrough(unittest.TestCase):
+    """Cross-platform: when all three backends return None, _get_pid_start_time
+    returns None and _pid_identity_match fails-OPEN (returns True).
+    """
+
+    def setUp(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def tearDown(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def test_all_backends_fail_returns_none(self):
+        import cozempic.guard as g
+
+        with patch("cozempic.guard._get_pid_start_time_linux", return_value=None), \
+             patch("cozempic.guard._get_pid_start_time_macos", return_value=None), \
+             patch("cozempic.guard._get_pid_start_time_psutil", return_value=None):
+            result = g._get_pid_start_time(os.getpid())
+
+        self.assertIsNone(result, "all backends failing must return None")
+
+    def test_all_backends_fail_pid_match_fails_open(self):
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        session_id = "fallthrough111122223333444455556666"
+        # Pre-load identity with a known start_time.
+        g._CLAUDE_IDENTITY[session_id] = (pid, 1716220000.0)
+
+        with patch("cozempic.guard._get_pid_start_time_linux", return_value=None), \
+             patch("cozempic.guard._get_pid_start_time_macos", return_value=None), \
+             patch("cozempic.guard._get_pid_start_time_psutil", return_value=None):
+            result = g._pid_identity_match(pid, session_id)
+
+        self.assertTrue(result, "all backends failing must return True (fail-OPEN)")
+
+    def test_linux_backend_tried_first_on_linux(self):
+        """On Linux, the Linux backend is tried before macOS and psutil."""
+        import cozempic.guard as g
+        import platform
+
+        if platform.system() != "Linux":
+            self.skipTest("Linux dispatch only")
+
+        called = []
+        def fake_linux(pid):
+            called.append("linux")
+            return 1234567890.0
+
+        with patch("cozempic.guard._get_pid_start_time_linux", side_effect=fake_linux), \
+             patch("cozempic.guard._get_pid_start_time_macos",
+                   side_effect=AssertionError("macOS must not be called on Linux")), \
+             patch("cozempic.guard._get_pid_start_time_psutil",
+                   side_effect=AssertionError("psutil must not be called when Linux works")):
+            result = g._get_pid_start_time(os.getpid())
+
+        self.assertEqual(result, 1234567890.0)
+        self.assertIn("linux", called)
+
+    def test_macos_backend_tried_first_on_darwin(self):
+        """On Darwin, the macOS backend is tried before psutil."""
+        import cozempic.guard as g
+        import platform
+
+        if platform.system() != "Darwin":
+            self.skipTest("Darwin dispatch only")
+
+        called = []
+        def fake_macos(pid):
+            called.append("macos")
+            return 1234567890.0
+
+        with patch("cozempic.guard._get_pid_start_time_macos", side_effect=fake_macos), \
+             patch("cozempic.guard._get_pid_start_time_psutil",
+                   side_effect=AssertionError("psutil must not be called when macOS works")):
+            result = g._get_pid_start_time(os.getpid())
+
+        self.assertEqual(result, 1234567890.0)
+        self.assertIn("macos", called)
+
+    def test_psutil_fallback_when_platform_backend_fails(self):
+        """When the platform-native backend returns None, psutil is tried."""
+        import cozempic.guard as g
+        import platform
+
+        _sys = platform.system()
+        psutil_called = []
+
+        def fake_psutil(pid):
+            psutil_called.append(pid)
+            return 9999999999.0
+
+        if _sys == "Linux":
+            ctx = patch("cozempic.guard._get_pid_start_time_linux", return_value=None)
+        elif _sys == "Darwin":
+            ctx = patch("cozempic.guard._get_pid_start_time_macos", return_value=None)
+        else:
+            self.skipTest("Only Linux/Darwin dispatch tested here")
+
+        with ctx, patch("cozempic.guard._get_pid_start_time_psutil", side_effect=fake_psutil):
+            result = g._get_pid_start_time(os.getpid())
+
+        self.assertEqual(result, 9999999999.0)
+        self.assertEqual(len(psutil_called), 1, "psutil must be called as fallback")

--- a/tests/test_guard_pid_recycling.py
+++ b/tests/test_guard_pid_recycling.py
@@ -227,15 +227,14 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
         fake_pid = 12345
         fake_session_id = "sssssssstttt1111222233334444ssss"
 
-        # We need a real session file so start_guard doesn't bail early.
         with tempfile.TemporaryDirectory() as td:
             jsonl = Path(td) / "session.jsonl"
             jsonl.write_text("{}\n")
 
-            # Patch the world so start_guard runs exactly one cycle then stops.
             fake_session = {
                 "session_id": fake_session_id,
                 "session_path": str(jsonl),
+                "path": jsonl,
                 "project_dir": td,
             }
 
@@ -243,16 +242,26 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
 
             def fake_record(sid, pid):
                 calls.append((sid, pid))
-                # After recording, raise to exit the watchdog loop cleanly.
 
-            with patch("cozempic.guard.find_current_session", return_value=fake_session), \
+            # start_guard calls _resolve_session_by_id (not find_current_session)
+            # when session_id is passed, then load_messages, detect_context_window,
+            # record_session, etc. Patch everything between session resolution and
+            # the watchdog loop so we reach line 503 (_record_claude_identity call).
+            with patch("cozempic.guard._resolve_session_by_id", return_value=fake_session), \
                  patch("cozempic.guard.find_claude_pid", return_value=fake_pid), \
                  patch("cozempic.guard._record_claude_identity", side_effect=fake_record), \
+                 patch("cozempic.guard.load_messages", return_value=[]), \
+                 patch("cozempic.tokens.detect_context_window", return_value=200000), \
+                 patch("cozempic.tokens.default_token_thresholds_4tier", return_value=(50000, 110000, 160000)), \
+                 patch("cozempic.session.record_session"), \
+                 patch("cozempic.guard._cleanup_stale_watchers"), \
+                 patch("cozempic.guard.ping_install_if_new"), \
+                 patch("cozempic.guard.maybe_auto_update"), \
                  patch("cozempic.guard.checkpoint_team"), \
                  patch("cozempic.guard.time.sleep", side_effect=RuntimeError("stop loop")):
                 try:
                     g.start_guard(session_id=fake_session_id, claude_pid=fake_pid)
-                except RuntimeError:
+                except (RuntimeError, SystemExit):
                     pass
 
         self.assertEqual(len(calls), 1, "_record_claude_identity must be called exactly once")

--- a/tests/test_guard_pid_recycling.py
+++ b/tests/test_guard_pid_recycling.py
@@ -46,9 +46,12 @@ class TestPidIdentityMatchRecycledPid(unittest.TestCase):
         import cozempic.guard as g
 
         # Use a real live PID (ourselves) and record its real start_time.
+        # _record_claude_identity now validates the PID is Claude (MED-1 hardening);
+        # mock that gate True for the test since pytest is not Claude.
         pid = os.getpid()
         session_id = "aaaa1111bbbb2222cccc3333dddd4444"
-        g._record_claude_identity(session_id, pid)
+        with patch.object(g, "_is_claude_process", return_value=True):
+            g._record_claude_identity(session_id, pid)
 
         # Confirm identity was recorded.
         self.assertIn(session_id, g._CLAUDE_IDENTITY)
@@ -70,7 +73,8 @@ class TestPidIdentityMatchRecycledPid(unittest.TestCase):
 
         pid = os.getpid()
         session_id = "aaaa1111bbbb2222cccc3333dddd5555"
-        g._record_claude_identity(session_id, pid)
+        with patch.object(g, "_is_claude_process", return_value=True):
+            g._record_claude_identity(session_id, pid)
 
         recorded_pid, recorded_start_time = g._CLAUDE_IDENTITY[session_id]
 
@@ -85,7 +89,8 @@ class TestPidIdentityMatchRecycledPid(unittest.TestCase):
 
         pid = os.getpid()
         session_id = "aaaa1111bbbb2222cccc3333dddd6666"
-        g._record_claude_identity(session_id, pid)
+        with patch.object(g, "_is_claude_process", return_value=True):
+            g._record_claude_identity(session_id, pid)
 
         # Pass a completely different PID.
         with patch("cozempic.guard._get_pid_start_time", return_value=9999999.0):

--- a/tests/test_guard_pid_recycling.py
+++ b/tests/test_guard_pid_recycling.py
@@ -1,0 +1,259 @@
+"""RED tests for PID start-time tracking (recycled-PID resurrection vector).
+
+Architect spec: AUDIT_REPORT_pid_recycling.md (commit 5af7c0d)
+Vector: os.kill(pid, 0) answers liveness, not identity. If Claude dies and its
+PID is recycled to a live unrelated process AND the JSONL is freshly written,
+_is_claude_process's mtime fallback still returns True → resurrection.
+Fix: record (pid, start_time) at guard startup via _record_claude_identity;
+gate _terminate_and_resume with _pid_identity_match before _is_claude_process.
+
+These 4 tests are expected to FAIL (AttributeError / AssertionError) until
+the implementation in fix commit 2 + 3 lands.
+"""
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — _pid_identity_match: real psutil, recycled PID detected
+# ---------------------------------------------------------------------------
+class TestPidIdentityMatchRecycledPid(unittest.TestCase):
+    """Unit test: record real process start_time, then mock _get_pid_start_time
+    to return a different start_time (simulating PID recycling after the original
+    process died). _pid_identity_match must return False.
+    """
+
+    def setUp(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def tearDown(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def test_recycled_pid_start_time_mismatch_returns_false(self):
+        import cozempic.guard as g
+
+        # Use a real live PID (ourselves) and record its real start_time.
+        pid = os.getpid()
+        session_id = "aaaa1111bbbb2222cccc3333dddd4444"
+        g._record_claude_identity(session_id, pid)
+
+        # Confirm identity was recorded.
+        self.assertIn(session_id, g._CLAUDE_IDENTITY)
+        recorded_pid, recorded_start_time = g._CLAUDE_IDENTITY[session_id]
+        self.assertEqual(recorded_pid, pid)
+
+        # Simulate PID recycled: same PID but different start_time (10000s later).
+        recycled_start_time = recorded_start_time + 10000.0
+        with patch("cozempic.guard._get_pid_start_time", return_value=recycled_start_time):
+            result = g._pid_identity_match(pid, session_id)
+
+        self.assertFalse(
+            result,
+            "recycled PID with different start_time must return False",
+        )
+
+    def test_matching_pid_start_time_returns_true(self):
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        session_id = "aaaa1111bbbb2222cccc3333dddd5555"
+        g._record_claude_identity(session_id, pid)
+
+        recorded_pid, recorded_start_time = g._CLAUDE_IDENTITY[session_id]
+
+        # Same start_time: identity matches.
+        with patch("cozempic.guard._get_pid_start_time", return_value=recorded_start_time):
+            result = g._pid_identity_match(pid, session_id)
+
+        self.assertTrue(result, "same PID + same start_time must return True")
+
+    def test_different_pid_than_recorded_returns_false(self):
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        session_id = "aaaa1111bbbb2222cccc3333dddd6666"
+        g._record_claude_identity(session_id, pid)
+
+        # Pass a completely different PID.
+        with patch("cozempic.guard._get_pid_start_time", return_value=9999999.0):
+            result = g._pid_identity_match(pid + 9999, session_id)
+
+        self.assertFalse(result, "different PID than recorded must return False")
+
+
+import os  # noqa: E402 — placed after class for import order clarity
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — No resurrection when PID recycled (integration)
+# ---------------------------------------------------------------------------
+class TestNoResurrectionOnRecycledPid(unittest.TestCase):
+    """Integration test: full _terminate_and_resume with a recycled PID.
+
+    Scenario (architect's reproducer § "POST-fix flow"):
+    - session_id recorded with (pid=89113, start_time=T0)
+    - Claude dies, JSONL mtime refreshed by save_messages → fresh
+    - OS recycles pid=89113 to an unrelated process with start_time=T1
+    - _terminate_and_resume is called
+    Expected: _pid_identity_match returns False → early return → NO SIGTERM,
+    NO SIGKILL, NO sentinel write, NO _spawn_reload_watcher call.
+    """
+
+    def setUp(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def tearDown(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def test_recycled_pid_no_resurrection(self):
+        import cozempic.guard as g
+
+        session_id = "ddddddddeeee1111222233334444aaaa"
+        fake_pid = 89113
+        T0 = 1716220000.0
+        T1 = 1716230000.0  # 10000s later — clearly different process
+
+        # Record original identity.
+        g._CLAUDE_IDENTITY[session_id] = (fake_pid, T0)
+
+        with tempfile.TemporaryDirectory() as td:
+            jsonl = Path(td) / "session.jsonl"
+            jsonl.write_text("{}\n")  # fresh mtime — would fool mtime fallback
+
+            # _pid_is_alive returns True (recycled process IS alive).
+            # _get_pid_start_time returns T1 (different process).
+            with patch("cozempic.guard._pid_is_alive", return_value=True), \
+                 patch("cozempic.guard._get_pid_start_time", return_value=T1), \
+                 patch("cozempic.guard._spawn_reload_watcher") as mock_watcher, \
+                 patch("cozempic.guard.write_reload_sentinel") as mock_sentinel, \
+                 patch("cozempic.guard.os.kill") as mock_kill, \
+                 patch("cozempic.guard._detect_terminal_env", return_value="plain"):
+                g._terminate_and_resume(
+                    claude_pid=fake_pid,
+                    project_dir=td,
+                    session_id=session_id,
+                    session_path=jsonl,
+                )
+
+        mock_watcher.assert_not_called()
+        mock_sentinel.assert_not_called()
+        mock_kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — _pid_identity_match degrades gracefully when psutil unavailable
+# ---------------------------------------------------------------------------
+class TestPidIdentityMatchDegrades(unittest.TestCase):
+    """Unit test: psutil unavailable → _pid_identity_match returns True (fail-OPEN).
+
+    Fail-OPEN rationale: without psutil we can't check start_time; we fall through
+    to the existing _pid_is_alive + _is_claude_process layers (same risk as v1.8.16).
+    Fail-CLOSED would break non-Claude-Code installs and CI without psutil.
+    """
+
+    def setUp(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def tearDown(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def test_psutil_unavailable_returns_true(self):
+        import cozempic.guard as g
+
+        pid = os.getpid()
+        session_id = "aaaa1111bbbb2222cccc3333eeee7777"
+        # Record an identity so the session_id IS in _CLAUDE_IDENTITY.
+        g._CLAUDE_IDENTITY[session_id] = (pid, 1716220000.0)
+
+        # _get_pid_start_time returns None when psutil raises ImportError.
+        with patch("cozempic.guard._get_pid_start_time", return_value=None):
+            result = g._pid_identity_match(pid, session_id)
+
+        self.assertTrue(
+            result,
+            "psutil unavailable (None start_time) must return True (fail-OPEN)",
+        )
+
+    def test_no_session_id_returns_true(self):
+        import cozempic.guard as g
+
+        result = g._pid_identity_match(os.getpid(), session_id=None)
+        self.assertTrue(result, "None session_id must return True (conservative allow)")
+
+    def test_session_id_not_recorded_returns_true(self):
+        import cozempic.guard as g
+
+        # Session not in _CLAUDE_IDENTITY at all.
+        result = g._pid_identity_match(os.getpid(), session_id="not-recorded-xxxx")
+        self.assertTrue(result, "unrecorded session_id must return True (conservative allow)")
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — _record_claude_identity called during start_guard
+# ---------------------------------------------------------------------------
+class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
+    """Verify _record_claude_identity(session_id, pid) is called once during
+    start_guard after find_claude_pid() resolves, before the watchdog loop runs.
+    """
+
+    def setUp(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def tearDown(self):
+        import cozempic.guard as g
+        g._CLAUDE_IDENTITY.clear()
+
+    def test_record_called_with_correct_args(self):
+        import cozempic.guard as g
+
+        fake_pid = 12345
+        fake_session_id = "sssssssstttt1111222233334444ssss"
+
+        # We need a real session file so start_guard doesn't bail early.
+        with tempfile.TemporaryDirectory() as td:
+            jsonl = Path(td) / "session.jsonl"
+            jsonl.write_text("{}\n")
+
+            # Patch the world so start_guard runs exactly one cycle then stops.
+            fake_session = {
+                "session_id": fake_session_id,
+                "session_path": str(jsonl),
+                "project_dir": td,
+            }
+
+            calls = []
+
+            def fake_record(sid, pid):
+                calls.append((sid, pid))
+                # After recording, raise to exit the watchdog loop cleanly.
+
+            with patch("cozempic.guard.find_current_session", return_value=fake_session), \
+                 patch("cozempic.guard.find_claude_pid", return_value=fake_pid), \
+                 patch("cozempic.guard._record_claude_identity", side_effect=fake_record), \
+                 patch("cozempic.guard.checkpoint_team"), \
+                 patch("cozempic.guard.time.sleep", side_effect=RuntimeError("stop loop")):
+                try:
+                    g.start_guard(session_id=fake_session_id, claude_pid=fake_pid)
+                except RuntimeError:
+                    pass
+
+        self.assertEqual(len(calls), 1, "_record_claude_identity must be called exactly once")
+        self.assertEqual(calls[0], (fake_session_id, fake_pid))


### PR DESCRIPTION
## Summary (round 2 — stdlib swap)

This PR was reviewed by @junaidtitan on 2026-05-21 with engineering approved + 2 pre-merge blockers (B1 zero-dep test failures, B2 gate no-op without psutil). Round 2 implements the suggested stdlib swap that closes both blockers in a single change.

Engineering structure unchanged: gate ordering, recording moment, fail-OPEN posture, MED-1 defense, 0.1s tolerance, all 8 original tests. The swap is purely the source of truth for `start_time`:

| Platform | Backend (post-swap) | Resolution | Zero-dep? |
|---|---|---|---|
| Linux | `/proc/<pid>/stat` field 22 + `/proc/stat btime` + `os.sysconf("SC_CLK_TCK")` | 10ms (CLK_TCK=100) | ✅ |
| macOS | `ps -p <pid> -o lstart=` with `LC_ALL=C` env + `time.strptime` | 1s | ✅ |
| Windows + final fallback | `psutil.Process(pid).create_time()` (existing lazy-import) | microseconds | psutil if present |

## Problem (from @junaidtitan PR #98 review)

> Suite goes red on a default install. The three TestPidIdentityMatchRecycledPid cases call the real _record_claude_identity → psutil, but cozempic ships zero dependencies, so psutil is absent on a default install and those three fail (we measured 3 failed / 859 passed without psutil; the 862-green run had psutil incidentally present).

> The gate is a no-op without psutil — which is most installs. psutil is an optional lazy import (never pulled in transitively), so _get_pid_start_time returns None on a default install and _pid_identity_match fails open → the recycling gate does nothing for the zero-dep majority.

Soft note (as @junaidtitan suggested): prior to this round, the headline closed the recycling vector only for users with psutil incidentally present. The stdlib swap delivers the headline on every default install.

## Fix per commit (round 2 additions on top of round 1)

### `fix(guard): stdlib start_time (Linux /proc + macOS ps lstart=) — close PR #98 review B1+B2` (bc1b078)

Replaces psutil-only `_get_pid_start_time` with platform-dispatched chain:
- `_get_pid_start_time_linux`: `/proc/<pid>/stat` field 22 read (no subprocess) + `/proc/stat btime` → `btime + ticks/SC_CLK_TCK`
- `_get_pid_start_time_macos`: `ps -p <pid> -o lstart=` (`subprocess.run(env={**os.environ, "LC_ALL": "C"}, timeout=2.0)`) → `re.sub(r"\s+", " ", raw).strip()` → `time.mktime(time.strptime(s, "%a %b %d %H:%M:%S %Y"))`
- `_get_pid_start_time_psutil`: unchanged (existing lazy-import path)
- `_get_pid_start_time(pid)`: dispatches by `platform.system()` — Linux first, then macOS, then psutil. Returns first non-None.

Signature, return type, tolerance, fail-OPEN paths all unchanged. New tests: `TestLinuxStdlibStartTime` (skipUnless Linux), `TestMacosStdlibStartTime`, `TestStdlibFallthrough` cross-platform.

### `fix(guard): DA round-2 MED-A fold — guard against malformed /proc lacking parens` (4373ada)

Internal round-2 adversarial review flagged: `_get_pid_start_time_linux`'s `rfind(")")` returns -1 on no-parens input → silent wrong slice → wrong starttime → false-positive identity mismatch. Real Linux /proc always has parens (kernel guarantee); this only fires on fuse-/proc / WSL1 / BSD-on-Linux emulation. Defensive: bail to None (fail-OPEN, falls through to macOS/psutil chain).

## Tests

`PYTHONPATH=src python3 -m pytest tests/ -q` → **869 passed, 5 skipped, 36 subtests** (was 854 on v1.8.16 base; 8 round-1 tests + 14 new round-2 tests = +22, of which 5 skip on the non-Linux CI host).

2 pre-existing race-stress flakes (`TestR1_DaemonProcessRace::test_two_processes_one_winner`, `TestThreeProcessContention::test_three_process_contention`) — confirmed pre-existing at base commit `3a4cb1c` by validator (5-run probe) and DA (independent 5-run re-confirmation). Zero overlap with code modified in this PR: `git diff origin/main..HEAD --name-only` does not include `spawn_lock.py` or the race-stress test files.

**B1 + B2 empirically closed**: fresh `python -m venv` (pytest installed, NO psutil) → `pytest tests/test_guard_pid_recycling.py -v` → **17 passed, 5 skipped (Linux-only on macOS host)**. Independently confirmed by lead and by DA in `/tmp/da_fresh_venv` (full suite 841 passed in fresh venv + 1 pre-existing race flake).

3-round internal pipeline: architect (Sonnet, 95%) → implementer (Sonnet, 98%) → validator (Sonnet, 92%, applied CLAUDE.md Rule 12 fresh-venv probe) → DA (Opus, 93%, applied CLAUDE.md Rules 9+10 realistic-install probe + gate value framing) → lead fold (MED-A).

## Test plan

- [ ] `git fetch && git checkout this-branch && PYTHONPATH=src python3 -m pytest tests/ -q` → 869 passed + 5 Linux-skipped (on macOS host)
- [ ] Fresh-venv probe: `python3 -m venv /tmp/probe && /tmp/probe/bin/pip install pytest && PYTHONPATH=src /tmp/probe/bin/python -m pytest tests/test_guard_pid_recycling.py -v` → 17 passed (NO psutil installed); confirms the stdlib backend carries the gate
- [ ] Locale probe (macOS): `LC_ALL=ja_JP.UTF-8 PYTHONPATH=src python3 -m pytest tests/test_guard_pid_recycling.py::TestMacosStdlibStartTime -v` → all pass (function's internal `LC_ALL=C` overrides parent env)
- [ ] Reproducer empirical: `PYTHONPATH=src python3 -c "from cozempic import guard; import os; print(guard._get_pid_start_time(os.getpid()))"` → returns float in the past (your platform's backend)

## Scope

- Zero new required dependencies. psutil stays optional (Windows fallback only).
- Backward-compatible: contract unchanged, signature unchanged, fail-OPEN paths unchanged, tolerance unchanged.
- Hook schema v10 unchanged (architect picked module-level dict over pidfile-format extension precisely so this round doesn't change the schema either).
- All previously-deferred items from round-1 DA review remain in our local TODO (MED-2 cosmetic `_CLAUDE_IDENTITY.pop` on early-return + 3 LOW); none touched by round 2.

## Process learnings (since you asked about residuals)

Your review caught a class-of-bug we hadn't named before — "defensible but valueless": a fix whose happy path is correct AND degraded paths fail safe, BUT the realistic install case IS the degraded path. Our 5-gate BMAD pipeline (architect + implementer + validator + DA + lead pre-push) all missed it because the validator host had psutil incidentally installed and the DA framed verdict as "no regression vs current" (where current = the bug).

Added to our internal `CLAUDE.md` FIX DISCIPLINE for future PRs (Rules 9–12): Realistic-install adversarial probe, Gate value framing, Optional-dep gate requires stdlib fallback, Validator env contamination check. Round 2 pipeline applied these (validator V0 fresh-venv probe; DA A13 realistic-install probe in independent fresh venv).

## Reported by

@junaidtitan, PR #98 review comment (https://github.com/Ruya-AI/cozempic/pull/98#issuecomment-4512782516). Thanks for the patient framing — calling out the difference between "no regression" and "delivers value" is the lesson we needed.