### PR TITLE
fix(doctor): show runnable treat commands for oversized sessions

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -855,7 +855,9 @@ def cmd_doctor(args):
         print(f"    {icon} {r.name:<25} [{r.status.upper()}]")
         print(f"      {r.message}")
         if r.fix_description and r.status not in ("ok", "fixed"):
-            print(f"      Fix: {r.fix_description}")
+            fix_prefix = "      Fix: "
+            fix_text = r.fix_description.replace("\n", f"\n{' ' * len(fix_prefix)}")
+            print(f"{fix_prefix}{fix_text}")
         print()
 
         if r.status == "issue":

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -138,16 +138,21 @@ def check_oversized_sessions() -> CheckResult:
             message=f"No oversized sessions found ({len(sessions)} sessions checked)",
         )
 
+    sorted_large = sorted(large, key=lambda s: s["size"], reverse=True)
     sizes = ", ".join(
         f"{s['session_id'][:8]}…({s['size'] / 1024 / 1024:.0f}MB)"
-        for s in sorted(large, key=lambda s: s["size"], reverse=True)[:5]
+        for s in sorted_large[:5]
+    )
+    cmds = "\n".join(
+        f"  cozempic treat {s['session_id'][:8]} -rx aggressive --execute"
+        for s in sorted_large
     )
 
     return CheckResult(
         name="oversized-sessions",
         status="issue",
         message=f"{len(large)} session(s) over 50MB: {sizes}. These will likely hang on resume.",
-        fix_description="Run: cozempic treat <session> -rx aggressive --execute",
+        fix_description=f"Treat each oversized session:\n{cmds}",
     )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -15,6 +15,7 @@ from cozempic.doctor import (
     check_corrupted_tool_use,
     check_hooks_trust_flag,
     check_orphaned_tool_results,
+    check_oversized_sessions,
     check_stale_tmp_artifacts,
     check_zombie_teams,
     fix_claude_json_corruption,
@@ -476,6 +477,53 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         msg2 = fix_stale_tmp_artifacts()
         self.assertIn("0", msg1)
         self.assertIn("0", msg2)
+
+
+class TestOversizedSessions(unittest.TestCase):
+
+    def _make_session(self, session_id: str, size_mb: int) -> dict:
+        return {"session_id": session_id, "path": f"/tmp/fake/{session_id}.jsonl", "size": size_mb * 1024 * 1024}
+
+    def test_no_large_sessions_ok(self):
+        sessions = [self._make_session("aabbccdd1122", 10)]
+        with patch("cozempic.doctor.find_sessions", return_value=sessions):
+            result = check_oversized_sessions()
+        self.assertEqual(result.status, "ok")
+        self.assertIsNone(result.fix_description)
+
+    def test_fix_description_contains_real_session_ids(self):
+        sessions = [
+            self._make_session("aabbccdd1122eeff", 80),
+            self._make_session("11223344aabbccdd", 60),
+        ]
+        with patch("cozempic.doctor.find_sessions", return_value=sessions):
+            result = check_oversized_sessions()
+        self.assertEqual(result.status, "issue")
+        self.assertIn("cozempic treat aabbccdd", result.fix_description)
+        self.assertIn("cozempic treat 11223344", result.fix_description)
+        self.assertNotIn("<session>", result.fix_description)
+
+    def test_fix_description_one_line_per_session(self):
+        sessions = [
+            self._make_session("aaaa1111bbbb2222", 100),
+            self._make_session("cccc3333dddd4444", 75),
+            self._make_session("eeee5555ffff6666", 55),
+        ]
+        with patch("cozempic.doctor.find_sessions", return_value=sessions):
+            result = check_oversized_sessions()
+        lines = [l for l in result.fix_description.splitlines() if "cozempic treat" in l]
+        self.assertEqual(len(lines), 3)
+
+    def test_fix_description_sorted_largest_first(self):
+        sessions = [
+            self._make_session("small11122233344", 55),
+            self._make_session("large99988877766", 200),
+        ]
+        with patch("cozempic.doctor.find_sessions", return_value=sessions):
+            result = check_oversized_sessions()
+        idx_large = result.fix_description.index("large999")
+        idx_small = result.fix_description.index("small111")
+        self.assertLess(idx_large, idx_small)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I have been running a Cozempic fork for a month and accumulated a few enhancements I like. This first one is cosmetic to give the exact commands a user can run to 'treat' a session. Just want to see if PRs are accepted, then will submit the others which have small improvements I found useful. 

## Problem

The `doctor` command suggested running the `treat` command, but didn't provide command the user can just copy & paste. 

## Change

Output now includes the exact commands to run:

```
Treat each oversized session:
  cozempic treat a1b2c3d4 -rx aggressive --execute
  cozempic treat e5f6a7b8 -rx aggressive --execute
```

No functional changes, just text output. 

## Tests

Four new unit tests in `tests/test_doctor.py` (using the same `patch("cozempic.doctor.find_sessions", ...)` pattern as neighboring tests):

- clean-session case still returns `status="ok"` with no fix_description
- fix_description contains real 8-char IDs, not `<session>`
- one `cozempic treat` line per offending session
- commands are sorted largest-first (same order as the message summary)

All 41 existing tests continue to pass.