### PR TITLE
fix(watcher): detect growth after prune (shrink + inode-swap), missing-file fallback, deterministic kqueue close (watcher.py audit)

### DIFF
--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -96,6 +96,7 @@ class JsonlWatcher:
                         self._last_size = new_size
                         try:
                             self.on_growth(self.filepath, new_size)
+                            self._cb_error_logged = False  # reset on success
                         except Exception as exc:
                             self._log_cb_error(exc)  # don't crash the watcher thread
                 if inode_replaced:
@@ -119,5 +120,6 @@ class JsonlWatcher:
                 self._last_size = new_size
                 try:
                     self.on_growth(self.filepath, new_size)
+                    self._cb_error_logged = False  # reset on success
                 except Exception as exc:
                     self._log_cb_error(exc)  # don't crash the watcher thread

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -57,19 +57,24 @@ class JsonlWatcher:
     def _watch_kqueue(self) -> None:
         """macOS kqueue watcher — 0.04ms wake latency, 0% CPU idle.
 
-        Falls back to poll if the watched inode is replaced (os.replace / atomic prune).
+        Falls back to poll on:
+        - OSError from os.open (file missing, permission denied, etc.)
+        - OSError from select.kqueue() or kq.control() (EMFILE, etc.)
+        - Inode replacement detected via KQ_NOTE_DELETE/RENAME (os.replace / atomic prune)
         """
         import select
 
         try:
             fd = os.open(self.filepath, os.O_RDONLY)
-        except FileNotFoundError:
-            # File not yet created — poll path handles OSError gracefully
+        except OSError:
+            # File not yet created, permission denied, or other OS error —
+            # poll path handles OSError in _get_size() gracefully
             self._watch_poll()
             return
-        # kq = None sentinel: if select.kqueue() raises (e.g. EMFILE), the finally
-        # block below must still close fd — deterministic, not GC-dependent.
+        # kq = None sentinel: ensures the finally block can guard kq.close()
+        # independently of whether kqueue() succeeded.
         kq = None
+        kqueue_error = False
         inode_replaced = False
         try:
             kq = select.kqueue()
@@ -101,11 +106,17 @@ class JsonlWatcher:
                             self._log_cb_error(exc)  # don't crash the watcher thread
                 if inode_replaced:
                     break
+        except OSError:
+            # kqueue setup or control() failed (e.g. EMFILE) — degrade to poll
+            kqueue_error = True
         finally:
-            if kq is not None:
-                kq.close()
-            os.close(fd)
-        if inode_replaced and self._running:
+            # Nested try ensures os.close(fd) always runs even if kq.close() raises
+            try:
+                if kq is not None:
+                    kq.close()
+            finally:
+                os.close(fd)
+        if (inode_replaced or kqueue_error) and self._running:
             self._watch_poll()
 
     def _watch_poll(self) -> None:

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -9,6 +9,7 @@ Stdlib only — no dependencies.
 from __future__ import annotations
 
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Callable
@@ -23,6 +24,7 @@ class JsonlWatcher:
         self._running = False
         self._last_size = self._get_size()
         self._use_kqueue = hasattr(__import__("select"), "kqueue")
+        self._cb_error_logged = False
 
     def _get_size(self) -> int:
         try:
@@ -40,6 +42,12 @@ class JsonlWatcher:
 
     def stop(self) -> None:
         self._running = False
+
+    def _log_cb_error(self, exc: Exception) -> None:
+        """Log the first on_growth callback error to stderr; suppress repeats."""
+        if not self._cb_error_logged:
+            print(f"  [watcher] on_growth error: {exc}", file=sys.stderr)
+            self._cb_error_logged = True
 
     def _watch_kqueue(self) -> None:
         """macOS kqueue watcher — 0.04ms wake latency, 0% CPU idle."""
@@ -64,12 +72,15 @@ class JsonlWatcher:
                 events = kq.control([ev], 1, 1.0)
                 if events:
                     new_size = self._get_size()
+                    if new_size < self._last_size:
+                        # File shrank (prune completed) — reset baseline
+                        self._last_size = new_size
                     if new_size > self._last_size:
                         self._last_size = new_size
                         try:
                             self.on_growth(self.filepath, new_size)
-                        except Exception:
-                            pass  # Don't crash the watcher thread
+                        except Exception as exc:
+                            self._log_cb_error(exc)  # don't crash the watcher thread
         finally:
             kq.close()
             os.close(fd)
@@ -79,9 +90,12 @@ class JsonlWatcher:
         while self._running:
             time.sleep(0.2)
             new_size = self._get_size()
+            if new_size < self._last_size:
+                # File shrank (prune completed) — reset baseline
+                self._last_size = new_size
             if new_size > self._last_size:
                 self._last_size = new_size
                 try:
                     self.on_growth(self.filepath, new_size)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    self._log_cb_error(exc)  # don't crash the watcher thread

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -50,7 +50,10 @@ class JsonlWatcher:
             self._cb_error_logged = True
 
     def _watch_kqueue(self) -> None:
-        """macOS kqueue watcher — 0.04ms wake latency, 0% CPU idle."""
+        """macOS kqueue watcher — 0.04ms wake latency, 0% CPU idle.
+
+        Falls back to poll if the watched inode is replaced (os.replace / atomic prune).
+        """
         import select
 
         try:
@@ -60,17 +63,23 @@ class JsonlWatcher:
             self._watch_poll()
             return
         kq = select.kqueue()
+        inode_replaced = False
         try:
             ev = select.kevent(
                 fd,
                 filter=select.KQ_FILTER_VNODE,
                 flags=select.KQ_EV_ADD | select.KQ_EV_CLEAR,
-                fflags=select.KQ_NOTE_WRITE | select.KQ_NOTE_EXTEND,
+                fflags=(select.KQ_NOTE_WRITE | select.KQ_NOTE_EXTEND
+                        | select.KQ_NOTE_DELETE | select.KQ_NOTE_RENAME),
             )
             while self._running:
                 # Block up to 1s, then re-check _running
                 events = kq.control([ev], 1, 1.0)
-                if events:
+                for event in events:
+                    if event.fflags & (select.KQ_NOTE_DELETE | select.KQ_NOTE_RENAME):
+                        # Inode replaced (atomic prune via os.replace); drop to poll
+                        inode_replaced = True
+                        break
                     new_size = self._get_size()
                     if new_size < self._last_size:
                         # File shrank (prune completed) — reset baseline
@@ -81,9 +90,13 @@ class JsonlWatcher:
                             self.on_growth(self.filepath, new_size)
                         except Exception as exc:
                             self._log_cb_error(exc)  # don't crash the watcher thread
+                if inode_replaced:
+                    break
         finally:
             kq.close()
             os.close(fd)
+        if inode_replaced and self._running:
+            self._watch_poll()
 
     def _watch_poll(self) -> None:
         """Fallback polling watcher — 200ms interval."""

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -14,6 +14,12 @@ import time
 from pathlib import Path
 from typing import Callable
 
+try:
+    import select as _select
+    _HAS_KQUEUE = hasattr(_select, "kqueue")
+except ImportError:
+    _HAS_KQUEUE = False
+
 
 class JsonlWatcher:
     """Watch a JSONL file for size growth. Sub-second on macOS via kqueue."""
@@ -23,7 +29,7 @@ class JsonlWatcher:
         self.on_growth = on_growth
         self._running = False
         self._last_size = self._get_size()
-        self._use_kqueue = hasattr(__import__("select"), "kqueue")
+        self._use_kqueue = _HAS_KQUEUE
         self._cb_error_logged = False
 
     def _get_size(self) -> int:

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -110,12 +110,17 @@ class JsonlWatcher:
             # kqueue setup or control() failed (e.g. EMFILE) — degrade to poll
             kqueue_error = True
         finally:
-            # Nested try ensures os.close(fd) always runs even if kq.close() raises
-            try:
-                if kq is not None:
+            # Swallow cleanup-close errors: neither close must kill the thread or
+            # prevent the poll-fallback tail line from being reached.
+            if kq is not None:
+                try:
                     kq.close()
-            finally:
+                except OSError:
+                    pass  # cleanup only — never let it kill the thread
+            try:
                 os.close(fd)
+            except OSError:
+                pass  # cleanup only (fd opened once, closed once; defensive)
         if (inode_replaced or kqueue_error) and self._running:
             self._watch_poll()
 

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import sys
 import time
-from pathlib import Path
 from typing import Callable
 
 try:
@@ -68,9 +67,12 @@ class JsonlWatcher:
             # File not yet created — poll path handles OSError gracefully
             self._watch_poll()
             return
-        kq = select.kqueue()
+        # kq = None sentinel: if select.kqueue() raises (e.g. EMFILE), the finally
+        # block below must still close fd — deterministic, not GC-dependent.
+        kq = None
         inode_replaced = False
         try:
+            kq = select.kqueue()
             ev = select.kevent(
                 fd,
                 filter=select.KQ_FILTER_VNODE,
@@ -99,7 +101,8 @@ class JsonlWatcher:
                 if inode_replaced:
                     break
         finally:
-            kq.close()
+            if kq is not None:
+                kq.close()
             os.close(fd)
         if inode_replaced and self._running:
             self._watch_poll()

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -45,7 +45,12 @@ class JsonlWatcher:
         """macOS kqueue watcher — 0.04ms wake latency, 0% CPU idle."""
         import select
 
-        fd = os.open(self.filepath, os.O_RDONLY)
+        try:
+            fd = os.open(self.filepath, os.O_RDONLY)
+        except FileNotFoundError:
+            # File not yet created — poll path handles OSError gracefully
+            self._watch_poll()
+            return
         kq = select.kqueue()
         try:
             ev = select.kevent(

--- a/src/cozempic/watcher.py
+++ b/src/cozempic/watcher.py
@@ -46,8 +46,8 @@ class JsonlWatcher:
         import select
 
         fd = os.open(self.filepath, os.O_RDONLY)
+        kq = select.kqueue()
         try:
-            kq = select.kqueue()
             ev = select.kevent(
                 fd,
                 filter=select.KQ_FILTER_VNODE,
@@ -66,6 +66,7 @@ class JsonlWatcher:
                         except Exception:
                             pass  # Don't crash the watcher thread
         finally:
+            kq.close()
             os.close(fd)
 
     def _watch_poll(self) -> None:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -625,5 +625,117 @@ class TestJsonlWatcherImportIdiom(unittest.TestCase):
             os.unlink(path)
 
 
+# ---------------------------------------------------------------------------
+# Round-3 — OSError-robustness: any kqueue-path OSError must degrade to poll
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
+class TestJsonlWatcherOSErrorRobustness(unittest.TestCase):
+    """kqueue path must fall back to poll on any OSError, not crash the daemon thread.
+
+    Three scenarios:
+    R1 — os.open raises PermissionError (subclass of OSError, not FileNotFoundError)
+    R2 — select.kqueue() raises OSError (EMFILE) → poll fallback, thread stays alive
+    R3 — kq.close() raises → os.close(fd) still runs (nested finally)
+    """
+
+    def test_permission_error_on_open_falls_back_to_poll(self):
+        """PermissionError on os.open must fall back to poll, not crash the thread.
+
+        Current code catches only FileNotFoundError; PermissionError propagates
+        uncaught → thread dies. Fix: catch OSError (parent of both).
+        """
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "watch.jsonl")
+            with open(path, "wb") as f:
+                f.write(b"x" * 100)
+
+            with patch("os.open", side_effect=PermissionError("EACCES simulated")):
+                w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+                t = _start_thread(w)
+                t.join(timeout=1.5)
+
+            # Thread must still be alive — fell back to poll loop
+            self.assertTrue(t.is_alive(),
+                "Watcher thread died on PermissionError from os.open. "
+                "R1 not fixed: only FileNotFoundError caught, not OSError.")
+            w.stop()
+            t.join(timeout=2)
+
+    def test_kqueue_oserror_falls_back_to_poll(self):
+        """OSError from select.kqueue() (e.g. EMFILE) must fall back to poll.
+
+        Current behaviour: OSError propagates out of the try/finally that closes fd,
+        then bubbles up through start() → thread dies. Fix: catch OSError around the
+        kqueue+control-loop block and fall back to poll.
+        """
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                          mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 100)
+        try:
+            with patch("select.kqueue", side_effect=OSError("EMFILE simulated")):
+                w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+                t = _start_thread(w)
+                t.join(timeout=1.5)
+
+            # Thread must still be alive — fell back to poll loop
+            self.assertTrue(t.is_alive(),
+                "Watcher thread died on select.kqueue() OSError. "
+                "R2 not fixed: OSError not caught; no poll fallback after kqueue failure.")
+            w.stop()
+            t.join(timeout=2)
+        finally:
+            os.unlink(path)
+
+    def test_fd_closed_even_if_kq_close_raises(self):
+        """os.close(fd) must run even if kq.close() raises an exception.
+
+        Current finally block: kq.close() then os.close(fd) — if kq.close() raises,
+        os.close(fd) is skipped. Fix: nest them so os.close(fd) is unconditional.
+        """
+        import select as _sel
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                          mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 100)
+        try:
+            fd_closed = threading.Event()
+            real_os_close = os.close
+
+            def spy_close(fd: int) -> None:
+                fd_closed.set()
+                real_os_close(fd)
+
+            real_kqueue_cls = _sel.kqueue
+
+            def spy_kqueue():
+                real_kq = real_kqueue_cls()
+                mock_kq = MagicMock()
+                mock_kq.control.side_effect = real_kq.control
+                # kq.close() raises — simulates a misbehaving kqueue object
+                def raising_close():
+                    real_kq.close()
+                    raise OSError("kq.close() failed")
+                mock_kq.close.side_effect = raising_close
+                return mock_kq
+
+            with patch("select.kqueue", side_effect=spy_kqueue), \
+                 patch("os.close", side_effect=spy_close):
+                w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+                t = _start_thread(w)
+                time.sleep(0.2)
+                w.stop()
+                t.join(timeout=2)
+
+            self.assertTrue(fd_closed.is_set(),
+                "os.close(fd) not called when kq.close() raised. "
+                "R3 not fixed: kq.close() must be in a nested try so os.close(fd) "
+                "always runs unconditionally.")
+        finally:
+            os.unlink(path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -736,6 +736,99 @@ class TestJsonlWatcherOSErrorRobustness(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_kq_close_oserror_does_not_kill_thread_and_polls(self):
+        """kq.close() raising OSError in finally must NOT kill the thread.
+
+        Gap in the current nested try/finally (R3):
+            try:
+                if kq is not None: kq.close()   # raises OSError here
+            finally:
+                os.close(fd)                     # still runs (R3 ok)
+        ...but kq.close()'s OSError propagates out of the outer finally,
+        killing the thread and skipping the poll-fallback tail line.
+
+        Fix: swallow cleanup-close errors. Both closes are attempted and neither
+        propagates; the poll fallback at the end of _watch_kqueue is always reached.
+
+        This test combines with a kqueue()-EMFILE scenario so kqueue_error is True
+        when kq.close() raises — ensuring poll fallback IS entered (b), not just
+        that the thread survives a graceful stop.
+
+        Asserts:
+        (a) os.close(fd) is still called
+        (b) _watch_poll IS entered (poll fallback runs even when cleanup raises)
+        (c) thread stays alive / joins cleanly (does not die from cleanup exception)
+        """
+        import select as _sel
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                          mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 100)
+        try:
+            fd_closed = threading.Event()
+            poll_entered = threading.Event()
+            real_os_close = os.close
+
+            def spy_close(fd: int) -> None:
+                fd_closed.set()
+                real_os_close(fd)
+
+            real_kqueue_cls = _sel.kqueue
+            kqueue_call_count = [0]
+
+            def spy_kqueue():
+                kqueue_call_count[0] += 1
+                real_kq = real_kqueue_cls()
+                mock_kq = MagicMock()
+                # First control() call raises OSError → kqueue_error=True → poll fallback
+                # This ensures fall_back_to_poll is True when we reach the finally block
+                call_n = [0]
+                def raising_control(events, max_events, timeout):
+                    call_n[0] += 1
+                    if call_n[0] == 1:
+                        raise OSError("kq.control() failed — EMFILE simulation")
+                    return real_kq.control(events, max_events, timeout)
+                mock_kq.control.side_effect = raising_control
+                # kq.close() also raises — the key condition being tested
+                def raising_close():
+                    real_kq.close()
+                    raise OSError("kq.close() misbehaved in cleanup")
+                mock_kq.close.side_effect = raising_close
+                return mock_kq
+
+            w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+
+            # Spy on _watch_poll to detect poll-fallback entry
+            real_watch_poll = w._watch_poll
+            def spy_poll():
+                poll_entered.set()
+                real_watch_poll()
+            w._watch_poll = spy_poll
+
+            with patch("select.kqueue", side_effect=spy_kqueue), \
+                 patch("os.close", side_effect=spy_close):
+                t = _start_thread(w)
+                # Wait for poll fallback to be entered (or timeout)
+                poll_entered.wait(timeout=2.0)
+                w.stop()
+                t.join(timeout=2)
+
+            # (a) fd was closed despite kq.close() raising
+            self.assertTrue(fd_closed.is_set(),
+                "os.close(fd) not called when kq.close() raised. "
+                "Cleanup swallow not implemented (addendum fix).")
+            # (b) poll fallback was entered despite the cleanup exception
+            self.assertTrue(poll_entered.is_set(),
+                "_watch_poll not entered after kq.close() OSError. "
+                "Addendum not fixed: OSError in cleanup kills thread before "
+                "poll-fallback tail line is reached.")
+            # (c) thread joined cleanly
+            self.assertFalse(t.is_alive(),
+                "Thread still alive after stop(). May be stuck in unexpected state.")
+        finally:
+            os.unlink(path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,10 +1,11 @@
-"""RED tests for JsonlWatcher bugs W1-W5.
+"""Tests for JsonlWatcher bugs W1-W5.
 
-W1 — kqueue fd leak (kq never closed in finally)
+W1 — kqueue fd must be closed deterministically (not relying on GC / CPython refcount)
 W2 — FileNotFoundError crash when file missing at start
 W3 — _last_size not reset after shrink → growth blindness post-prune
-W4 — on_growth exceptions silently swallowed; must log to stderr
+W4 — on_growth exceptions silently swallowed; must log to stderr (one-shot)
 W5 — kqueue watches orphaned inode after os.replace → blind post-prune (kqueue only)
+W6 — module-level _HAS_KQUEUE constant (no __import__ idiom in __init__)
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import tempfile
 import threading
 import time
 import unittest
+from unittest.mock import MagicMock, call, patch
 
 from cozempic.watcher import JsonlWatcher
 
@@ -23,18 +25,6 @@ from cozempic.watcher import JsonlWatcher
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _open_fd_count() -> int:
-    """Return number of open fds for current process (macOS/Linux)."""
-    import subprocess
-    pid = os.getpid()
-    try:
-        # macOS / BSD
-        out = subprocess.check_output(["lsof", "-p", str(pid), "-n"], text=True)
-        return len(out.strip().splitlines()) - 1  # strip header
-    except Exception:
-        return -1
-
 
 def _make_watcher(path: str, callback, *, use_kqueue: bool) -> JsonlWatcher:
     """Create a JsonlWatcher with an overridden _use_kqueue flag."""
@@ -50,51 +40,89 @@ def _start_thread(watcher: JsonlWatcher) -> threading.Thread:
 
 
 # ---------------------------------------------------------------------------
-# W1 — kqueue fd leak
+# W1 — kqueue fd must close deterministically; must not rely on GC
 # ---------------------------------------------------------------------------
 
 @unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
 class TestJsonlWatcherFdLeak(unittest.TestCase):
-    """W1: kq.close() must be called in finally or kqueue fd leaks."""
+    """W1: kq.close() must be called in finally — not left to GC.
 
-    def test_kqueue_fd_closed_after_normal_stop(self):
-        """Each start/stop cycle must NOT leak a kqueue fd."""
+    Tests use mock-spy so they are deterministic and RED if kq.close() is
+    removed from the finally block (CPython GC happens to call __del__ in
+    the simple case, making lsof-count tests unreliable as regression guards).
+    """
+
+    def test_kqueue_close_called_after_normal_stop(self):
+        """kq.close() must be called deterministically when watcher stops normally.
+
+        select.kqueue is a C extension — its .close attribute is read-only, so we
+        cannot monkey-patch the method on the instance directly. Instead, wrap the
+        real kqueue object in a MagicMock that proxies control() and tracks close().
+        """
+        import select as _sel
+
         with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as f:
             path = f.name
         try:
-            before = _open_fd_count()
-            w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
-            t = _start_thread(w)
-            time.sleep(0.2)
-            w.stop()
-            t.join(timeout=2)
-            after = _open_fd_count()
-            # Allow ±2 slack for any incidental fd (e.g. lsof itself)
-            delta = after - before
-            self.assertLessEqual(delta, 2,
-                f"fd delta={delta} — kqueue fd may be leaking (W1 not fixed)")
+            close_called = threading.Event()
+
+            real_kqueue_cls = _sel.kqueue
+
+            def spy_kqueue():
+                real_kq = real_kqueue_cls()
+                mock_kq = MagicMock()
+                # Proxy control() through to the real kqueue so the watcher loop works
+                mock_kq.control.side_effect = real_kq.control
+                # Track close() and also close the real fd to avoid leaking it
+                def tracked_close():
+                    close_called.set()
+                    real_kq.close()
+                mock_kq.close.side_effect = tracked_close
+                return mock_kq
+
+            with patch("select.kqueue", side_effect=spy_kqueue):
+                w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+                t = _start_thread(w)
+                time.sleep(0.2)
+                w.stop()
+                t.join(timeout=2)
+
+            self.assertTrue(close_called.is_set(),
+                "kq.close() never called after normal stop. "
+                "W1 not fixed: deterministic close absent (matters on PyPy / ref-cycles).")
         finally:
             os.unlink(path)
 
-    def test_kqueue_fd_closed_on_file_disappear(self):
-        """Even if the watched file is deleted mid-watch, no fd should leak."""
+    def test_kqueue_fd_closed_if_kqueue_constructor_raises(self):
+        """If select.kqueue() raises, the file fd opened before it must still be closed.
+
+        This is H-2: `kq = select.kqueue()` sits outside the try whose finally
+        closes fd — if kqueue() raises (EMFILE / OSError), fd leaks.
+        Fix requires kq = None sentinel so finally always closes fd.
+        """
+        import select as _sel
+
         with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as f:
             path = f.name
         try:
-            before = _open_fd_count()
-            w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
-            t = _start_thread(w)
-            time.sleep(0.15)
+            fd_closed = threading.Event()
+            real_os_close = os.close
+
+            def spy_close(fd: int) -> None:
+                fd_closed.set()
+                real_os_close(fd)
+
+            with patch("select.kqueue", side_effect=OSError("EMFILE simulated")), \
+                 patch("os.close", side_effect=spy_close):
+                w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+                t = _start_thread(w)
+                t.join(timeout=2)
+
+            self.assertTrue(fd_closed.is_set(),
+                "os.close(fd) not called after select.kqueue() raised OSError. "
+                "H-2: fd leaks when kqueue constructor fails.")
+        finally:
             os.unlink(path)
-            time.sleep(0.15)
-            w.stop()
-            t.join(timeout=2)
-            after = _open_fd_count()
-            delta = after - before
-            self.assertLessEqual(delta, 2,
-                f"fd delta={delta} — kqueue fd leaked on file disappear (W1 not fixed)")
-        except FileNotFoundError:
-            pass  # already deleted
 
 
 # ---------------------------------------------------------------------------
@@ -107,20 +135,16 @@ class TestJsonlWatcherMissingFileKqueue(unittest.TestCase):
 
     def test_kqueue_falls_back_to_poll_when_file_missing(self):
         """Watcher thread must stay alive when file doesn't exist at start (kqueue)."""
-        path = "/tmp/_cozempic_test_nonexistent_watcher_kqueue.jsonl"
-        # Ensure it doesn't exist
-        try:
-            os.unlink(path)
-        except FileNotFoundError:
-            pass
-        w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
-        t = _start_thread(w)
-        t.join(timeout=1.0)
-        # Thread should still be alive (poll loop keeps running)
-        self.assertTrue(t.is_alive(),
-            "Watcher thread died immediately on missing file (W2 not fixed: os.open unguarded)")
-        w.stop()
-        t.join(timeout=2)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "nonexistent.jsonl")
+            w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+            t = _start_thread(w)
+            t.join(timeout=1.0)
+            # Thread should still be alive (fell back to poll loop, which returns 0 for OSError)
+            self.assertTrue(t.is_alive(),
+                "Watcher thread died immediately on missing file (W2 not fixed: os.open unguarded)")
+            w.stop()
+            t.join(timeout=2)
 
 
 class TestJsonlWatcherMissingFilePoll(unittest.TestCase):
@@ -128,18 +152,15 @@ class TestJsonlWatcherMissingFilePoll(unittest.TestCase):
 
     def test_poll_handles_missing_file_gracefully(self):
         """Poll-mode watcher must stay alive when file doesn't exist."""
-        path = "/tmp/_cozempic_test_nonexistent_watcher_poll.jsonl"
-        try:
-            os.unlink(path)
-        except FileNotFoundError:
-            pass
-        w = _make_watcher(path, lambda p, s: None, use_kqueue=False)
-        t = _start_thread(w)
-        time.sleep(0.35)
-        self.assertTrue(t.is_alive(),
-            "Poll watcher thread died on missing file")
-        w.stop()
-        t.join(timeout=2)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "nonexistent.jsonl")
+            w = _make_watcher(path, lambda p, s: None, use_kqueue=False)
+            t = _start_thread(w)
+            time.sleep(0.35)
+            self.assertTrue(t.is_alive(),
+                "Poll watcher thread died on missing file")
+            w.stop()
+            t.join(timeout=2)
 
 
 # ---------------------------------------------------------------------------
@@ -283,25 +304,28 @@ class TestJsonlWatcherCallbackErrorLoggedPoll(unittest.TestCase):
             f.write(b"a" * 100)
 
         try:
+            logged = threading.Event()
+
             def bad_cb(path: str, size: int) -> None:
                 raise RuntimeError("boom from test")
 
             w = _make_watcher(path, bad_cb, use_kqueue=False)
 
             captured = io.StringIO()
-            old_stderr = sys.stderr
-            sys.stderr = captured
+            # Patch sys.stderr in the watcher module so the background thread sees it
+            import cozempic.watcher as watcher_mod
+            old_stderr = watcher_mod.sys.stderr
+            watcher_mod.sys.stderr = captured
 
             try:
                 t = _start_thread(w)
-                # Trigger growth
                 with open(path, "ab") as f:
                     f.write(b"b" * 200)
                 time.sleep(0.6)
                 w.stop()
                 t.join(timeout=2)
             finally:
-                sys.stderr = old_stderr
+                watcher_mod.sys.stderr = old_stderr
 
             err_output = captured.getvalue()
             self.assertIn("[watcher]", err_output,
@@ -319,10 +343,7 @@ class TestJsonlWatcherCallbackErrorLoggedPoll(unittest.TestCase):
             f.write(b"a" * 100)
 
         try:
-            call_count = [0]
-
             def bad_cb(path: str, size: int) -> None:
-                call_count[0] += 1
                 raise RuntimeError("crash me")
 
             w = _make_watcher(path, bad_cb, use_kqueue=False)
@@ -354,12 +375,12 @@ class TestJsonlWatcherCallbackErrorLoggedPoll(unittest.TestCase):
             w = _make_watcher(path, bad_cb, use_kqueue=False)
 
             captured = io.StringIO()
-            old_stderr = sys.stderr
-            sys.stderr = captured
+            import cozempic.watcher as watcher_mod
+            old_stderr = watcher_mod.sys.stderr
+            watcher_mod.sys.stderr = captured
 
             try:
                 t = _start_thread(w)
-                # Trigger multiple growth events
                 for i in range(3):
                     with open(path, "ab") as f:
                         f.write(b"x" * 100)
@@ -367,14 +388,62 @@ class TestJsonlWatcherCallbackErrorLoggedPoll(unittest.TestCase):
                 w.stop()
                 t.join(timeout=2)
             finally:
-                sys.stderr = old_stderr
+                watcher_mod.sys.stderr = old_stderr
 
             err_output = captured.getvalue()
-            # Should log exactly once — count occurrences of the sentinel
             occurrences = err_output.count("[watcher]")
             self.assertEqual(occurrences, 1,
                 f"Expected exactly 1 '[watcher]' log line, got {occurrences}. "
                 "One-shot suppression (W4) not implemented.")
+        finally:
+            os.unlink(path)
+
+    def test_error_log_resets_after_successful_callback(self):
+        """_cb_error_logged must reset to False after a successful on_growth call.
+
+        Without reset, one transient error permanently silences logging for
+        an hours-long daemon. Reset on success re-enables visibility after recovery.
+        """
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"a" * 50)
+
+        try:
+            call_count = [0]
+            # First call raises, second call succeeds, third call raises again
+            def intermittent_cb(path: str, size: int) -> None:
+                n = call_count[0]
+                call_count[0] += 1
+                if n == 0 or n == 2:
+                    raise RuntimeError(f"transient error #{n}")
+                # n == 1: success — should reset _cb_error_logged
+
+            w = _make_watcher(path, intermittent_cb, use_kqueue=False)
+
+            captured = io.StringIO()
+            import cozempic.watcher as watcher_mod
+            old_stderr = watcher_mod.sys.stderr
+            watcher_mod.sys.stderr = captured
+
+            try:
+                t = _start_thread(w)
+                # Trigger 3 growth events: error, success, error
+                for i in range(3):
+                    with open(path, "ab") as f:
+                        f.write(b"x" * 100)
+                    time.sleep(0.4)
+                w.stop()
+                t.join(timeout=2)
+            finally:
+                watcher_mod.sys.stderr = old_stderr
+
+            err_output = captured.getvalue()
+            occurrences = err_output.count("[watcher]")
+            # First error logged, success resets flag, third error logged again → 2
+            self.assertEqual(occurrences, 2,
+                f"Expected 2 '[watcher]' log lines (reset on success), got {occurrences}. "
+                "M-3 not fixed: _cb_error_logged not reset after successful callback.")
         finally:
             os.unlink(path)
 
@@ -397,8 +466,9 @@ class TestJsonlWatcherCallbackErrorLoggedKqueue(unittest.TestCase):
             w = _make_watcher(path, bad_cb, use_kqueue=True)
 
             captured = io.StringIO()
-            old_stderr = sys.stderr
-            sys.stderr = captured
+            import cozempic.watcher as watcher_mod
+            old_stderr = watcher_mod.sys.stderr
+            watcher_mod.sys.stderr = captured
 
             try:
                 t = _start_thread(w)
@@ -408,7 +478,7 @@ class TestJsonlWatcherCallbackErrorLoggedKqueue(unittest.TestCase):
                 w.stop()
                 t.join(timeout=2)
             finally:
-                sys.stderr = old_stderr
+                watcher_mod.sys.stderr = old_stderr
 
             err_output = captured.getvalue()
             self.assertIn("[watcher]", err_output,
@@ -429,34 +499,41 @@ class TestJsonlWatcherInodeReplacement(unittest.TestCase):
     """W5: after os.replace (atomic prune), watcher must still detect growth."""
 
     def test_kqueue_detects_growth_after_atomic_replace(self):
-        """Growth after os.replace must fire on_growth (via poll fallback)."""
+        """Growth after os.replace must fire on_growth (via poll fallback).
+
+        The new file after os.replace is grown ABOVE the original size (800B > 500B)
+        so the callback fires unambiguously regardless of what _last_size inherited
+        from the kqueue phase.
+        """
         fired: list[int] = []
         growth_after_replace = threading.Event()
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
                                          mode="wb") as f:
             path = f.name
-            f.write(b"x" * 500)
+            f.write(b"x" * 500)  # original: 500 bytes
 
         try:
             def cb(p: str, size: int) -> None:
                 fired.append(size)
-                growth_after_replace.set()
+                if size > 500:
+                    growth_after_replace.set()
 
             w = _make_watcher(path, cb, use_kqueue=True)
+            # _last_size = 500 at __init__
             t = _start_thread(w)
             time.sleep(0.2)  # let kqueue register
 
-            # Simulate atomic prune: write smaller content to tmp, replace
+            # Simulate atomic prune: replace with 50B (shrink), then grow to 800B
             tmp_path = path + ".tmp"
             with open(tmp_path, "wb") as f:
                 f.write(b"y" * 50)
-            os.replace(tmp_path, path)
-            time.sleep(0.2)  # let DELETE/RENAME event fire
+            os.replace(tmp_path, path)   # DELETE/RENAME event → poll takeover
+            time.sleep(0.3)              # let poll takeover complete
 
-            # Now grow the new file
+            # Grow new file well above original 500B
             with open(path, "ab") as f:
-                f.write(b"z" * 300)
+                f.write(b"z" * 750)     # total ~800B > 500B original
 
             growth_after_replace.wait(timeout=3.0)
             w.stop()
@@ -464,7 +541,7 @@ class TestJsonlWatcherInodeReplacement(unittest.TestCase):
 
             self.assertTrue(
                 growth_after_replace.is_set(),
-                f"on_growth did not fire after os.replace+growth. "
+                f"on_growth did not fire with size>500 after os.replace+growth. "
                 f"fired={fired}. W5 not fixed: kqueue watches orphaned inode.",
             )
         finally:
@@ -478,15 +555,44 @@ class TestJsonlWatcherInodeReplacement(unittest.TestCase):
                 pass
 
     def test_kqueue_registers_delete_rename_fflags(self):
-        """kqueue kevent must include KQ_NOTE_DELETE and KQ_NOTE_RENAME in fflags."""
-        import select
-        # This test verifies the fix design by checking the module-level constants
-        # are accessible (belt-and-braces: validates the test environment).
-        self.assertTrue(hasattr(select, "KQ_NOTE_DELETE"),
-            "select.KQ_NOTE_DELETE not available")
-        self.assertTrue(hasattr(select, "KQ_NOTE_RENAME"),
-            "select.KQ_NOTE_RENAME not available")
-        # The actual fflags check is covered by test_kqueue_detects_growth_after_atomic_replace
+        """kqueue kevent fflags arg must include KQ_NOTE_DELETE and KQ_NOTE_RENAME.
+
+        Uses mock to intercept select.kevent construction and inspect the fflags
+        keyword argument. RED at base if KQ_NOTE_DELETE/RENAME absent from fflags.
+        """
+        import select as _sel
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 100)
+
+        try:
+            kevent_calls: list[dict] = []
+            real_kevent = _sel.kevent
+
+            def spy_kevent(*args, **kwargs):
+                kevent_calls.append(kwargs)
+                return real_kevent(*args, **kwargs)
+
+            with patch("select.kevent", side_effect=spy_kevent):
+                w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+                t = _start_thread(w)
+                time.sleep(0.2)
+                w.stop()
+                t.join(timeout=2)
+
+            self.assertTrue(kevent_calls, "select.kevent was never called (test setup issue)")
+            fflags = kevent_calls[0].get("fflags", 0)
+            self.assertTrue(fflags & _sel.KQ_NOTE_DELETE,
+                f"KQ_NOTE_DELETE not in fflags={fflags:#x}. W5 incomplete.")
+            self.assertTrue(fflags & _sel.KQ_NOTE_RENAME,
+                f"KQ_NOTE_RENAME not in fflags={fflags:#x}. W5 incomplete.")
+        finally:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -508,8 +614,6 @@ class TestJsonlWatcherImportIdiom(unittest.TestCase):
     def test_init_uses_module_constant_not_import_idiom(self):
         """JsonlWatcher._use_kqueue must be derived from _HAS_KQUEUE, not inline __import__."""
         import cozempic.watcher as watcher_mod
-        # The __import__ idiom is gone when _HAS_KQUEUE exists at module level.
-        # We verify by instantiating without a real file and checking the flag.
         with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as f:
             path = f.name
         try:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,525 @@
+"""RED tests for JsonlWatcher bugs W1-W5.
+
+W1 — kqueue fd leak (kq never closed in finally)
+W2 — FileNotFoundError crash when file missing at start
+W3 — _last_size not reset after shrink → growth blindness post-prune
+W4 — on_growth exceptions silently swallowed; must log to stderr
+W5 — kqueue watches orphaned inode after os.replace → blind post-prune (kqueue only)
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+from cozempic.watcher import JsonlWatcher
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open_fd_count() -> int:
+    """Return number of open fds for current process (macOS/Linux)."""
+    import subprocess
+    pid = os.getpid()
+    try:
+        # macOS / BSD
+        out = subprocess.check_output(["lsof", "-p", str(pid), "-n"], text=True)
+        return len(out.strip().splitlines()) - 1  # strip header
+    except Exception:
+        return -1
+
+
+def _make_watcher(path: str, callback, *, use_kqueue: bool) -> JsonlWatcher:
+    """Create a JsonlWatcher with an overridden _use_kqueue flag."""
+    w = JsonlWatcher(path, callback)
+    w._use_kqueue = use_kqueue
+    return w
+
+
+def _start_thread(watcher: JsonlWatcher) -> threading.Thread:
+    t = threading.Thread(target=watcher.start, daemon=True)
+    t.start()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# W1 — kqueue fd leak
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
+class TestJsonlWatcherFdLeak(unittest.TestCase):
+    """W1: kq.close() must be called in finally or kqueue fd leaks."""
+
+    def test_kqueue_fd_closed_after_normal_stop(self):
+        """Each start/stop cycle must NOT leak a kqueue fd."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as f:
+            path = f.name
+        try:
+            before = _open_fd_count()
+            w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+            t = _start_thread(w)
+            time.sleep(0.2)
+            w.stop()
+            t.join(timeout=2)
+            after = _open_fd_count()
+            # Allow ±2 slack for any incidental fd (e.g. lsof itself)
+            delta = after - before
+            self.assertLessEqual(delta, 2,
+                f"fd delta={delta} — kqueue fd may be leaking (W1 not fixed)")
+        finally:
+            os.unlink(path)
+
+    def test_kqueue_fd_closed_on_file_disappear(self):
+        """Even if the watched file is deleted mid-watch, no fd should leak."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as f:
+            path = f.name
+        try:
+            before = _open_fd_count()
+            w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+            t = _start_thread(w)
+            time.sleep(0.15)
+            os.unlink(path)
+            time.sleep(0.15)
+            w.stop()
+            t.join(timeout=2)
+            after = _open_fd_count()
+            delta = after - before
+            self.assertLessEqual(delta, 2,
+                f"fd delta={delta} — kqueue fd leaked on file disappear (W1 not fixed)")
+        except FileNotFoundError:
+            pass  # already deleted
+
+
+# ---------------------------------------------------------------------------
+# W2 — missing-file crash / fallback to poll
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
+class TestJsonlWatcherMissingFileKqueue(unittest.TestCase):
+    """W2 (kqueue): os.open on missing file must fall back to poll, not crash."""
+
+    def test_kqueue_falls_back_to_poll_when_file_missing(self):
+        """Watcher thread must stay alive when file doesn't exist at start (kqueue)."""
+        path = "/tmp/_cozempic_test_nonexistent_watcher_kqueue.jsonl"
+        # Ensure it doesn't exist
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        w = _make_watcher(path, lambda p, s: None, use_kqueue=True)
+        t = _start_thread(w)
+        t.join(timeout=1.0)
+        # Thread should still be alive (poll loop keeps running)
+        self.assertTrue(t.is_alive(),
+            "Watcher thread died immediately on missing file (W2 not fixed: os.open unguarded)")
+        w.stop()
+        t.join(timeout=2)
+
+
+class TestJsonlWatcherMissingFilePoll(unittest.TestCase):
+    """W2 (poll): poll path already handles missing file — regression guard."""
+
+    def test_poll_handles_missing_file_gracefully(self):
+        """Poll-mode watcher must stay alive when file doesn't exist."""
+        path = "/tmp/_cozempic_test_nonexistent_watcher_poll.jsonl"
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        w = _make_watcher(path, lambda p, s: None, use_kqueue=False)
+        t = _start_thread(w)
+        time.sleep(0.35)
+        self.assertTrue(t.is_alive(),
+            "Poll watcher thread died on missing file")
+        w.stop()
+        t.join(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# W3 — shrink-reset: _last_size must reset after file shrinks
+# ---------------------------------------------------------------------------
+
+class TestJsonlWatcherShrinkResetPoll(unittest.TestCase):
+    """W3 (poll path): growth after shrink must fire callback."""
+
+    def test_growth_detected_after_file_shrinks_poll(self):
+        """After prune shrinks file, next growth must trigger on_growth."""
+        fired: list[int] = []
+
+        def cb(path: str, size: int) -> None:
+            fired.append(size)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 1000)
+
+        try:
+            w = _make_watcher(path, cb, use_kqueue=False)
+            # _last_size captured at __init__ = 1000
+
+            t = _start_thread(w)
+            time.sleep(0.05)  # let thread enter loop
+
+            # Simulate prune: shrink file to 100 bytes
+            with open(path, "wb") as f:
+                f.write(b"y" * 100)
+            time.sleep(0.5)  # wait for poll to detect shrink
+
+            # Now grow: append 200 more bytes (total 300)
+            with open(path, "ab") as f:
+                f.write(b"z" * 200)
+            time.sleep(0.5)  # wait for growth detection
+
+            w.stop()
+            t.join(timeout=2)
+
+            self.assertTrue(
+                any(s >= 300 for s in fired),
+                f"on_growth did not fire after shrink+regrowth. "
+                f"fired={fired}. W3 not fixed: _last_size not reset on shrink.",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_shrink_alone_does_not_fire_callback(self):
+        """Shrinking the file must NOT trigger on_growth."""
+        fired: list[int] = []
+
+        def cb(path: str, size: int) -> None:
+            fired.append(size)
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 1000)
+
+        try:
+            w = _make_watcher(path, cb, use_kqueue=False)
+            t = _start_thread(w)
+            time.sleep(0.05)
+
+            # Only shrink
+            with open(path, "wb") as f:
+                f.write(b"y" * 100)
+            time.sleep(0.5)
+
+            w.stop()
+            t.join(timeout=2)
+
+            self.assertEqual(fired, [],
+                f"on_growth fired on shrink (false positive). fired={fired}")
+        finally:
+            os.unlink(path)
+
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
+class TestJsonlWatcherShrinkResetKqueue(unittest.TestCase):
+    """W3 (kqueue path): growth after shrink must fire callback."""
+
+    def test_kqueue_growth_detected_after_file_shrinks(self):
+        """After prune shrinks file, kqueue path must detect next growth."""
+        fired: list[int] = []
+        event = threading.Event()
+
+        def cb(path: str, size: int) -> None:
+            fired.append(size)
+            event.set()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 1000)
+
+        try:
+            w = _make_watcher(path, cb, use_kqueue=True)
+            t = _start_thread(w)
+            time.sleep(0.1)
+
+            # Shrink file
+            with open(path, "wb") as f:
+                f.write(b"y" * 100)
+            time.sleep(0.2)
+
+            # Grow past 100 bytes
+            with open(path, "ab") as f:
+                f.write(b"z" * 300)
+
+            event.wait(timeout=3.0)
+            w.stop()
+            t.join(timeout=2)
+
+            self.assertTrue(
+                any(s >= 300 for s in fired),
+                f"kqueue on_growth not fired after shrink+regrowth. "
+                f"fired={fired}. W3 not fixed in kqueue path.",
+            )
+        finally:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# W4 — callback errors must be logged to stderr (one-shot)
+# ---------------------------------------------------------------------------
+
+class TestJsonlWatcherCallbackErrorLoggedPoll(unittest.TestCase):
+    """W4 (poll): on_growth exception must print to stderr, not silently pass."""
+
+    def test_callback_error_logged_to_stderr_poll(self):
+        """First callback error must appear on stderr."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"a" * 100)
+
+        try:
+            def bad_cb(path: str, size: int) -> None:
+                raise RuntimeError("boom from test")
+
+            w = _make_watcher(path, bad_cb, use_kqueue=False)
+
+            captured = io.StringIO()
+            old_stderr = sys.stderr
+            sys.stderr = captured
+
+            try:
+                t = _start_thread(w)
+                # Trigger growth
+                with open(path, "ab") as f:
+                    f.write(b"b" * 200)
+                time.sleep(0.6)
+                w.stop()
+                t.join(timeout=2)
+            finally:
+                sys.stderr = old_stderr
+
+            err_output = captured.getvalue()
+            self.assertIn("[watcher]", err_output,
+                "Expected '[watcher]' in stderr. W4 not fixed: error silently swallowed.")
+            self.assertIn("on_growth error", err_output,
+                "Expected 'on_growth error' in stderr. W4 not fixed.")
+        finally:
+            os.unlink(path)
+
+    def test_callback_error_does_not_crash_watcher_poll(self):
+        """Watcher thread must survive a callback that raises."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"a" * 100)
+
+        try:
+            call_count = [0]
+
+            def bad_cb(path: str, size: int) -> None:
+                call_count[0] += 1
+                raise RuntimeError("crash me")
+
+            w = _make_watcher(path, bad_cb, use_kqueue=False)
+            t = _start_thread(w)
+            time.sleep(0.05)
+
+            with open(path, "ab") as f:
+                f.write(b"b" * 200)
+            time.sleep(0.5)
+
+            self.assertTrue(t.is_alive(),
+                "Watcher thread died after callback raised (W4 regression)")
+            w.stop()
+            t.join(timeout=2)
+        finally:
+            os.unlink(path)
+
+    def test_one_shot_error_log_not_repeated_on_each_growth(self):
+        """Repeated callback errors must only log ONCE (one-shot pattern)."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"a" * 50)
+
+        try:
+            def bad_cb(path: str, size: int) -> None:
+                raise RuntimeError("persistent failure")
+
+            w = _make_watcher(path, bad_cb, use_kqueue=False)
+
+            captured = io.StringIO()
+            old_stderr = sys.stderr
+            sys.stderr = captured
+
+            try:
+                t = _start_thread(w)
+                # Trigger multiple growth events
+                for i in range(3):
+                    with open(path, "ab") as f:
+                        f.write(b"x" * 100)
+                    time.sleep(0.4)
+                w.stop()
+                t.join(timeout=2)
+            finally:
+                sys.stderr = old_stderr
+
+            err_output = captured.getvalue()
+            # Should log exactly once — count occurrences of the sentinel
+            occurrences = err_output.count("[watcher]")
+            self.assertEqual(occurrences, 1,
+                f"Expected exactly 1 '[watcher]' log line, got {occurrences}. "
+                "One-shot suppression (W4) not implemented.")
+        finally:
+            os.unlink(path)
+
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
+class TestJsonlWatcherCallbackErrorLoggedKqueue(unittest.TestCase):
+    """W4 (kqueue): callback errors must log to stderr."""
+
+    def test_callback_error_logged_to_stderr_kqueue(self):
+        """kqueue path: first callback error must appear on stderr."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"a" * 100)
+
+        try:
+            def bad_cb(path: str, size: int) -> None:
+                raise RuntimeError("kqueue boom")
+
+            w = _make_watcher(path, bad_cb, use_kqueue=True)
+
+            captured = io.StringIO()
+            old_stderr = sys.stderr
+            sys.stderr = captured
+
+            try:
+                t = _start_thread(w)
+                with open(path, "ab") as f:
+                    f.write(b"b" * 500)
+                time.sleep(1.5)
+                w.stop()
+                t.join(timeout=2)
+            finally:
+                sys.stderr = old_stderr
+
+            err_output = captured.getvalue()
+            self.assertIn("[watcher]", err_output,
+                "Expected '[watcher]' in stderr from kqueue path. W4 not fixed.")
+        finally:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# W5 — inode replacement: kqueue must survive os.replace, fall back to poll
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue macOS only")
+class TestJsonlWatcherInodeReplacement(unittest.TestCase):
+    """W5: after os.replace (atomic prune), watcher must still detect growth."""
+
+    def test_kqueue_detects_growth_after_atomic_replace(self):
+        """Growth after os.replace must fire on_growth (via poll fallback)."""
+        fired: list[int] = []
+        growth_after_replace = threading.Event()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl",
+                                         mode="wb") as f:
+            path = f.name
+            f.write(b"x" * 500)
+
+        try:
+            def cb(p: str, size: int) -> None:
+                fired.append(size)
+                growth_after_replace.set()
+
+            w = _make_watcher(path, cb, use_kqueue=True)
+            t = _start_thread(w)
+            time.sleep(0.2)  # let kqueue register
+
+            # Simulate atomic prune: write smaller content to tmp, replace
+            tmp_path = path + ".tmp"
+            with open(tmp_path, "wb") as f:
+                f.write(b"y" * 50)
+            os.replace(tmp_path, path)
+            time.sleep(0.2)  # let DELETE/RENAME event fire
+
+            # Now grow the new file
+            with open(path, "ab") as f:
+                f.write(b"z" * 300)
+
+            growth_after_replace.wait(timeout=3.0)
+            w.stop()
+            t.join(timeout=2)
+
+            self.assertTrue(
+                growth_after_replace.is_set(),
+                f"on_growth did not fire after os.replace+growth. "
+                f"fired={fired}. W5 not fixed: kqueue watches orphaned inode.",
+            )
+        finally:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            try:
+                os.unlink(path + ".tmp")
+            except FileNotFoundError:
+                pass
+
+    def test_kqueue_registers_delete_rename_fflags(self):
+        """kqueue kevent must include KQ_NOTE_DELETE and KQ_NOTE_RENAME in fflags."""
+        import select
+        # This test verifies the fix design by checking the module-level constants
+        # are accessible (belt-and-braces: validates the test environment).
+        self.assertTrue(hasattr(select, "KQ_NOTE_DELETE"),
+            "select.KQ_NOTE_DELETE not available")
+        self.assertTrue(hasattr(select, "KQ_NOTE_RENAME"),
+            "select.KQ_NOTE_RENAME not available")
+        # The actual fflags check is covered by test_kqueue_detects_growth_after_atomic_replace
+
+
+# ---------------------------------------------------------------------------
+# W6 — __import__ idiom: module-level constant must be used
+# ---------------------------------------------------------------------------
+
+class TestJsonlWatcherImportIdiom(unittest.TestCase):
+    """W6: __import__("select") in __init__ must be replaced with module-level constant."""
+
+    def test_module_has_has_kqueue_constant(self):
+        """After fix, watcher module must expose _HAS_KQUEUE at module level."""
+        import cozempic.watcher as watcher_mod
+        self.assertTrue(
+            hasattr(watcher_mod, "_HAS_KQUEUE"),
+            "_HAS_KQUEUE module-level constant missing. W6 not fixed: "
+            "__import__('select') idiom still in __init__.",
+        )
+
+    def test_init_uses_module_constant_not_import_idiom(self):
+        """JsonlWatcher._use_kqueue must be derived from _HAS_KQUEUE, not inline __import__."""
+        import cozempic.watcher as watcher_mod
+        # The __import__ idiom is gone when _HAS_KQUEUE exists at module level.
+        # We verify by instantiating without a real file and checking the flag.
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl") as f:
+            path = f.name
+        try:
+            w = JsonlWatcher(path, lambda p, s: None)
+            expected = watcher_mod._HAS_KQUEUE  # type: ignore[attr-defined]
+            self.assertEqual(w._use_kqueue, expected,
+                "_use_kqueue does not match _HAS_KQUEUE module constant.")
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`watcher.py`'s `JsonlWatcher` powers the guard's reactive overflow recovery — it watches the session JSONL for growth (kqueue on macOS, `os.stat` polling elsewhere) and fires `OverflowRecovery.on_file_growth`. The module had no dedicated test file and several defects, two of which silently disable overflow detection after a normal prune:

1. **Blind after a prune (shrink).** Both watch paths fire only when `new_size > self._last_size`. A guard prune shrinks the JSONL (e.g. 50 MB → 5 MB), but `_last_size` keeps the old 50 MB, so growth is not reported again until the file re-exceeds its pre-prune size — exactly when overflow recovery should stay armed.
2. **Blind after a prune (kqueue inode swap).** Prunes write via `save_messages` → `os.replace`, which swaps the file's inode. The kqueue path watches the *old* fd's inode and never sees the new file's growth, and it did not register `KQ_NOTE_DELETE`/`KQ_NOTE_RENAME` to notice the swap. Independent from #1 — even with the shrink fix, the kqueue path stayed dead post-prune.
3. **Crash when the session file doesn't exist yet.** The kqueue path called `os.open(filepath, O_RDONLY)` unguarded → `FileNotFoundError` killed the watcher thread (the poll path degrades gracefully).
4. **Silent callback errors.** Both paths did `except Exception: pass`, so a persistently-failing `on_growth` callback was invisible.
5. **kqueue fd not closed deterministically.** The kqueue object was never `.close()`d; on CPython the fd is reclaimed by GC at function return, but relying on GC is fragile (PyPy / reference cycles).
6. `__import__("select")` idiom re-imported `select` on every instantiation.

## Fix

All changes are internal to `watcher.py` — `JsonlWatcher.__init__` / `start` / `stop` signatures are unchanged (the `guard.py` caller is untouched).

- **Shrink reset (both paths):** when `new_size < self._last_size`, reset the baseline so growth is detected from the pruned size. The overflow callback's own danger-threshold fast-path absorbs any sub-threshold calls.
- **kqueue inode-swap → poll fallback:** register `KQ_NOTE_DELETE | KQ_NOTE_RENAME`; on such an event, close the kqueue + fd and fall back to the polling watcher, which re-stats *by path* and is therefore immune to inode swaps. (Trade-off: after the first prune the watcher polls at 200 ms instead of kqueue's sub-ms wake — negligible for overflow detection, whose surrounding loop runs on a 30 s cadence.)
- **kqueue path never crashes the daemon thread — degrades to poll on ANY `OSError`:** `os.open` catches `OSError` (not just `FileNotFoundError`, so `PermissionError`/EACCES also fall back); `select.kqueue()` and the `kq.control()` loop are wrapped so an `OSError` (e.g. `EMFILE` under fd exhaustion) sets a fallback flag and degrades to polling instead of letting the exception kill the watcher thread silently (which would stop overflow recovery for the session).
- **Callback errors → one-shot stderr log, reset on success:** the first `on_growth` exception is logged (`[watcher] on_growth error: …`); repeats are suppressed via a private flag (reset after any successful callback, so a recovery re-arms logging) — a persistently-failing callback can't flood stderr.
- **Deterministic, leak-proof close:** `kq.close()` and `os.close(fd)` run in `finally` (no longer relying on GC), and cleanup-close `OSError`s are swallowed so a failing `kq.close()` can neither leak the fd nor skip the poll fallback.
- **Import hygiene:** `_HAS_KQUEUE` resolved once at module load.

## Tests

- New `tests/test_watcher.py` — covers shrink-then-growth (both paths), missing-file fallback, kqueue inode-replace → poll takeover, one-shot callback-error logging, and the kqueue-close/import-constant behaviors. kqueue-specific cases are `@skipUnless(sys.platform == "darwin")`; all watcher-thread tests use `daemon=True` threads with bounded `join` timeouts so the suite never hangs. (The existing poll-mode `TestJsonlWatcher` in `test_overflow.py` is left as-is.)
- **845 passing** (`pytest tests/ -q --ignore=tests/test_model_detection.py`), exit 0 — `tests/test_watcher.py` adds 20 tests, including the OSError-robustness set (PermissionError→poll, `kqueue()` EMFILE→poll, fd closed even when `kq.close()` raises, kqueue thread survives cleanup errors and still polls). The behavior-bug tests are genuinely RED at the pre-fix state — verified via broken-variant shims, not tautological. A few `test_spawn_lock` / `test_overflow` / `test_guard_hardening` race-stress tests are intermittent flakes pre-existing at the clean base `3a4cb1c` under heavy parallel load (their modules are not in this diff; they pass in isolation and sequentially).
- Zero new dependencies — pure stdlib.

## Scope

Touches only `watcher.py` and `tests/test_watcher.py`. No API change, so the `guard.py` / `overflow.py` call sites are untouched. The behavioral changes (shrink reset, inode-swap fallback) make the watcher report *more* of the growth it should already have reported — existing callers see correct callbacks, never fewer.
