### PR TITLE
fix(cli,digest): polish v3 — digest --session UUID resolution + COZEMPIC_DEBUG token parsing + ValueError dispatch coverage

### DIFF
--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -206,3 +206,40 @@ def parse_env_non_negative_int(name: str) -> int | None:
         _env_warn(name, raw, "must be non-negative")
         return None
     return value
+
+
+# Token sets are module-level constants so tests can import and inspect them.
+_BOOL_TRUE_TOKENS: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+_BOOL_FALSE_TOKENS: frozenset[str] = frozenset({"0", "false", "no", "off"})
+
+
+def parse_env_bool(name: str, default: bool = False, warn: bool = True) -> bool:
+    """Read env var `name`, parse as boolean, return `default` if absent.
+
+    Truthy tokens (case-insensitive, whitespace stripped): 1, true, yes, on
+    Falsy tokens  (case-insensitive, whitespace stripped): 0, false, no, off
+    Unrecognized non-empty value: if `warn`, emits a warning to stderr and
+    returns `default`.  Empty / absent: returns `default` silently.
+
+    Follows the warn+fallback contract of parse_env_positive_int:
+    env vars are ambient config; an unrecognized value must not crash.
+
+    The `warn` parameter suppresses the warning when set to False — useful
+    for in-body re-reads that run on every call (e.g. _debug()) where a
+    single module-load warning is enough and per-call spam would drown output.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _BOOL_TRUE_TOKENS:
+        return True
+    if normalized in _BOOL_FALSE_TOKENS:
+        return False
+    if warn:
+        _env_warn(
+            name,
+            raw,
+            f"must be one of {sorted(_BOOL_TRUE_TOKENS | _BOOL_FALSE_TOKENS)}",
+        )
+    return default

--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -211,6 +211,11 @@ def parse_env_non_negative_int(name: str) -> int | None:
 # Token sets are module-level constants so tests can import and inspect them.
 _BOOL_TRUE_TOKENS: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 _BOOL_FALSE_TOKENS: frozenset[str] = frozenset({"0", "false", "no", "off"})
+# Pre-computed help string — avoids recomputing sorted() on every warn call
+# and keeps truthy/falsy groups distinct so users can self-correct.
+_BOOL_TOKENS_HELP = (
+    f"truthy: {sorted(_BOOL_TRUE_TOKENS)}; falsy: {sorted(_BOOL_FALSE_TOKENS)}"
+)
 
 
 def parse_env_bool(name: str, default: bool = False, warn: bool = True) -> bool:
@@ -219,7 +224,8 @@ def parse_env_bool(name: str, default: bool = False, warn: bool = True) -> bool:
     Truthy tokens (case-insensitive, whitespace stripped): 1, true, yes, on
     Falsy tokens  (case-insensitive, whitespace stripped): 0, false, no, off
     Unrecognized non-empty value: if `warn`, emits a warning to stderr and
-    returns `default`.  Empty / absent: returns `default` silently.
+    returns `default`.  Empty / absent / whitespace-only: returns `default`
+    silently.
 
     Follows the warn+fallback contract of parse_env_positive_int:
     env vars are ambient config; an unrecognized value must not crash.
@@ -229,7 +235,7 @@ def parse_env_bool(name: str, default: bool = False, warn: bool = True) -> bool:
     single module-load warning is enough and per-call spam would drown output.
     """
     raw = os.environ.get(name)
-    if raw is None or raw == "":
+    if raw is None or raw.strip() == "":
         return default
     normalized = raw.strip().lower()
     if normalized in _BOOL_TRUE_TOKENS:
@@ -237,9 +243,5 @@ def parse_env_bool(name: str, default: bool = False, warn: bool = True) -> bool:
     if normalized in _BOOL_FALSE_TOKENS:
         return False
     if warn:
-        _env_warn(
-            name,
-            raw,
-            f"must be one of {sorted(_BOOL_TRUE_TOKENS | _BOOL_FALSE_TOKENS)}",
-        )
+        _env_warn(name, raw, f"must be a boolean ({_BOOL_TOKENS_HELP})")
     return default

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1085,7 +1085,16 @@ def cmd_formulary(args):
 
 
 def _digest_session(args):
-    """Resolve session path and ID from args."""
+    """Resolve session path and ID from args.
+
+    Resolution strategy:
+      - absent / "current"  → cwd-based auto-detect via find_current_session(cwd);
+                              exits 1 with a stderr message if none found.
+      - explicit UUID / UUID prefix / file path → resolve_session(session_arg);
+                              session_id recovered from resolved path stem.
+
+    Returns (path, session_id, cwd).
+    """
     from .session import find_current_session, resolve_session
     cwd = getattr(args, "cwd", None) or os.getcwd()
     session_arg = getattr(args, "session", None)
@@ -1276,7 +1285,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_digest.add_argument("digest_action", nargs="?", default="show",
                           choices=["show", "update", "clear", "flush", "recover", "inject"],
                           help="Action: show (default), update, clear, flush, recover, inject")
-    p_digest.add_argument("--session", help="Session ID or path")
+    p_digest.add_argument("--session", help=session_help)
     p_digest.add_argument("--cwd", help="Working directory (default: current)")
 
     return parser

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1086,16 +1086,21 @@ def cmd_formulary(args):
 
 def _digest_session(args):
     """Resolve session path and ID from args."""
-    from .session import find_current_session
+    from .session import find_current_session, resolve_session
     cwd = getattr(args, "cwd", None) or os.getcwd()
-    session_path = getattr(args, "session", None)
-    if not session_path:
+    session_arg = getattr(args, "session", None)
+    if not session_arg:
         sess = find_current_session(cwd)
         if not sess:
-            print("No active session found.")
+            # Changed to stderr: consistent with resolve_session error output
+            # and all other error paths in cli.py.
+            print("No active session found.", file=sys.stderr)
             sys.exit(1)
         return sess["path"], sess.get("session_id", ""), cwd
-    return session_path, "", cwd
+    # resolve_session handles: explicit path, UUID, UUID prefix, "current"
+    resolved = resolve_session(session_arg)
+    session_id = resolved.stem  # filename stem IS the session UUID
+    return resolved, session_id, cwd
 
 
 def cmd_digest(args):

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1089,7 +1089,11 @@ def _digest_session(args):
     from .session import find_current_session, resolve_session
     cwd = getattr(args, "cwd", None) or os.getcwd()
     session_arg = getattr(args, "session", None)
-    if not session_arg:
+    if not session_arg or session_arg == "current":
+        # Both absent and explicit "current" use cwd-based auto-detection,
+        # consistent with how the rest of cli.py resolves the current session.
+        # Routing "current" through resolve_session() would use process-detection
+        # (find_current_session(strict=False)) which is a different strategy.
         sess = find_current_session(cwd)
         if not sess:
             # Changed to stderr: consistent with resolve_session error output
@@ -1097,7 +1101,7 @@ def _digest_session(args):
             print("No active session found.", file=sys.stderr)
             sys.exit(1)
         return sess["path"], sess.get("session_id", ""), cwd
-    # resolve_session handles: explicit path, UUID, UUID prefix, "current"
+    # resolve_session handles: explicit path, UUID, UUID prefix
     resolved = resolve_session(session_arg)
     session_id = resolved.stem  # filename stem IS the session UUID
     return resolved, session_id, cwd

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+from ._validation import parse_env_bool
 from .helpers import get_content_blocks, get_msg_type, text_of
 from .types import Message
 
@@ -43,11 +44,12 @@ DECAY_DAYS = 30  # Universal decay period (MemoryArena 2602.16313)
 # AFTER import (programmatic or shell-inherited mid-run) takes effect.
 # Runs inside hooks (PreCompact, Stop) where unconditional stderr would leak
 # to users — hence env-gated.
-_DEBUG = os.environ.get("COZEMPIC_DEBUG") == "1"
+# Accepts: 1/true/yes/on (case-insensitive). Default off.
+_DEBUG = parse_env_bool("COZEMPIC_DEBUG", default=False)
 
 
 def _debug(msg: str) -> None:
-    if _DEBUG or os.environ.get("COZEMPIC_DEBUG") == "1":
+    if _DEBUG or parse_env_bool("COZEMPIC_DEBUG", default=False, warn=False):
         print(f"[cozempic.digest] {msg}", file=sys.stderr)
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import io
+import contextlib
 import os
-from unittest.mock import patch
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from cozempic.cli import _prescan_argv, build_parser
+from cozempic.cli import _prescan_argv, build_parser, _digest_session
 
 
 class TestPrescanArgvValidation:
@@ -231,3 +235,167 @@ class TestReloadSessionFlag:
         args = parser.parse_args(["reload", "-rx", "standard"])
         assert args.session is None
         assert args.rx == "standard"
+
+
+# ---------------------------------------------------------------------------
+# F15: ValueError dispatch in main() — cozempic.cli lines 1708-1719
+# ---------------------------------------------------------------------------
+
+def _run_main_with_argv(argv):
+    """Run main() with stubbed-out side-effects (updater, init hooks).
+
+    Returns (stdout_str, stderr_str).  Raises SystemExit transparently.
+    """
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+
+    with patch("sys.argv", ["cozempic"] + argv), \
+         patch("cozempic.cli._maybe_global_init"), \
+         patch("cozempic.cli._maybe_auto_init"), \
+         patch("cozempic.updater.ping_install_if_new"), \
+         patch("cozempic.updater.maybe_auto_update"), \
+         patch("sys.stdout", stdout_buf), \
+         patch("sys.stderr", stderr_buf):
+        from cozempic.cli import main
+        main()
+
+    return stdout_buf.getvalue(), stderr_buf.getvalue()
+
+
+class TestValueErrorDispatch:
+    """main() try/except ValueError must:
+      - guard / reload + ValueError → exit 2 + "Error:" on stderr
+      - other command + ValueError → re-raise (not silently swallowed)
+    """
+
+    def test_guard_valueerror_exits_2_with_error_stderr(self):
+        """guard command raising ValueError → SystemExit(2) + 'Error:' on stderr."""
+        with patch("cozempic.cli.cmd_guard", side_effect=ValueError("bad session id")):
+            try:
+                _run_main_with_argv(["guard"])
+                assert False, "expected SystemExit"
+            except SystemExit as exc:
+                assert exc.code == 2, f"expected code 2, got {exc.code}"
+
+    def test_guard_valueerror_error_on_stderr(self):
+        """guard ValueError message must appear on stderr prefixed with 'Error:'."""
+        stderr_buf = io.StringIO()
+        with patch("cozempic.cli.cmd_guard", side_effect=ValueError("bad session id")), \
+             patch("sys.argv", ["cozempic", "guard"]), \
+             patch("cozempic.cli._maybe_global_init"), \
+             patch("cozempic.cli._maybe_auto_init"), \
+             patch("cozempic.updater.ping_install_if_new"), \
+             patch("cozempic.updater.maybe_auto_update"), \
+             patch("sys.stderr", stderr_buf):
+            from cozempic.cli import main
+            try:
+                main()
+            except SystemExit:
+                pass
+        assert "Error:" in stderr_buf.getvalue(), (
+            f"expected 'Error:' in stderr, got: {stderr_buf.getvalue()!r}"
+        )
+
+    def test_reload_valueerror_exits_2_with_error_stderr(self):
+        """reload command raising ValueError → SystemExit(2)."""
+        with patch("cozempic.cli.cmd_reload", side_effect=ValueError("malformed")):
+            try:
+                _run_main_with_argv(["reload"])
+                assert False, "expected SystemExit"
+            except SystemExit as exc:
+                assert exc.code == 2, f"expected code 2, got {exc.code}"
+
+    def test_non_guard_valueerror_propagates(self):
+        """diagnose raising ValueError must propagate (not become exit 2)."""
+        with patch("cozempic.cli.cmd_diagnose", side_effect=ValueError("unexpected")):
+            try:
+                _run_main_with_argv(["diagnose", "current"])
+                assert False, "expected ValueError or SystemExit"
+            except ValueError as exc:
+                assert "unexpected" in str(exc)
+            except SystemExit as exc:
+                assert exc.code != 2, (
+                    "non-guard/reload ValueError must NOT exit 2 — got SystemExit(2)"
+                )
+
+    def test_error_message_text_appears_in_stderr(self):
+        """The ValueError message text must appear in stderr output."""
+        stderr_buf = io.StringIO()
+        with patch("cozempic.cli.cmd_guard", side_effect=ValueError("session_id malformed: @@")), \
+             patch("sys.argv", ["cozempic", "guard"]), \
+             patch("cozempic.cli._maybe_global_init"), \
+             patch("cozempic.cli._maybe_auto_init"), \
+             patch("cozempic.updater.ping_install_if_new"), \
+             patch("cozempic.updater.maybe_auto_update"), \
+             patch("sys.stderr", stderr_buf):
+            from cozempic.cli import main
+            try:
+                main()
+            except SystemExit:
+                pass
+        assert "session_id malformed: @@" in stderr_buf.getvalue(), (
+            f"error text missing from stderr: {stderr_buf.getvalue()!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI bug: _digest_session must resolve UUID via resolve_session (F4)
+# ---------------------------------------------------------------------------
+
+class TestDigestSessionResolution:
+    """_digest_session(args) must call resolve_session() when args.session
+    is provided, not return the string verbatim.
+
+    Before fix: `return session_path, "", cwd` → passes UUID as a file path.
+    After fix:  calls resolve_session(session_arg) → returns Path + stem ID.
+    """
+
+    def _make_args(self, session=None):
+        args = MagicMock()
+        args.session = session
+        args.cwd = None
+        return args
+
+    def test_uuid_arg_resolves_to_path(self):
+        """UUID string → resolve_session called, returned path is a Path object."""
+        fake_path = Path("/fake/abc123.jsonl")
+        with patch("cozempic.cli.resolve_session", return_value=fake_path) as mock_rs:
+            path, session_id, cwd = _digest_session(self._make_args(session="abc123"))
+        mock_rs.assert_called_once_with("abc123")
+        assert path == fake_path
+
+    def test_uuid_arg_session_id_from_stem(self):
+        """session_id must be derived from path.stem (the UUID)."""
+        fake_path = Path("/fake/abc123.jsonl")
+        with patch("cozempic.cli.resolve_session", return_value=fake_path):
+            path, session_id, cwd = _digest_session(self._make_args(session="abc123"))
+        assert session_id == "abc123", f"expected 'abc123', got {session_id!r}"
+
+    def test_path_arg_resolves_correctly(self):
+        """Explicit file path → resolve_session returns it, stem extracted."""
+        fake_path = Path("/real/path/uuid-val.jsonl")
+        with patch("cozempic.cli.resolve_session", return_value=fake_path):
+            path, session_id, cwd = _digest_session(
+                self._make_args(session="/real/path/uuid-val.jsonl")
+            )
+        assert path == fake_path
+        assert session_id == "uuid-val"
+
+    def test_no_session_arg_uses_find_current(self):
+        """args.session=None → find_current_session called; returns its path + id."""
+        fake_sess = {"path": Path("/x/sess.jsonl"), "session_id": "sess"}
+        # _digest_session does a local `from .session import find_current_session`,
+        # so patch the source module (cozempic.session) not the cli binding.
+        with patch("cozempic.session.find_current_session", return_value=fake_sess):
+            path, session_id, cwd = _digest_session(self._make_args(session=None))
+        assert path == Path("/x/sess.jsonl")
+        assert session_id == "sess"
+
+    def test_no_session_arg_no_current_exits_1(self):
+        """args.session=None + no current session → SystemExit(1)."""
+        with patch("cozempic.session.find_current_session", return_value=None):
+            try:
+                _digest_session(self._make_args(session=None))
+                assert False, "expected SystemExit(1)"
+            except SystemExit as exc:
+                assert exc.code == 1, f"expected exit 1, got {exc.code}"

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -401,3 +401,17 @@ class TestDigestSessionResolution:
                 assert False, "expected SystemExit(1)"
             except SystemExit as exc:
                 assert exc.code == 1, f"expected exit 1, got {exc.code}"
+
+    def test_current_literal_uses_cwd_find_current(self):
+        """args.session='current' → uses cwd-based find_current_session (same as
+        no-session path), NOT resolve_session('current') which uses process-detection.
+        C3: keeps both paths consistent."""
+        fake_sess = {"path": Path("/y/curr.jsonl"), "session_id": "curr"}
+        with patch("cozempic.session.find_current_session", return_value=fake_sess) as mock_fc, \
+             patch("cozempic.session.resolve_session") as mock_rs:
+            path, session_id, cwd = _digest_session(self._make_args(session="current"))
+        # Must use find_current_session (cwd-based), NOT resolve_session
+        mock_fc.assert_called_once()
+        mock_rs.assert_not_called()
+        assert path == Path("/y/curr.jsonl")
+        assert session_id == "curr"

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -359,7 +359,9 @@ class TestDigestSessionResolution:
     def test_uuid_arg_resolves_to_path(self):
         """UUID string → resolve_session called, returned path is a Path object."""
         fake_path = Path("/fake/abc123.jsonl")
-        with patch("cozempic.cli.resolve_session", return_value=fake_path) as mock_rs:
+        # _digest_session does `from .session import ..., resolve_session` locally,
+        # so patch the source module (cozempic.session) not the cli top-level binding.
+        with patch("cozempic.session.resolve_session", return_value=fake_path) as mock_rs:
             path, session_id, cwd = _digest_session(self._make_args(session="abc123"))
         mock_rs.assert_called_once_with("abc123")
         assert path == fake_path
@@ -367,14 +369,14 @@ class TestDigestSessionResolution:
     def test_uuid_arg_session_id_from_stem(self):
         """session_id must be derived from path.stem (the UUID)."""
         fake_path = Path("/fake/abc123.jsonl")
-        with patch("cozempic.cli.resolve_session", return_value=fake_path):
+        with patch("cozempic.session.resolve_session", return_value=fake_path):
             path, session_id, cwd = _digest_session(self._make_args(session="abc123"))
         assert session_id == "abc123", f"expected 'abc123', got {session_id!r}"
 
     def test_path_arg_resolves_correctly(self):
         """Explicit file path → resolve_session returns it, stem extracted."""
         fake_path = Path("/real/path/uuid-val.jsonl")
-        with patch("cozempic.cli.resolve_session", return_value=fake_path):
+        with patch("cozempic.session.resolve_session", return_value=fake_path):
             path, session_id, cwd = _digest_session(
                 self._make_args(session="/real/path/uuid-val.jsonl")
             )

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -2733,3 +2733,96 @@ class TestPolishV2_IsSystemNoiseSlashPrefixedTag(unittest.TestCase):
             _is_system_noise("/Users/alice/foo.py needs a fix"),
             "/Users/... file path wrongly flagged — A12 regression",
         )
+
+
+# ---------------------------------------------------------------------------
+# TestDebugFlagTokens — F11: COZEMPIC_DEBUG must accept 1/true/yes/on
+# ---------------------------------------------------------------------------
+
+import importlib
+import io as _io
+import contextlib as _contextlib
+import cozempic.digest as _digest_module
+
+
+class TestDebugFlagTokens(unittest.TestCase):
+    """F11: COZEMPIC_DEBUG must activate debug output for tokens
+    1/true/yes/on (case-insensitive), and suppress for 0/false/no/off.
+
+    Strategy A: monkeypatch `_DEBUG = False` to reset module-level cache,
+    then set COZEMPIC_DEBUG env var and call `_debug()`.  The in-body
+    re-read in `_debug()` must use `parse_env_bool` — accepting the full
+    token set.
+
+    Strategy C (one test): reload digest module to verify that the
+    import-time assignment also picks up `true`/`yes`/`on`.
+    """
+
+    def _capture_debug(self, env_val: str | None) -> str:
+        """Call `_debug()` with `_DEBUG=False` (monkeypatched) and the
+        given env var, return captured stderr."""
+        env = {} if env_val is None else {"COZEMPIC_DEBUG": env_val}
+        buf = _io.StringIO()
+        with patch("cozempic.digest._DEBUG", False):
+            with patch.dict(os.environ, env, clear=False):
+                if env_val is None:
+                    os.environ.pop("COZEMPIC_DEBUG", None)
+                with _contextlib.redirect_stderr(buf):
+                    _digest_module._debug("test-message")
+        return buf.getvalue()
+
+    def test_debug_off_by_default(self):
+        """No env var → no output."""
+        output = self._capture_debug(None)
+        self.assertEqual(output, "")
+
+    def test_debug_on_with_1(self):
+        """COZEMPIC_DEBUG=1 → debug output present."""
+        output = self._capture_debug("1")
+        self.assertIn("test-message", output)
+
+    def test_debug_on_with_true(self):
+        """COZEMPIC_DEBUG=true → debug output present (F11 core fix)."""
+        output = self._capture_debug("true")
+        self.assertIn("test-message", output)
+
+    def test_debug_on_with_yes(self):
+        """COZEMPIC_DEBUG=yes → debug output present."""
+        output = self._capture_debug("yes")
+        self.assertIn("test-message", output)
+
+    def test_debug_on_with_on(self):
+        """COZEMPIC_DEBUG=on → debug output present."""
+        output = self._capture_debug("on")
+        self.assertIn("test-message", output)
+
+    def test_debug_on_case_insensitive(self):
+        """COZEMPIC_DEBUG=TRUE → debug output present (case-insensitive)."""
+        output = self._capture_debug("TRUE")
+        self.assertIn("test-message", output)
+
+    def test_debug_off_with_0(self):
+        """COZEMPIC_DEBUG=0 → no output (explicit falsy token)."""
+        output = self._capture_debug("0")
+        self.assertEqual(output, "")
+
+    def test_debug_off_with_false(self):
+        """COZEMPIC_DEBUG=false → no output (explicit falsy token)."""
+        output = self._capture_debug("false")
+        self.assertEqual(output, "")
+
+    def test_import_time_true_token_activates_DEBUG(self):
+        """Strategy C: reload the module with COZEMPIC_DEBUG=true → _DEBUG must
+        be True.  Catches a regression if someone reverts line 46 to == "1"."""
+        with patch.dict(os.environ, {"COZEMPIC_DEBUG": "true"}, clear=False):
+            reloaded = importlib.reload(_digest_module)
+        try:
+            self.assertTrue(
+                reloaded._DEBUG,
+                "_DEBUG must be True after reload with COZEMPIC_DEBUG=true",
+            )
+        finally:
+            # Restore the module to its normal state (no COZEMPIC_DEBUG).
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("COZEMPIC_DEBUG", None)
+                importlib.reload(_digest_module)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -2758,6 +2758,21 @@ class TestDebugFlagTokens(unittest.TestCase):
     import-time assignment also picks up `true`/`yes`/`on`.
     """
 
+    def setUp(self):
+        """Ensure each test starts with a clean slate:
+        - module-level _DEBUG forced to False (so tests don't inherit a True
+          state left by the Strategy C reload test or a prior test run)
+        - COZEMPIC_DEBUG removed from env (so a shell-inherited value
+          doesn't poison tests that expect env to be absent)
+        """
+        _digest_module._DEBUG = False
+        os.environ.pop("COZEMPIC_DEBUG", None)
+
+    def tearDown(self):
+        """Restore module state after each test (mirrors setUp for symmetry)."""
+        _digest_module._DEBUG = False
+        os.environ.pop("COZEMPIC_DEBUG", None)
+
     def _capture_debug(self, env_val: str | None) -> str:
         """Call `_debug()` with `_DEBUG=False` (monkeypatched) and the
         given env var, return captured stderr."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -297,6 +297,24 @@ class TestParseEnvBool(unittest.TestCase):
         """warn=False must not suppress recognized-token parsing."""
         self.assertTrue(self._call(raw="yes", warn=False))
 
+    # ── whitespace-only input ────────────────────────────────────────────────
+
+    def test_whitespace_only_returns_default_silently(self):
+        """COZEMPIC_DEBUG='   ' must return default WITHOUT a warning.
+
+        The bug: raw == "" guard fires BEFORE strip(), so '   ' slips
+        through as non-empty → normalized="" → not in token sets → spurious
+        warning on stderr. Fix: check raw.strip() == "" instead of raw == "".
+        """
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = self._call(raw="   ")
+        self.assertFalse(result, "whitespace-only must return default (False)")
+        self.assertEqual(buf.getvalue(), "",
+                         "whitespace-only must produce NO warning on stderr")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -274,6 +274,14 @@ class TestParseEnvBool(unittest.TestCase):
         """Leading/trailing whitespace must be stripped before token lookup."""
         self.assertTrue(self._call(raw="  true  "))
 
+    def test_whitespace_stripped_numeric(self):
+        """Whitespace around a numeric truthy token must also be stripped."""
+        self.assertTrue(self._call(raw="  1  "))
+
+    def test_whitespace_stripped_uppercase_on(self):
+        """Whitespace + uppercase truthy token 'ON' → True (strip + lower)."""
+        self.assertTrue(self._call(raw="  ON  "))
+
     # ── warn=False suppresses stderr on unrecognized ─────────────────────────
 
     def test_warn_false_suppresses_warning(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -180,5 +180,115 @@ class TestBackwardsCompatReExport(unittest.TestCase):
         self.assertIs(reexported, ConfigError)
 
 
+class TestParseEnvBool(unittest.TestCase):
+    """Env var helper for boolean flags.
+
+    Truthy tokens:  1 / true / yes / on  (case-insensitive, whitespace stripped)
+    Falsy tokens:   0 / false / no / off (case-insensitive, whitespace stripped)
+    Absent / empty: return default silently.
+    Unrecognized:   warn to stderr, return default.
+    """
+
+    _VAR = "TEST_ENV_BOOL"
+
+    def setUp(self):
+        # Import here so the test fails with ImportError (not AttributeError)
+        # until the helper is implemented — correct RED failure mode.
+        from cozempic._validation import parse_env_bool
+        self.parse_env_bool = parse_env_bool
+
+    def _call(self, raw=None, default=False, warn=True):
+        env = {self._VAR: raw} if raw is not None else {}
+        with patch.dict(os.environ, env, clear=False):
+            if raw is None:
+                os.environ.pop(self._VAR, None)
+            return self.parse_env_bool(self._VAR, default=default, warn=warn)
+
+    # ── absent / empty ──────────────────────────────────────────────────────
+
+    def test_absent_returns_default_false(self):
+        self.assertFalse(self._call())
+
+    def test_empty_returns_default_false(self):
+        self.assertFalse(self._call(raw=""))
+
+    def test_absent_with_default_true(self):
+        self.assertTrue(self._call(default=True))
+
+    # ── truthy tokens ────────────────────────────────────────────────────────
+
+    def test_true_token_1(self):
+        self.assertTrue(self._call(raw="1"))
+
+    def test_true_token_true(self):
+        self.assertTrue(self._call(raw="true"))
+
+    def test_true_token_True_mixed_case(self):
+        self.assertTrue(self._call(raw="True"))
+
+    def test_true_token_yes(self):
+        self.assertTrue(self._call(raw="yes"))
+
+    def test_true_token_YES_uppercase(self):
+        self.assertTrue(self._call(raw="YES"))
+
+    def test_true_token_on(self):
+        self.assertTrue(self._call(raw="on"))
+
+    # ── falsy tokens ─────────────────────────────────────────────────────────
+
+    def test_false_token_0(self):
+        self.assertFalse(self._call(raw="0"))
+
+    def test_false_token_false(self):
+        self.assertFalse(self._call(raw="false"))
+
+    def test_false_token_no(self):
+        self.assertFalse(self._call(raw="no"))
+
+    def test_false_token_off(self):
+        self.assertFalse(self._call(raw="off"))
+
+    # ── unrecognized: warn + return default ──────────────────────────────────
+
+    def test_unrecognized_warns_and_returns_default(self):
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = self._call(raw="foo")
+        self.assertFalse(result)
+        self.assertGreater(len(buf.getvalue()), 0, "expected a warning on stderr")
+
+    def test_unrecognized_includes_var_name_in_warning(self):
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            self._call(raw="maybe")
+        self.assertIn(self._VAR, buf.getvalue())
+
+    # ── whitespace stripping ─────────────────────────────────────────────────
+
+    def test_whitespace_stripped(self):
+        """Leading/trailing whitespace must be stripped before token lookup."""
+        self.assertTrue(self._call(raw="  true  "))
+
+    # ── warn=False suppresses stderr on unrecognized ─────────────────────────
+
+    def test_warn_false_suppresses_warning(self):
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            result = self._call(raw="garbage", warn=False)
+        self.assertFalse(result)
+        self.assertEqual(buf.getvalue(), "", "expected NO warning when warn=False")
+
+    def test_warn_false_recognized_token_still_works(self):
+        """warn=False must not suppress recognized-token parsing."""
+        self.assertTrue(self._call(raw="yes", warn=False))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Three small, long-parked defects (queued since the polish-v2 audit) plus one CLI bug surfaced by live smoke testing:

1. **`cozempic digest --session <UUID>` crashes.** `_digest_session` returned the raw `--session` argument as a file path, so passing a session ID or UUID prefix — which the `--session` help advertises as supported — raised `FileNotFoundError` deep in `load_messages`. Only a full `.jsonl` path worked.
2. **`COZEMPIC_DEBUG` only honoured the literal `"1"`.** `COZEMPIC_DEBUG=true` / `yes` / `on` were silently ignored — inconsistent with common env-var conventions and surprising for a debug toggle.
3. **The `main()` `except ValueError` dispatch had zero test coverage.** The `guard`/`reload` error path (exit 2 + clean one-line stderr) versus the re-raise path for every other command was untested, so a refactor could silently break the user-facing error message.

## Fix

- **`parse_env_bool` helper** (new, `_validation.py`) — sits beside the existing `parse_env_positive_int` / `parse_env_non_negative_int` and follows the same warn-and-fallback contract. Accepts `1/true/yes/on` (truthy) and `0/false/no/off` (falsy), case-insensitive and whitespace-stripped; an unrecognized value warns once and falls back to the default. A `warn` parameter lets hot re-read paths suppress per-call spam.
- **`digest.py`** consumes `parse_env_bool` at both the module-level cache and the in-body `_debug()` re-read (module-load warns once; the in-body re-read uses `warn=False`) — a single parse path the two sites can no longer diverge on.
- **`_digest_session`** now routes an explicit `--session <UUID | prefix | path>` through the existing `resolve_session()` and recovers `session_id` from the resolved path stem. Absent or the `current` keyword take the same cwd-based `find_current_session(cwd)` auto-detect the no-arg path already used (kept consistent on purpose, so `--session current` does not silently switch to a different detection strategy).
- **ValueError dispatch coverage** adds `TestValueErrorDispatch` exercising both branches (test-only — the production code was already correct).

F7 from the original polish-v2 list (`COZEMPIC_DEBUG` captured at import time) was already fixed on `main` — `_debug()` re-reads the env on each call. Verified; no change needed.

## Tests

- **866 passing** (`pytest tests/ -q --ignore=tests/test_model_detection.py`, the standing exclusion), exit 0.
- Adds four test classes — `TestParseEnvBool`, `TestDebugFlagTokens`, `TestValueErrorDispatch`, `TestDigestSessionResolution` — covering token broadening (incl. case-insensitive, whitespace, explicit-falsy, warn suppression, whitespace-only silent), import-time reload, both dispatch branches, and UUID/prefix/path/`current`/no-arg resolution.
- Strict RED→GREEN: each fix has a test verified to fail at the pre-fix state (confirmed by reverting each fix and re-running).
- Zero new dependencies — pure stdlib (`os`/`sys`/`typing` + intra-package).

## Scope

Touches only `_validation.py`, `digest.py`, `cli.py` and their tests — no `guard.py` / `executor.py`.

**Deferred (documented, not folded):** the `COZEMPIC_NO_TELEMETRY` / `NO_AUTO_UPDATE` / `NO_GLOBAL_INIT` / `NO_AUTO_INIT` opt-out flags still use bare truthiness (so `=false` would still *enable* the opt-out). Migrating them to `parse_env_bool` is a behaviour change with back-compat implications for those opt-out semantics, so it is left as a follow-up rather than bundled here.

**Pre-existing, tracked follow-up:** `digest update` / `flush` resolve the current session non-strict (mtime fallback can guess on ambiguity), unlike `treat` which passes `strict=execute`. This predates the PR (base `3a4cb1c` is also non-strict) and `flush` runs in the Stop hook where `strict=True` could fail silently — it needs its own analysis, not a blind fold here.

**Known behaviour:** the module-load `parse_env_bool` now warns once on a genuinely-invalid `COZEMPIC_DEBUG` value (the old `== "1"` was silent). Hook paths suppress stderr via `2>/dev/null`, so this surfaces only in interactive use and is actionable. The import-time reload test relies on test-collection order-independence (verified).
