### PR TITLE
fix(session): normalize project slug (_,. → -) and use strict cross-project resolution

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -746,8 +746,11 @@ def cmd_post_compact(args):
 
     cwd = args.cwd or os.getcwd()
 
-    # Try to find project dir from current session
-    sess = find_current_session(cwd)
+    # Try to find project dir from current session.
+    # strict=True: refuse to fall back to the global most-recent session (Strategy 4).
+    # If no session is found, use Path(cwd) — reads from the local project dir,
+    # which is always project-correct and never cross-contaminates.
+    sess = find_current_session(cwd, strict=True)
     project_dir = Path(sess["path"]).parent if sess else Path(cwd)
 
     content = read_team_checkpoint(project_dir)
@@ -1105,7 +1108,9 @@ def _digest_session(args):
         # consistent with how the rest of cli.py resolves the current session.
         # Routing "current" through resolve_session() would use process-detection
         # (find_current_session(strict=False)) which is a different strategy.
-        sess = find_current_session(cwd)
+        # strict=True: digest flush/inject are write operations — injecting rules
+        # into an unrelated session's JSONL is a context-contamination risk.
+        sess = find_current_session(cwd, strict=True)
         if not sess:
             # Changed to stderr: consistent with resolve_session error output
             # and all other error paths in cli.py.

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -746,14 +746,17 @@ def cmd_post_compact(args):
 
     cwd = args.cwd or os.getcwd()
 
-    # Try to find project dir from current session.
-    # strict=True: refuse to fall back to the global most-recent session (Strategy 4).
-    # If no session is found, use Path(cwd) — reads from the local project dir,
-    # which is always project-correct and never cross-contaminates.
+    # Resolve the project dir for this session.
+    # strict=True: refuse Strategy 4 (global most-recent fallback) — wrong-project
+    # sessions produce wrong-project checkpoints.
+    # On None: Path(cwd) points to the local project dir (project-correct; may have
+    # no checkpoint file → read_team_checkpoint returns None → silent, which is safe).
     sess = find_current_session(cwd, strict=True)
     project_dir = Path(sess["path"]).parent if sess else Path(cwd)
 
-    content = read_team_checkpoint(project_dir)
+    # include_global=False: the global ~/.claude/team-checkpoint.md is a cross-project
+    # read vector — it holds the last-written checkpoint regardless of project.
+    content = read_team_checkpoint(project_dir, include_global=False)
     if content:
         print(content)
 

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1109,8 +1109,8 @@ def _digest_session(args):
     if not session_arg or session_arg == "current":
         # Both absent and explicit "current" use cwd-based auto-detection,
         # consistent with how the rest of cli.py resolves the current session.
-        # Routing "current" through resolve_session() would use process-detection
-        # (find_current_session(strict=False)) which is a different strategy.
+        # Routing "current" through resolve_session() would invoke process-detection
+        # (a different strategy from slug-match) — not what we want here.
         # strict=True: digest flush/inject are write operations — injecting rules
         # into an unrelated session's JSONL is a context-contamination risk.
         sess = find_current_session(cwd, strict=True)

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -893,7 +893,6 @@ def _get_memdir(cwd: str = "") -> Path | None:
     `CLAUDE_CONFIG_DIR` (used by the `claudes` profile launcher) before
     falling back to `~/.claude`. Prevents cross-profile leaks.
     """
-    import os
     from .session import cwd_to_project_slug, get_projects_dir
     if not cwd:
         cwd = os.getcwd()

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -894,17 +894,19 @@ def _get_memdir(cwd: str = "") -> Path | None:
     falling back to `~/.claude`. Prevents cross-profile leaks.
     """
     import os
-    from .session import get_projects_dir
+    from .session import cwd_to_project_slug, get_projects_dir
     if not cwd:
         cwd = os.getcwd()
     claude_dir = get_projects_dir()
     if not claude_dir.exists():
         return None
-    slug = cwd.lstrip("/").replace("/", "-")
-    project_dir = claude_dir / f"-{slug}"
+    # cwd_to_project_slug already includes the leading '-' (from the leading '/')
+    # so no f"-{slug}" prepend needed — avoids a double leading-dash regression.
+    slug = cwd_to_project_slug(cwd)
+    project_dir = claude_dir / slug
     if not project_dir.exists():
         for d in claude_dir.iterdir():
-            if d.is_dir() and slug in d.name:
+            if d.is_dir() and d.name == slug:
                 project_dir = d
                 break
         else:

--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -905,12 +905,9 @@ def _get_memdir(cwd: str = "") -> Path | None:
     slug = cwd_to_project_slug(cwd)
     project_dir = claude_dir / slug
     if not project_dir.exists():
-        for d in claude_dir.iterdir():
-            if d.is_dir() and d.name == slug:
-                project_dir = d
-                break
-        else:
-            return None
+        # No fallback iteration: if `claude_dir / slug` does not exist, no other
+        # dir in claude_dir can have that exact name — the scan would be dead code.
+        return None
     mem_dir = project_dir / "memory"
     return mem_dir if mem_dir.exists() else None
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -219,7 +219,11 @@ def checkpoint_team(
     Returns the extracted TeamState, or None if no session found.
     """
     if session_path is None:
-        sess = find_current_session(cwd)
+        # strict=True: refuse Strategy 4 (global most-recent fallback).
+        # Writing a checkpoint from the wrong project's session is worse than
+        # writing no checkpoint at all — the latter leaves PostCompact with
+        # nothing to inject, while the former injects another project's state.
+        sess = find_current_session(cwd, strict=True)
         if not sess:
             if not quiet:
                 print("  No active session found.", file=sys.stderr)
@@ -1866,8 +1870,12 @@ def start_guard_daemon(
                 "already_running": True,
             }
     else:
-        # No session_id — detect from CWD (backward compat with old hooks)
-        sess = find_current_session(cwd)
+        # No session_id — detect from CWD (backward compat with old hooks).
+        # strict=True: if ambiguous, skip dedup rather than dedup against the
+        # wrong session's PID file (which would pass spuriously and spawn a
+        # second daemon). Behavior with strict→None matches old hook invocations
+        # that provided no session_id (dedup was simply skipped then too).
+        sess = find_current_session(cwd, strict=True)
         if sess:
             session_id = sess.get("session_id", "")
 
@@ -2449,7 +2457,11 @@ def reload_self_daemon(
     cwd = cwd or os.getcwd()
 
     if not session_id:
-        sess = find_current_session(cwd)
+        # strict=True: if Strategy 3 fails, return "could not detect session" rather
+        # than looking for the reload target under a wrong (Strategy 4) session UUID,
+        # which would fail anyway (no daemon under that UUID) and give a misleading
+        # "no daemon running" error instead of the actual "ambiguous session" cause.
+        sess = find_current_session(cwd, strict=True)
         if sess:
             session_id = sess.get("session_id", "")
 

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -208,7 +209,6 @@ def cwd_to_project_slug(cwd: str | None = None) -> str:
       /Users/foo/topstep_automation -> -Users-foo-topstep-automation
       /Users/foo/.claude            -> -Users-foo--claude  (dot → dash, double-dash)
     """
-    import os, re
     if cwd is None:
         cwd = os.getcwd()
     return re.sub(r"[^a-zA-Z0-9]", "-", cwd)

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -211,6 +211,7 @@ def cwd_to_project_slug(cwd: str | None = None) -> str:
     """
     if cwd is None:
         cwd = os.getcwd()
+    cwd = os.path.normpath(cwd)
     return re.sub(r"[^a-zA-Z0-9]", "-", cwd)
 
 

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -201,13 +201,17 @@ def find_sessions(project_filter: str | None = None) -> list[dict]:
 def cwd_to_project_slug(cwd: str | None = None) -> str:
     """Convert a working directory path to the Claude project slug format.
 
-    Claude stores projects under ~/.claude/projects/ using the path with
-    slashes replaced by dashes, e.g. /Users/foo/myproject -> -Users-foo-myproject
+    Claude stores projects under ~/.claude/projects/ replacing every
+    non-alphanumeric character with a single '-' (1:1, no run collapsing).
+
+    Examples:
+      /Users/foo/topstep_automation -> -Users-foo-topstep-automation
+      /Users/foo/.claude            -> -Users-foo--claude  (dot → dash, double-dash)
     """
-    import os
+    import os, re
     if cwd is None:
         cwd = os.getcwd()
-    return cwd.replace("/", "-")
+    return re.sub(r"[^a-zA-Z0-9]", "-", cwd)
 
 
 def project_slug_to_path(slug: str) -> str:

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -333,9 +333,11 @@ def find_current_session(
         if matched:
             return matched
 
-    # Strategy 3: CWD slug match
+    # Strategy 3: CWD slug match — exact, not substring.
+    # Substring caused prefix collisions: '-Users-x-foo' IN '-Users-x-foobar'.
+    # Worktrees get their own project dir so exact-match is always correct.
     slug = cwd_to_project_slug(cwd)
-    matching = [s for s in sessions if slug in s["project"]]
+    matching = [s for s in sessions if s["project"] == slug]
     if matching:
         return max(matching, key=lambda s: s["mtime"])
 

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -685,20 +685,33 @@ def write_team_checkpoint(state: TeamState, project_dir: Path | None = None) -> 
     return path
 
 
-def read_team_checkpoint(project_dir: Path | None = None) -> str | None:
+def read_team_checkpoint(
+    project_dir: Path | None = None,
+    include_global: bool = True,
+) -> str | None:
     """Read saved team checkpoint from disk.
 
     Returns the checkpoint content, or None if not found or empty.
     Used by PostCompact hook to re-inject team state after compaction.
     The checkpoint is written by PreCompact (before compaction), so reading
     from disk is safer than re-scanning the compacted JSONL.
+
+    Args:
+        project_dir: The resolved project directory (contains team-checkpoint.md).
+        include_global: When True (default), falls back to the shared
+            ~/.claude/team-checkpoint.md if the project-local file is absent.
+            Pass False from cmd_post_compact to prevent cross-project reads:
+            with a correctly resolved project_dir the global file is redundant,
+            and if resolution fails we prefer silence over injecting another
+            project's state.
     """
     from .session import get_claude_dir
 
     candidates = []
     if project_dir and project_dir.exists():
         candidates.append(project_dir / "team-checkpoint.md")
-    candidates.append(get_claude_dir() / "team-checkpoint.md")
+    if include_global:
+        candidates.append(get_claude_dir() / "team-checkpoint.md")
 
     for path in candidates:
         if path.exists():

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -415,3 +415,25 @@ class TestDigestSessionResolution:
         mock_rs.assert_not_called()
         assert path == Path("/y/curr.jsonl")
         assert session_id == "curr"
+
+    def test_no_session_arg_calls_find_current_with_strict_true(self):
+        """_digest_session calls find_current_session(cwd, strict=True) — not the
+        non-strict default.
+
+        digest flush/inject are write operations. Without strict=True, a user running
+        `cozempic digest flush` in a project whose Strategy-3 lookup fails would
+        silently inject rules into another project's session (Strategy-4 fallback).
+
+        Spy asserts keyword `strict=True` is passed; no behavior gap if omitted.
+        """
+        fake_sess = {"path": Path("/z/strict.jsonl"), "session_id": "strict-sess"}
+        with patch("cozempic.session.find_current_session", return_value=fake_sess) as mock_fc:
+            _digest_session(self._make_args(session=None))
+
+        mock_fc.assert_called_once()
+        _, kwargs = mock_fc.call_args
+        assert kwargs.get("strict") is True, (
+            f"find_current_session was called with strict={kwargs.get('strict')!r}, "
+            "expected strict=True. Without this, digest writes can cross-contaminate "
+            "when Strategy-3 fails and Strategy-4 picks a newer unrelated session."
+        )

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -2841,3 +2841,83 @@ class TestDebugFlagTokens(unittest.TestCase):
             with patch.dict(os.environ, {}, clear=False):
                 os.environ.pop("COZEMPIC_DEBUG", None)
                 importlib.reload(_digest_module)
+
+
+# ---------------------------------------------------------------------------
+# TestGetMemdirUnderscoreProject — Bug C (P0-D) regression
+# ---------------------------------------------------------------------------
+
+def _correct_slug_for_test(cwd: str) -> str:
+    """The CORRECT slug formula (Claude's actual normalization). Used in test fixtures
+    to create dirs matching what Claude Code actually writes to disk, independent of
+    the (currently broken) cwd_to_project_slug implementation."""
+    import re as _re
+    return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+
+
+class TestGetMemdirUnderscoreProject(unittest.TestCase):
+    """_get_memdir must route through cwd_to_project_slug and use exact-match.
+
+    Fixtures use the CORRECT slug (Claude's real normalization) to mirror what's
+    on disk. The old inline derivation in _get_memdir computes a broken slug with '_',
+    which won't match the correctly-named dir → returns None.
+    """
+
+    def test_get_memdir_resolves_underscore_project(self):
+        """_get_memdir must NOT return None for a project with '_' in path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cwd = "/Users/x/topstep_automation"
+            # Use CORRECT formula to create dir, as Claude Code actually does
+            slug = _correct_slug_for_test(cwd)    # "-Users-x-topstep-automation"
+            mem_dir = tmp_path / slug / "memory"
+            mem_dir.mkdir(parents=True)
+
+            with patch("cozempic.session.get_projects_dir", return_value=tmp_path):
+                result = _get_memdir(cwd)
+
+        self.assertIsNotNone(
+            result,
+            f"_get_memdir returned None for an underscore project (slug={slug!r}). "
+            "The inline slug derivation is still broken (keeps '_' → mismatch)."
+        )
+        self.assertEqual(result, mem_dir)
+
+    def test_get_memdir_no_prefix_collision(self):
+        """_get_memdir must resolve '-Users-x-foo', not '-Users-x-foobar'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cwd = "/Users/x/foo"
+            slug = _correct_slug_for_test(cwd)    # "-Users-x-foo"
+            mem_foo = tmp_path / slug / "memory"
+            mem_foobar = tmp_path / f"{slug}bar" / "memory"
+            mem_foo.mkdir(parents=True)
+            mem_foobar.mkdir(parents=True)
+
+            with patch("cozempic.session.get_projects_dir", return_value=tmp_path):
+                result = _get_memdir(cwd)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result, mem_foo,
+            f"Expected {mem_foo}, got {result}. Prefix collision: 'bar' suffix is leaking."
+        )
+
+    def test_get_memdir_dot_project(self):
+        """_get_memdir must handle paths containing '.' (produces double-dash slug)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cwd = "/Users/x/.claude"
+            slug = _correct_slug_for_test(cwd)    # "-Users-x--claude"
+            mem_dir = tmp_path / slug / "memory"
+            mem_dir.mkdir(parents=True)
+
+            with patch("cozempic.session.get_projects_dir", return_value=tmp_path):
+                result = _get_memdir(cwd)
+
+        self.assertIsNotNone(
+            result,
+            f"_get_memdir returned None for a dot-path project (slug={slug!r}). "
+            "Slug with double-dash is not being matched."
+        )
+        self.assertEqual(result, mem_dir)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -2884,7 +2884,14 @@ class TestGetMemdirUnderscoreProject(unittest.TestCase):
         self.assertEqual(result, mem_dir)
 
     def test_get_memdir_no_prefix_collision(self):
-        """_get_memdir must resolve '-Users-x-foo', not '-Users-x-foobar'."""
+        """_get_memdir('/Users/x/foo') must resolve '-Users-x-foo/memory', never '-Users-x-foobar/memory'.
+
+        Both project dirs and their memory subdirs exist. The old substring fallback
+        `slug in d.name` would match '-Users-x-foobar' for slug '-Users-x-foo' and
+        could return the wrong memdir depending on iteration order. The primary path
+        claude_dir/slug finds '-Users-x-foo' directly (exact), so this test
+        validates the primary-path exact lookup is in force.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             cwd = "/Users/x/foo"
@@ -2900,7 +2907,32 @@ class TestGetMemdirUnderscoreProject(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(
             result, mem_foo,
-            f"Expected {mem_foo}, got {result}. Prefix collision: 'bar' suffix is leaking."
+            f"Expected {mem_foo}, got {result}. "
+            "Prefix collision: '-foobar' dir is being returned for '-foo' slug."
+        )
+        self.assertNotEqual(
+            result, mem_foobar,
+            "Returned foobar's memdir instead of foo's — prefix collision not closed."
+        )
+
+    def test_get_memdir_returns_none_when_project_dir_absent(self):
+        """_get_memdir returns None (not a neighbor's memdir) when project dir missing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cwd = "/Users/x/foo"
+            slug = _correct_slug_for_test(cwd)    # "-Users-x-foo"
+            # Only foobar exists — foo's project dir is absent
+            mem_foobar = tmp_path / f"{slug}bar" / "memory"
+            mem_foobar.mkdir(parents=True)
+
+            with patch("cozempic.session.get_projects_dir", return_value=tmp_path):
+                result = _get_memdir(cwd)
+
+        self.assertIsNone(
+            result,
+            f"_get_memdir returned {result} instead of None when project dir absent. "
+            "The old substring fallback loop may still be matching '-Users-x-foobar' "
+            "for slug '-Users-x-foo' (substring match)."
         )
 
     def test_get_memdir_dot_project(self):

--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -124,6 +124,31 @@ class TestStrictMode:
             assert find_current_session(strict=True) is None
             assert find_current_session(strict=False) is None
 
+    def test_trailing_slash_cwd_resolves_project(self, tmp_path):
+        """cwd with trailing slash must find the project after normpath strips it.
+
+        Without normpath: slug('-Users-x-proj-') ≠ dir('-Users-x-proj') → None.
+        With normpath: '/Users/x/proj/' → '/Users/x/proj' → slug='-Users-x-proj' → found.
+
+        RED-at-base (815485d): no normpath → trailing dash mismatch → strict=True → None.
+        """
+        literal_dir = "-Users-x-proj"
+        proj = tmp_path / "projects" / literal_dir
+        session_id = "ffff6666-0000-0000-0000-000000000000"
+        _write_session(proj, session_id)
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            result = find_current_session(cwd="/Users/x/proj/", strict=True)
+
+        assert result is not None, (
+            "find_current_session(cwd='/Users/x/proj/', strict=True) returned None. "
+            "normpath is not stripping the trailing slash before slug computation."
+        )
+        assert result["session_id"] == session_id
+
 
 # ---------------------------------------------------------------------------
 # TestStrategy3ExactMatch — Bug B: substring → exact-match in Strategy 3

--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -91,6 +91,77 @@ class TestStrictMode:
             assert find_current_session(strict=False) is None
 
 
+# ---------------------------------------------------------------------------
+# TestStrategy3ExactMatch — Bug B: substring → exact-match in Strategy 3
+# ---------------------------------------------------------------------------
+
+class TestStrategy3ExactMatch:
+    """Strategy 3 must use exact-match on slug, not substring."""
+
+    def test_underscore_project_found_after_slug_fix(self, tmp_path):
+        """After P0-A+P0-B: an underscore-path project is found by Strategy 3."""
+        cwd = "/Users/x/topstep_automation"
+        from cozempic.session import cwd_to_project_slug
+        slug = cwd_to_project_slug(cwd)            # "-Users-x-topstep-automation"
+        proj = tmp_path / "projects" / slug
+        session_id = "dddd4444-0000-0000-0000-000000000000"
+        _write_session(proj, session_id)
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            result = find_current_session(cwd=cwd, strict=True)
+
+        assert result is not None, (
+            "find_current_session must find the underscore-cwd project via Strategy 3. "
+            "If this fails, the slug is still wrong or Strategy 3 still uses substring."
+        )
+        assert result["session_id"] == session_id
+
+    def test_strategy3_no_prefix_collision(self, tmp_path):
+        """Slug '-Users-x-foo' must NOT match project '-Users-x-foobar'."""
+        from cozempic.session import cwd_to_project_slug
+        cwd_foo = "/Users/x/foo"
+        slug_foo = cwd_to_project_slug(cwd_foo)    # "-Users-x-foo"
+
+        # Create BOTH project dirs
+        proj_foo = tmp_path / "projects" / slug_foo
+        proj_foobar = tmp_path / "projects" / f"{slug_foo}bar"
+        sess_foo = "eeee5555-0000-0000-0000-000000000000"
+        sess_foobar = "ffff6666-0000-0000-0000-000000000000"
+        _write_session(proj_foo, sess_foo)
+        _write_session(proj_foobar, sess_foobar)
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            result = find_current_session(cwd=cwd_foo, strict=True)
+
+        assert result is not None
+        assert result["session_id"] == sess_foo, (
+            f"Expected session for '-Users-x-foo', got {result['session_id']!r}. "
+            "Prefix collision: Strategy 3 is still using substring match."
+        )
+
+    def test_strategy4_strict_returns_none_on_no_match(self, tmp_path):
+        """strict=True blocks Strategy 4 fallback when no slug matches."""
+        proj = tmp_path / "projects" / "-some-other-path"
+        _write_session(proj, "aaaa1111-0000-0000-0000-000000000000")
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            result = find_current_session(cwd="/unrelated/underscore_path", strict=True)
+
+        assert result is None, (
+            "strict=True must return None when no slug matches. "
+            "Strategy 4 fallback is leaking through."
+        )
+
+
 class TestSlugRoundTrip:
     def test_simple_path_round_trips(self):
         from cozempic.session import cwd_to_project_slug, project_slug_to_path

--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -63,21 +63,53 @@ class TestStrictMode:
         assert result["session_id"] == session_id
 
     def test_strict_succeeds_on_cwd_slug_match(self, tmp_path):
-        """CWD slug match (Strategy 3) satisfies strict mode."""
-        cwd = "/Users/foo/myproject"
-        slug = cwd.replace("/", "-")
-        proj = tmp_path / "projects" / slug
-        session_id = "cccc3333-0000-0000-0000-000000000000"
-        _write_session(proj, session_id)
+        """CWD slug match (Strategy 3) satisfies strict mode — underscore and dot variants.
+
+        Uses cwd_to_project_slug() (imported, not hand-copied) so the test tracks
+        the canonical formula. Covers underscore and dot-path cwds, not just plain paths.
+        """
+        from cozempic.session import cwd_to_project_slug
+
+        # Underscore cwd (was the original bug trigger)
+        cwd_under = "/Users/foo/topstep_automation"
+        slug_under = cwd_to_project_slug(cwd_under)
+        proj_under = tmp_path / "projects" / slug_under
+        sess_under = "cccc3333-0000-0000-0000-000000000000"
+        _write_session(proj_under, sess_under)
 
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
         ):
-            result = find_current_session(cwd=cwd, strict=True)
+            result = find_current_session(cwd=cwd_under, strict=True)
 
-        assert result is not None
-        assert result["session_id"] == session_id
+        assert result is not None, (
+            f"Strategy 3 did not find underscore-cwd project. "
+            f"slug={slug_under!r}, project dir={proj_under.name!r}"
+        )
+        assert result["session_id"] == sess_under
+
+    def test_strict_succeeds_on_dot_cwd_slug_match(self, tmp_path):
+        """Dot-path cwd (double-dash slug) is found by Strategy 3 in strict mode."""
+        from cozempic.session import cwd_to_project_slug
+
+        cwd_dot = "/Users/foo/.claude"
+        slug_dot = cwd_to_project_slug(cwd_dot)   # "-Users-foo--claude"
+        proj_dot = tmp_path / "projects" / slug_dot
+        sess_dot = "eeee5555-0000-0000-0000-000000000000"
+        _write_session(proj_dot, sess_dot)
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            result = find_current_session(cwd=cwd_dot, strict=True)
+
+        assert result is not None, (
+            f"Strategy 3 did not find dot-path project. "
+            f"slug={slug_dot!r}, project dir={proj_dot.name!r}"
+        )
+        assert result["session_id"] == sess_dot
 
     def test_no_sessions_returns_none_regardless_of_strict(self, tmp_path):
         projects = tmp_path / "projects"
@@ -99,11 +131,21 @@ class TestStrategy3ExactMatch:
     """Strategy 3 must use exact-match on slug, not substring."""
 
     def test_underscore_project_found_after_slug_fix(self, tmp_path):
-        """After P0-A+P0-B: an underscore-path project is found by Strategy 3."""
+        """Strategy 3 must find an underscore-path project via its exact slug.
+
+        Fixture uses the LITERAL dir name '-Users-x-topstep-automation' (not derived
+        from cwd_to_project_slug) so the test is independent of the function under test.
+        strict=True disables Strategy 4 — if Strategy 3 misses, returns None (RED).
+
+        RED-at-base (815485d): broken slug '-Users-x-topstep_automation' (keeps '_')
+        ≠ literal dir '-Users-x-topstep-automation' → Strategy 3 finds 0 matches →
+        strict=True → None → assertIsNotNone FAILS.
+        """
         cwd = "/Users/x/topstep_automation"
-        from cozempic.session import cwd_to_project_slug
-        slug = cwd_to_project_slug(cwd)            # "-Users-x-topstep-automation"
-        proj = tmp_path / "projects" / slug
+        # Hardcoded literal — the dir name Claude Code actually creates on disk.
+        # NOT derived from cwd_to_project_slug() so this test is not tautological.
+        literal_dir = "-Users-x-topstep-automation"
+        proj = tmp_path / "projects" / literal_dir
         session_id = "dddd4444-0000-0000-0000-000000000000"
         _write_session(proj, session_id)
 
@@ -114,8 +156,9 @@ class TestStrategy3ExactMatch:
             result = find_current_session(cwd=cwd, strict=True)
 
         assert result is not None, (
-            "find_current_session must find the underscore-cwd project via Strategy 3. "
-            "If this fails, the slug is still wrong or Strategy 3 still uses substring."
+            "find_current_session(strict=True) returned None for underscore cwd. "
+            "The slug normalization is not replacing '_' with '-'. "
+            "Expected: computed slug '-Users-x-topstep-automation' matches literal dir."
         )
         assert result["session_id"] == session_id
 

--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -65,15 +65,15 @@ class TestStrictMode:
     def test_strict_succeeds_on_cwd_slug_match(self, tmp_path):
         """CWD slug match (Strategy 3) satisfies strict mode — underscore and dot variants.
 
-        Uses cwd_to_project_slug() (imported, not hand-copied) so the test tracks
-        the canonical formula. Covers underscore and dot-path cwds, not just plain paths.
+        Fixture dirs use HARDCODED literal names (what Claude Code actually writes to disk),
+        independent of cwd_to_project_slug. If the slug formula regresses, the computed
+        slug won't match the literal dir → strict=True returns None → test FAILS.
         """
-        from cozempic.session import cwd_to_project_slug
-
-        # Underscore cwd (was the original bug trigger)
+        # Underscore cwd (was the original bug trigger).
+        # Literal dir: '/Users/foo/topstep_automation' → '-Users-foo-topstep-automation'
         cwd_under = "/Users/foo/topstep_automation"
-        slug_under = cwd_to_project_slug(cwd_under)
-        proj_under = tmp_path / "projects" / slug_under
+        literal_dir_under = "-Users-foo-topstep-automation"
+        proj_under = tmp_path / "projects" / literal_dir_under
         sess_under = "cccc3333-0000-0000-0000-000000000000"
         _write_session(proj_under, sess_under)
 
@@ -85,17 +85,19 @@ class TestStrictMode:
 
         assert result is not None, (
             f"Strategy 3 did not find underscore-cwd project. "
-            f"slug={slug_under!r}, project dir={proj_under.name!r}"
+            f"Expected slug '-Users-foo-topstep-automation' to match literal dir."
         )
         assert result["session_id"] == sess_under
 
     def test_strict_succeeds_on_dot_cwd_slug_match(self, tmp_path):
-        """Dot-path cwd (double-dash slug) is found by Strategy 3 in strict mode."""
-        from cozempic.session import cwd_to_project_slug
+        """Dot-path cwd (double-dash slug) is found by Strategy 3 in strict mode.
 
+        Fixture dir uses HARDCODED literal name.
+        '/Users/foo/.claude' → '-Users-foo--claude' (dot→dash produces double-dash).
+        """
         cwd_dot = "/Users/foo/.claude"
-        slug_dot = cwd_to_project_slug(cwd_dot)   # "-Users-foo--claude"
-        proj_dot = tmp_path / "projects" / slug_dot
+        literal_dir_dot = "-Users-foo--claude"   # double-dash from dot replacement
+        proj_dot = tmp_path / "projects" / literal_dir_dot
         sess_dot = "eeee5555-0000-0000-0000-000000000000"
         _write_session(proj_dot, sess_dot)
 
@@ -107,7 +109,7 @@ class TestStrictMode:
 
         assert result is not None, (
             f"Strategy 3 did not find dot-path project. "
-            f"slug={slug_dot!r}, project dir={proj_dot.name!r}"
+            f"Expected slug '-Users-foo--claude' to match literal dir."
         )
         assert result["session_id"] == sess_dot
 

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2240,38 +2240,94 @@ class TestDaemonStrictNoneIsBehaviorPreserving(unittest.TestCase):
     """
 
     def test_start_guard_daemon_skips_dedup_when_session_not_detected(self):
-        """start_guard_daemon with no session_id + strict→None uses CWD-hash pid path.
+        """start_guard_daemon with strict→None uses CWD-hash pid path, by design.
 
-        Verifies that strict→None does NOT produce "already_running" (which would
-        require a session_id lookup that would use the wrong UUID). Instead the
-        function proceeds normally past the dedup branch.
+        Isolation: subprocess.Popen and DaemonSpawnClaim are BOTH mocked, so no
+        daemon can spawn and no pid file leaks into /tmp — isolation is by design,
+        not an accident of the cwd not existing.
+
+        Contract:
+        1. result is NOT already_running (wrong-UUID dedup was not executed)
+        2. DaemonSpawnClaim was instantiated with the CWD as its session_id arg
+           (confirming the CWD-hash path was taken, not the UUID path)
+        3. No pid files exist after the call (no leak by construction)
         """
+        import hashlib
+        from unittest.mock import MagicMock, call
+
+        cwd = "/Users/x/topstep_automation"
+        # Pre-compute the expected CWD-hash key used when session_id is empty
+        expected_pid_key = hashlib.md5(cwd.encode()).hexdigest()[:12]
+
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
+            # Build a context-manager mock for DaemonSpawnClaim so the with-block
+            # in start_guard_daemon succeeds without writing any real pid file.
+            mock_claim = MagicMock()
+            mock_claim.__enter__ = MagicMock(return_value=mock_claim)
+            mock_claim.__exit__ = MagicMock(return_value=False)
+            mock_claim.handed_off = False
+            MockClaimClass = MagicMock(return_value=mock_claim)
+
+            # Mock Popen so no subprocess is actually spawned.
+            mock_proc = MagicMock()
+            mock_proc.pid = 99999
+
             with (
-                # Session detection fails (strict=True → None)
                 patch("cozempic.guard.find_current_session", return_value=None),
-                # No Claude process — function returns after PID-path setup
-                patch("cozempic.guard.find_claude_pid", return_value=None),
-                # Redirect tmp root so no files leak into /tmp/cozempic_*
+                patch("cozempic.guard.find_claude_pid", return_value=42),
                 patch("cozempic.guard._guard_tmp_root", return_value=tmp_path),
-                # Prevent legacy-pidfile cleanup side effects
                 patch("cozempic.guard._cleanup_legacy_pid"),
-                # Sentinel check must return False (no reload in flight)
                 patch("cozempic.guard._reload_sentinel_active", return_value=False),
+                # DaemonSpawnClaim is imported inside the function body:
+                # `from .spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim`
+                # Patch it at the source module so the local import picks it up.
+                patch("cozempic.spawn_lock.DaemonSpawnClaim", MockClaimClass),
+                patch("subprocess.Popen", return_value=mock_proc),
             ):
                 from cozempic.guard import start_guard_daemon
-                result = start_guard_daemon(cwd="/Users/x/topstep_automation")
+                result = start_guard_daemon(cwd=cwd)
 
-        # Must not be "already_running" — that would mean a wrong-session dedup fired
-        self.assertFalse(
-            result.get("already_running"),
-            "start_guard_daemon reported already_running when no session detected. "
-            "The CWD-hash fallback path was not taken after strict→None."
-        )
-        # Must not raise — the CWD-hash branch runs without error
-        self.assertIn("started", result, f"Unexpected result shape: {result}")
+            # 1. Not already_running — wrong-UUID dedup was not fired
+            self.assertFalse(
+                result.get("already_running"),
+                "start_guard_daemon returned already_running when no session detected. "
+                "The wrong-UUID dedup path fired instead of being skipped."
+            )
+
+            # 2. DaemonSpawnClaim was called with CWD as session_id (not a UUID).
+            #    The call is DaemonSpawnClaim(session_id or cwd, pid_path).
+            #    With session_id="" → session_id or cwd = cwd.
+            spawn_calls = MockClaimClass.call_args_list
+            self.assertTrue(
+                len(spawn_calls) >= 1,
+                f"DaemonSpawnClaim was never instantiated — did start_guard_daemon exit early? result={result}"
+            )
+            claim_first_arg = spawn_calls[0][0][0]   # positional arg 0
+            self.assertEqual(
+                claim_first_arg, cwd,
+                f"DaemonSpawnClaim was called with key={claim_first_arg!r}, "
+                f"expected cwd={cwd!r}. The UUID dedup path was taken instead of CWD-hash."
+            )
+
+            # 3. The pid file in tmp_path uses the CWD-hash key (not a UUID).
+            #    The file name is cozempic_guard_<md5(cwd)[:12]>.pid.
+            import hashlib
+            expected_pid_key = hashlib.md5(cwd.encode()).hexdigest()[:12]
+            expected_pid_name = f"cozempic_guard_{expected_pid_key}.pid"
+            all_pid_files = list(tmp_path.glob("*.pid"))
+            # No UUID-keyed pid file: uuid-keyed files are named with a UUID pattern
+            import re as _re
+            uuid_pid_files = [
+                f for f in all_pid_files
+                if _re.search(r"[0-9a-f]{8}-[0-9a-f]{4}", f.name)
+            ]
+            self.assertEqual(
+                uuid_pid_files, [],
+                f"UUID-keyed pid file found: {uuid_pid_files}. "
+                "The wrong-session dedup path produced a UUID pid file instead of CWD-hash."
+            )
 
     def test_reload_self_daemon_returns_reason_when_session_not_detected(self):
         """reload_self_daemon returns 'could not detect session' when strict→None.
@@ -2389,6 +2445,107 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             b_cp.exists() and not b_cp_existed_before,
             "Project B's team-checkpoint.md was created — write-side contamination."
         )
+
+    def test_checkpoint_team_writes_correct_project_state(self):
+        """Positive write-side: checkpoint_team(cwd=A) must write A's state to A's dir.
+
+        Setup: project A (underscore, correct dir name) with a JSONL containing a
+        Task spawn (non-empty team state). Project B newer with DIFFERENT team state.
+
+        Contract: checkpoint_team(cwd=A) resolves A via Strategy 3, extracts A's
+        state, writes A's checkpoint to A's dir. B's checkpoint is NOT written.
+
+        RED-at-base (815485d): broken slug → Strategy 3 misses A → Strategy 4 picks
+        B's session (newer) → extracts B's state → writes to B's project dir (NOT A's)
+        → A's checkpoint file never created → assertIsNotNone FAILS.
+        """
+        import json
+        import re as _re
+        import time
+        from cozempic.guard import checkpoint_team
+
+        def _correct_slug(cwd: str) -> str:
+            return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+
+        # Minimal JSONL that produces a non-empty TeamState.
+        # A 'Task' tool_use block in an assistant message → 1 subagent detected.
+        def _team_jsonl(label: str) -> str:
+            task_msg = json.dumps({
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": f"tool-{label}-001",
+                        "name": "Task",
+                        "input": {
+                            "subagent_type": "general-purpose",
+                            "prompt": f"do work for {label}",
+                            "description": f"{label}-agent",
+                        },
+                    }],
+                }
+            })
+            return task_msg + "\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            # Project A: underscore cwd — correct dir name
+            cwd_a = "/Users/x/topstep_automation"
+            slug_a = _correct_slug(cwd_a)        # -Users-x-topstep-automation
+            proj_a = tmp_path / slug_a
+            proj_a.mkdir(parents=True)
+            sess_a_id = "aaaa1111-0000-0000-0000-aaa000000001"
+            (proj_a / f"{sess_a_id}.jsonl").write_text(
+                _team_jsonl("TOPSTEP"), encoding="utf-8"
+            )
+
+            time.sleep(0.02)  # ensure B is strictly newer
+
+            # Project B: newer, no underscore — DIFFERENT team state
+            slug_b = _correct_slug("/Users/x/fanugugc")   # -Users-x-fanugugc
+            proj_b = tmp_path / slug_b
+            proj_b.mkdir(parents=True)
+            sess_b_id = "bbbb2222-0000-0000-0000-bbb000000002"
+            (proj_b / f"{sess_b_id}.jsonl").write_text(
+                _team_jsonl("FANNU"), encoding="utf-8"
+            )
+
+            with (
+                patch("cozempic.session.get_projects_dir", return_value=tmp_path),
+                patch("cozempic.session._session_id_from_process", return_value=None),
+            ):
+                result = checkpoint_team(cwd=cwd_a, quiet=True)
+
+            # After fix: Strategy 3 finds A's session → extracts TOPSTEP state → writes to A's dir
+            self.assertIsNotNone(
+                result,
+                "checkpoint_team returned None — Strategy 3 did not find project A's session. "
+                "At base: broken slug misses A → Strategy 4 picks B → writes to B → A has no checkpoint."
+            )
+            # A's checkpoint must exist and contain TOPSTEP (not FANNU)
+            a_cp = proj_a / "team-checkpoint.md"
+            self.assertTrue(
+                a_cp.exists(),
+                f"Project A's team-checkpoint.md was not written. "
+                f"proj_a contents: {[p.name for p in proj_a.iterdir()]}"
+            )
+            a_cp_text = a_cp.read_text(encoding="utf-8")
+            self.assertIn(
+                "TOPSTEP", a_cp_text,
+                f"Project A's checkpoint does not contain 'TOPSTEP'. Contents:\n{a_cp_text[:200]}"
+            )
+            self.assertNotIn(
+                "FANNU", a_cp_text,
+                f"Project A's checkpoint contains 'FANNU' — cross-project state injected.\n{a_cp_text[:200]}"
+            )
+            # B's checkpoint must NOT have been written by this call
+            b_cp = proj_b / "team-checkpoint.md"
+            self.assertFalse(
+                b_cp.exists(),
+                "Project B's team-checkpoint.md was written by checkpoint_team(cwd=A). "
+                "write-side contamination: B's session was used."
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2252,12 +2252,9 @@ class TestDaemonStrictNoneIsBehaviorPreserving(unittest.TestCase):
            (confirming the CWD-hash path was taken, not the UUID path)
         3. No pid files exist after the call (no leak by construction)
         """
-        import hashlib
-        from unittest.mock import MagicMock, call
+        from unittest.mock import MagicMock
 
         cwd = "/Users/x/topstep_automation"
-        # Pre-compute the expected CWD-hash key used when session_id is empty
-        expected_pid_key = hashlib.md5(cwd.encode()).hexdigest()[:12]
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -2284,7 +2281,7 @@ class TestDaemonStrictNoneIsBehaviorPreserving(unittest.TestCase):
                 # `from .spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim`
                 # Patch it at the source module so the local import picks it up.
                 patch("cozempic.spawn_lock.DaemonSpawnClaim", MockClaimClass),
-                patch("subprocess.Popen", return_value=mock_proc),
+                patch("cozempic.guard.subprocess.Popen", return_value=mock_proc),
             ):
                 from cozempic.guard import start_guard_daemon
                 result = start_guard_daemon(cwd=cwd)
@@ -2311,17 +2308,13 @@ class TestDaemonStrictNoneIsBehaviorPreserving(unittest.TestCase):
                 f"expected cwd={cwd!r}. The UUID dedup path was taken instead of CWD-hash."
             )
 
-            # 3. The pid file in tmp_path uses the CWD-hash key (not a UUID).
-            #    The file name is cozempic_guard_<md5(cwd)[:12]>.pid.
-            import hashlib
-            expected_pid_key = hashlib.md5(cwd.encode()).hexdigest()[:12]
-            expected_pid_name = f"cozempic_guard_{expected_pid_key}.pid"
+            # 3. No UUID-keyed pid file in tmp — uuid-keyed files are named with a UUID
+            #    pattern (cozempic_guard_<uuid>.pid); their presence would indicate the
+            #    wrong-session dedup path ran instead of the CWD-hash path.
             all_pid_files = list(tmp_path.glob("*.pid"))
-            # No UUID-keyed pid file: uuid-keyed files are named with a UUID pattern
-            import re as _re
             uuid_pid_files = [
                 f for f in all_pid_files
-                if _re.search(r"[0-9a-f]{8}-[0-9a-f]{4}", f.name)
+                if re.search(r"[0-9a-f]{8}-[0-9a-f]{4}", f.name)
             ]
             self.assertEqual(
                 uuid_pid_files, [],

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2222,5 +2222,78 @@ class TestPolishV2_StartGuardDaemonValidatesSessionId(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# TestCheckpointTeamWriteSideIsolation — Bug P0-E regression
+# ---------------------------------------------------------------------------
+class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
+    """checkpoint_team must NOT write another project's state when no session_path given.
+
+    The write-side of the cross-project contamination chain:
+      1. PreCompact hook calls cmd_checkpoint → checkpoint_team(cwd=cwd_a)
+      2. Old code: non-strict find_current_session → Strategy 4 → returns newer project B's session
+      3. Checkpoint extracted from B's JSONL and WRITTEN into project A's dir
+      4. PostCompact reads A's dir → finds B's team state → contamination
+
+    After fix (strict=True): checkpoint_team returns None when Strategy 3 fails,
+    so no wrong checkpoint is written.
+    """
+
+    def test_checkpoint_team_does_not_write_wrong_project_when_other_is_newer(self):
+        """strict=True: checkpoint_team returns None, doesn't write fanugugc's state."""
+        import time
+        from cozempic.session import cwd_to_project_slug
+        from cozempic.guard import checkpoint_team
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            # Project A — underscore path (slug mismatch under old code)
+            cwd_a = "/Users/x/topstep_automation"
+            slug_a = cwd_to_project_slug(cwd_a)
+            proj_a = tmp_path / slug_a
+            sess_a_id = "aaaa1111-0000-0000-0000-100000000001"
+            sess_a_file = proj_a / f"{sess_a_id}.jsonl"
+            proj_a.mkdir(parents=True)
+            sess_a_file.write_text(
+                '{"type":"user","message":{"role":"user","content":"hi"}}\n',
+                encoding="utf-8",
+            )
+
+            time.sleep(0.01)
+
+            # Project B — newer, no underscore (old Strategy 4 would return this)
+            slug_b = cwd_to_project_slug("/Users/x/fanugugc")
+            proj_b = tmp_path / slug_b
+            sess_b_id = "bbbb2222-0000-0000-0000-200000000002"
+            sess_b_file = proj_b / f"{sess_b_id}.jsonl"
+            proj_b.mkdir(parents=True)
+            sess_b_file.write_text(
+                '{"type":"user","message":{"role":"user","content":"hi"}}\n',
+                encoding="utf-8",
+            )
+
+            with (
+                patch("cozempic.session.get_projects_dir", return_value=tmp_path),
+                patch("cozempic.session._session_id_from_process", return_value=None),
+                patch("cozempic.guard.find_current_session",
+                      wraps=lambda cwd=None, **kw: __import__(
+                          "cozempic.session", fromlist=["find_current_session"]
+                      ).find_current_session(cwd, **kw)),
+            ):
+                result = checkpoint_team(cwd=cwd_a)
+
+            # With strict=True (fix), Strategy 3 can't match the slug (pre-fix),
+            # so checkpoint_team returns None — no write. After the full fix
+            # (P0-A + P0-E), Strategy 3 finds the right session OR strict blocks.
+            # The key invariant: result must NOT be project B's state.
+            if result is not None:
+                # If we got a result, it must belong to project A, not B
+                self.assertNotEqual(
+                    str(result),
+                    str(sess_b_file),
+                    "checkpoint_team returned project B's session — write-side contamination."
+                )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2226,73 +2226,95 @@ class TestPolishV2_StartGuardDaemonValidatesSessionId(unittest.TestCase):
 # TestCheckpointTeamWriteSideIsolation — Bug P0-E regression
 # ---------------------------------------------------------------------------
 class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
-    """checkpoint_team must NOT write another project's state when no session_path given.
+    """checkpoint_team must return None and not write when strict session resolution fails.
 
     The write-side of the cross-project contamination chain:
       1. PreCompact hook calls cmd_checkpoint → checkpoint_team(cwd=cwd_a)
       2. Old code: non-strict find_current_session → Strategy 4 → returns newer project B's session
-      3. Checkpoint extracted from B's JSONL and WRITTEN into project A's dir
+      3. Checkpoint extracted from B's JSONL → WRITTEN into project A's project dir
       4. PostCompact reads A's dir → finds B's team state → contamination
 
-    After fix (strict=True): checkpoint_team returns None when Strategy 3 fails,
-    so no wrong checkpoint is written.
+    After fix (strict=True): checkpoint_team returns None when Strategy 3 can't match,
+    and project B's checkpoint file is not created or modified.
+
+    RED-at-base proof (815485d): non-strict → Strategy 4 returns B's session →
+    extract_team_state([]) returns empty TeamState → checkpoint_team returns the empty
+    state (not None) → `assertIsNone` FAILS.
     """
 
-    def test_checkpoint_team_does_not_write_wrong_project_when_other_is_newer(self):
-        """strict=True: checkpoint_team returns None, doesn't write fanugugc's state."""
+    def test_checkpoint_team_strict_refuses_wrong_project(self):
+        """With cwd=topstep_automation: checkpoint_team must return None.
+
+        Setup: project A (underscore, correct dir name) has no session.
+               project B (newer, no underscore) has a session.
+               _session_id_from_process → None (no process detection).
+
+        At base (broken slug + non-strict):
+          Strategy 3 computes broken slug '-Users-x-topstep_automation' ≠ any dir
+          → 0 matches → Strategy 4 picks B's session (newer)
+          → extract_team_state returns empty TeamState → checkpoint_team returns it
+          → result is not None → assertIsNone FAILS → RED.
+
+        After fix (P0-A + P0-E):
+          Project A has no session file → Strategy 3 matches A's dir but finds
+          no JSONL → sessions list empty → strict returns None → checkpoint_team
+          returns None → GREEN.
+          OR: strict=True on broken slug → None → GREEN.
+
+        Either way the invariant holds: with only B's session present, B's
+        checkpoint must NOT be written and result must be None.
+        """
+        import re as _re
         import time
-        from cozempic.session import cwd_to_project_slug
         from cozempic.guard import checkpoint_team
+
+        def _correct_slug(cwd: str) -> str:
+            return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
-            # Project A — underscore path (slug mismatch under old code)
+            # Project A: underscore path — correct dir name (Claude's real format).
+            # No session file: if Strategy 3 correctly finds this dir, find_sessions
+            # finds no JSONL here → sessions list is empty for this project.
             cwd_a = "/Users/x/topstep_automation"
-            slug_a = cwd_to_project_slug(cwd_a)
+            slug_a = _correct_slug(cwd_a)      # -Users-x-topstep-automation
             proj_a = tmp_path / slug_a
-            sess_a_id = "aaaa1111-0000-0000-0000-100000000001"
-            sess_a_file = proj_a / f"{sess_a_id}.jsonl"
             proj_a.mkdir(parents=True)
-            sess_a_file.write_text(
-                '{"type":"user","message":{"role":"user","content":"hi"}}\n',
-                encoding="utf-8",
-            )
+            # No .jsonl file in proj_a — so project A has no sessions.
 
-            time.sleep(0.01)
+            time.sleep(0.02)  # ensure B is strictly newer
 
-            # Project B — newer, no underscore (old Strategy 4 would return this)
-            slug_b = cwd_to_project_slug("/Users/x/fanugugc")
+            # Project B: newer, no underscore — has a session (Strategy 4 returns this at base)
+            slug_b = _correct_slug("/Users/x/fanugugc")   # -Users-x-fanugugc
             proj_b = tmp_path / slug_b
-            sess_b_id = "bbbb2222-0000-0000-0000-200000000002"
-            sess_b_file = proj_b / f"{sess_b_id}.jsonl"
             proj_b.mkdir(parents=True)
-            sess_b_file.write_text(
-                '{"type":"user","message":{"role":"user","content":"hi"}}\n',
-                encoding="utf-8",
+            sess_b_id = "bbbb2222-0000-0000-0000-200000000002"
+            (proj_b / f"{sess_b_id}.jsonl").write_text(
+                '{"role":"user","content":"hi"}\n', encoding="utf-8"
             )
+            b_cp = proj_b / "team-checkpoint.md"
+            b_cp_existed_before = b_cp.exists()
 
             with (
                 patch("cozempic.session.get_projects_dir", return_value=tmp_path),
                 patch("cozempic.session._session_id_from_process", return_value=None),
-                patch("cozempic.guard.find_current_session",
-                      wraps=lambda cwd=None, **kw: __import__(
-                          "cozempic.session", fromlist=["find_current_session"]
-                      ).find_current_session(cwd, **kw)),
             ):
-                result = checkpoint_team(cwd=cwd_a)
+                result = checkpoint_team(cwd=cwd_a, quiet=True)
 
-            # With strict=True (fix), Strategy 3 can't match the slug (pre-fix),
-            # so checkpoint_team returns None — no write. After the full fix
-            # (P0-A + P0-E), Strategy 3 finds the right session OR strict blocks.
-            # The key invariant: result must NOT be project B's state.
-            if result is not None:
-                # If we got a result, it must belong to project A, not B
-                self.assertNotEqual(
-                    str(result),
-                    str(sess_b_file),
-                    "checkpoint_team returned project B's session — write-side contamination."
-                )
+        # Core invariant: only B's session is present; checkpoint_team called with
+        # cwd=A must return None (never use B's session).
+        self.assertIsNone(
+            result,
+            f"checkpoint_team(cwd=topstep_automation) returned {result!r} instead of None. "
+            "The cross-project session fallback is not being blocked. "
+            "At base: Strategy 4 returns B's session → empty TeamState returned (not None)."
+        )
+        # Belt-and-suspenders: B's checkpoint must be untouched
+        self.assertFalse(
+            b_cp.exists() and not b_cp_existed_before,
+            "Project B's team-checkpoint.md was created — write-side contamination."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2425,19 +2425,21 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             ):
                 result = checkpoint_team(cwd=cwd_a, quiet=True)
 
-        # Core invariant: only B's session is present; checkpoint_team called with
-        # cwd=A must return None (never use B's session).
-        self.assertIsNone(
-            result,
-            f"checkpoint_team(cwd=topstep_automation) returned {result!r} instead of None. "
-            "The cross-project session fallback is not being blocked. "
-            "At base: Strategy 4 returns B's session → empty TeamState returned (not None)."
-        )
-        # Belt-and-suspenders: B's checkpoint must be untouched
-        self.assertFalse(
-            b_cp.exists() and not b_cp_existed_before,
-            "Project B's team-checkpoint.md was created — write-side contamination."
-        )
+            # Core invariant: only B's session is present; checkpoint_team called with
+            # cwd=A must return None (never use B's session).
+            self.assertIsNone(
+                result,
+                f"checkpoint_team(cwd=topstep_automation) returned {result!r} instead of None. "
+                "The cross-project session fallback is not being blocked. "
+                "At base: Strategy 4 returns B's session → empty TeamState returned (not None)."
+            )
+            # Belt-and-suspenders: B's checkpoint must be untouched.
+            # Both assertions are inside the `with tempfile.TemporaryDirectory()` block
+            # so b_cp.exists() queries the live tmpdir (not a deleted one).
+            self.assertFalse(
+                b_cp.exists() and not b_cp_existed_before,
+                "Project B's team-checkpoint.md was created — write-side contamination."
+            )
 
     def test_checkpoint_team_writes_correct_project_state(self):
         """Positive write-side: checkpoint_team(cwd=A) must write A's state to A's dir.

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2221,6 +2221,80 @@ class TestPolishV2_StartGuardDaemonValidatesSessionId(unittest.TestCase):
             f"{[str(o) for o in bash_orphans]}",
         )
 
+# ---------------------------------------------------------------------------
+# TestDaemonStrictNoneIsBehaviorPreserving — guard.py:1878/2464
+# ---------------------------------------------------------------------------
+class TestDaemonStrictNoneIsBehaviorPreserving(unittest.TestCase):
+    """strict→None in daemon paths must degrade gracefully (no new failure modes).
+
+    guard.py:1878 (start_guard_daemon): when find_current_session(cwd, strict=True)
+    returns None, session_id stays "". The function falls through to the CWD-hash
+    PID path — same behavior as calling with no session_id at all (old hook compat).
+
+    guard.py:2464 (reload_self_daemon): when find_current_session returns None,
+    session_id stays "" → returns {"reloaded": False, "reason": "could not detect session"}.
+    Same outcome as the pre-existing `if not session_id: return ...` guard.
+
+    Neither path spawns a subprocess in these tests — we patch find_current_session
+    and _guard_tmp_root to keep tests fast and isolated.
+    """
+
+    def test_start_guard_daemon_skips_dedup_when_session_not_detected(self):
+        """start_guard_daemon with no session_id + strict→None uses CWD-hash pid path.
+
+        Verifies that strict→None does NOT produce "already_running" (which would
+        require a session_id lookup that would use the wrong UUID). Instead the
+        function proceeds normally past the dedup branch.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            with (
+                # Session detection fails (strict=True → None)
+                patch("cozempic.guard.find_current_session", return_value=None),
+                # No Claude process — function returns after PID-path setup
+                patch("cozempic.guard.find_claude_pid", return_value=None),
+                # Redirect tmp root so no files leak into /tmp/cozempic_*
+                patch("cozempic.guard._guard_tmp_root", return_value=tmp_path),
+                # Prevent legacy-pidfile cleanup side effects
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                # Sentinel check must return False (no reload in flight)
+                patch("cozempic.guard._reload_sentinel_active", return_value=False),
+            ):
+                from cozempic.guard import start_guard_daemon
+                result = start_guard_daemon(cwd="/Users/x/topstep_automation")
+
+        # Must not be "already_running" — that would mean a wrong-session dedup fired
+        self.assertFalse(
+            result.get("already_running"),
+            "start_guard_daemon reported already_running when no session detected. "
+            "The CWD-hash fallback path was not taken after strict→None."
+        )
+        # Must not raise — the CWD-hash branch runs without error
+        self.assertIn("started", result, f"Unexpected result shape: {result}")
+
+    def test_reload_self_daemon_returns_reason_when_session_not_detected(self):
+        """reload_self_daemon returns 'could not detect session' when strict→None.
+
+        After fix: returns 'could not detect session' — clearer than pre-fix behavior
+        which could return 'no daemon running for session' with a wrong UUID.
+        The behavior-preserving claim: no reload attempt, no signal sent.
+        """
+        from cozempic.guard import reload_self_daemon
+
+        with patch("cozempic.guard.find_current_session", return_value=None):
+            result = reload_self_daemon(
+                cwd="/Users/x/topstep_automation",
+                session_id="",   # no session_id provided
+            )
+
+        self.assertFalse(result.get("reloaded"), f"Expected reloaded=False, got {result}")
+        self.assertEqual(
+            result.get("reason"), "could not detect session",
+            f"Expected reason='could not detect session', got {result.get('reason')!r}. "
+            "strict→None must produce this reason, not 'no daemon running for session'."
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestCheckpointTeamWriteSideIsolation — Bug P0-E regression

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -2,15 +2,122 @@
 
 from __future__ import annotations
 
+import argparse
 import io
+import json
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 from cozempic.team import read_team_checkpoint
 from cozempic.init import COZEMPIC_HOOKS
+
+
+def _write_session_file(proj_dir: Path, session_id: str, content: str = "") -> Path:
+    """Helper: write a minimal JSONL session file into proj_dir."""
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    p = proj_dir / f"{session_id}.jsonl"
+    p.write_text(
+        content or json.dumps({"role": "user", "content": "hi"}) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# TestCmdPostCompactCrossProjectIsolation — Bug C regression
+# ---------------------------------------------------------------------------
+
+class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
+    """cmd_post_compact must NEVER inject another project's checkpoint."""
+
+    def _run_post_compact(self, cwd: str) -> str:
+        from cozempic.cli import cmd_post_compact
+        args = argparse.Namespace(cwd=cwd)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            cmd_post_compact(args)
+        finally:
+            sys.stdout = old_stdout
+        return captured.getvalue()
+
+    def test_does_not_return_other_projects_checkpoint_when_other_is_newer(self, tmp_path=None):
+        """Core bug: Strategy 4 picks a newer OTHER project's session → wrong checkpoint.
+
+        Fixture uses the CORRECT dir names (as Claude Code actually creates them, with dashes
+        for underscores). Old code computes broken slug with '_', so Strategy 3 misses project A
+        and Strategy 4 returns project B's (newer) session → contamination.
+        """
+        import tempfile
+        import re as _re
+        # Use explicit tmp_path if provided by pytest, otherwise create our own
+        if tmp_path is None:
+            tmp_path = Path(tempfile.mkdtemp())
+
+        # The CORRECT (fixed) slug formula — what Claude Code actually stores on disk
+        def _correct_slug(cwd: str) -> str:
+            return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+
+        # Project A: topstep_automation — dir name uses dashes (Claude's real format)
+        cwd_a = "/Users/x/topstep_automation"
+        slug_a_correct = _correct_slug(cwd_a)   # "-Users-x-topstep-automation"
+        proj_a = tmp_path / "projects" / slug_a_correct
+        _write_session_file(proj_a, "aaaa1111-0000-0000-0000-000000000001")
+        # Write a checkpoint for project A
+        (proj_a / "team-checkpoint.md").write_text("TOPSTEP", encoding="utf-8")
+
+        # Small sleep ensures project B mtime is strictly newer
+        time.sleep(0.01)
+
+        # Project B: fanugugc (no underscore → still returned by Strategy 4 when A is missed)
+        cwd_b = "/Users/x/fanugugc"
+        slug_b_correct = _correct_slug(cwd_b)   # "-Users-x-fanugugc"
+        proj_b = tmp_path / "projects" / slug_b_correct
+        _write_session_file(proj_b, "bbbb2222-0000-0000-0000-000000000002")
+        # Give project B a team-checkpoint too (the one that must NOT appear)
+        (proj_b / "team-checkpoint.md").write_text("FANNU", encoding="utf-8")
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            output = self._run_post_compact(cwd=cwd_a)
+
+        self.assertNotIn(
+            "FANNU", output,
+            "cmd_post_compact must NOT output fanugugc's checkpoint when cwd=topstep_automation. "
+            "Cross-project contamination detected."
+        )
+        # Output must be either the correct checkpoint or empty (strict→None→Path(cwd) fallback)
+        if output.strip():
+            self.assertIn(
+                "TOPSTEP", output,
+                "If cmd_post_compact outputs anything, it must be the current project's checkpoint."
+            )
+
+    def test_falls_back_safely_when_no_session_found(self):
+        """strict→None→Path(cwd) fallback must not crash and produce no output."""
+        import tempfile
+        tmp_path = Path(tempfile.mkdtemp())
+        # Empty projects dir — no sessions at all
+        (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
+
+        cwd = str(tmp_path / "my_project")
+        Path(cwd).mkdir(exist_ok=True)
+        # No team-checkpoint.md in cwd
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+        ):
+            output = self._run_post_compact(cwd=cwd)
+
+        self.assertEqual(output, "", "cmd_post_compact must be silent when no checkpoint exists.")
 
 
 class TestReadTeamCheckpoint(unittest.TestCase):

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -119,6 +119,49 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
         self.assertEqual(output, "", "cmd_post_compact must be silent when no checkpoint exists.")
 
+    def test_global_checkpoint_not_read_when_local_absent(self):
+        """Global ~/.claude/team-checkpoint.md must NOT be returned by cmd_post_compact.
+
+        The global file is a cross-project read vector: it holds the most-recently
+        written checkpoint regardless of project. When the resolved project_dir has no
+        local checkpoint, cmd_post_compact must be silent (not inject the global file).
+
+        This tests the include_global=False guard added to the read_team_checkpoint call.
+        """
+        import tempfile
+        from cozempic.session import get_claude_dir
+
+        tmp_path = Path(tempfile.mkdtemp())
+        (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
+
+        cwd = str(tmp_path / "my_project")
+        Path(cwd).mkdir(exist_ok=True)
+        # No local team-checkpoint.md in cwd
+
+        # Place a checkpoint in the global ~/.claude/ location (simulated)
+        global_cp = tmp_path / "claude_dir" / "team-checkpoint.md"
+        global_cp.parent.mkdir(parents=True, exist_ok=True)
+        global_cp.write_text("GLOBAL_CHECKPOINT", encoding="utf-8")
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+            # get_claude_dir is imported inside read_team_checkpoint via `from .session import`
+            # so we patch it at the source module level.
+            patch("cozempic.session.get_claude_dir", return_value=tmp_path / "claude_dir"),
+        ):
+            output = self._run_post_compact(cwd=cwd)
+
+        self.assertNotIn(
+            "GLOBAL_CHECKPOINT", output,
+            "cmd_post_compact must not inject the global team-checkpoint.md. "
+            "include_global=False is not being passed to read_team_checkpoint."
+        )
+        self.assertEqual(
+            output, "",
+            "cmd_post_compact must be silent when only global checkpoint present."
+        )
+
 
 class TestReadTeamCheckpoint(unittest.TestCase):
 

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -202,9 +202,14 @@ class TestReadTeamCheckpoint(unittest.TestCase):
             self.assertEqual(result, "# Project Team")
 
     def test_falls_back_to_none_when_dir_missing(self):
-        result = read_team_checkpoint(Path("/nonexistent/dir"))
-        # Should not raise, just return None (falls through to global check)
-        # Global checkpoint may or may not exist, but shouldn't crash
+        # include_global=False: prevents this test from accidentally passing by
+        # reading the developer's real ~/.claude/team-checkpoint.md when present.
+        result = read_team_checkpoint(Path("/nonexistent/dir"), include_global=False)
+        self.assertIsNone(
+            result,
+            "read_team_checkpoint must return None when project_dir doesn't exist "
+            "and include_global=False."
+        )
 
 
 class TestCmdPostCompact(unittest.TestCase):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from types import SimpleNamespace
 
 from pathlib import Path
@@ -10,11 +11,88 @@ from unittest.mock import patch
 
 from cozempic.session import (
     MAX_LINE_BYTES,
+    cwd_to_project_slug,
     find_claude_pid,
     get_claude_dir,
     get_claude_json_path,
     load_messages,
 )
+
+
+# ---------------------------------------------------------------------------
+# TestCwdToProjectSlug — slug parity with real ~/.claude/projects/ dir names
+# ---------------------------------------------------------------------------
+
+class TestCwdToProjectSlug:
+    """Table-driven slug parity. Every non-alphanumeric char → '-', 1:1."""
+
+    def test_underscore_maps_to_dash(self):
+        """Bug A regression: '_' must become '-', not stay '_'."""
+        result = cwd_to_project_slug("/Users/x/topstep_automation")
+        assert result == "-Users-x-topstep-automation", (
+            f"Expected '-Users-x-topstep-automation', got {result!r}. "
+            "Underscore is not being replaced."
+        )
+
+    def test_dot_maps_to_double_dash(self):
+        """'.claude' produces double-dash because '.' → '-' and leading '/' → '-'."""
+        result = cwd_to_project_slug("/Users/x/.claude")
+        assert result == "-Users-x--claude", (
+            f"Expected '-Users-x--claude', got {result!r}. "
+            "Dot is not being replaced."
+        )
+
+    def test_worktree_dotclaude_in_path(self):
+        """Worktrees whose path contains '.claude' must produce correct slug."""
+        result = cwd_to_project_slug("/Users/x/cozempic/.claude/worktrees/fix-slug")
+        assert result == "-Users-x-cozempic--claude-worktrees-fix-slug", (
+            f"Got {result!r}. Dot in path component not replaced."
+        )
+
+    def test_plain_path_identity(self):
+        """Plain paths (no underscores or dots) must be unchanged by fix."""
+        result = cwd_to_project_slug("/Users/x/myproject")
+        assert result == "-Users-x-myproject"
+
+    def test_space_maps_to_dash(self):
+        """Spaces must become dashes (Claude normalises all non-alnum chars)."""
+        result = cwd_to_project_slug("/Users/x/my project")
+        assert result == "-Users-x-my-project", (
+            f"Got {result!r}. Space not replaced."
+        )
+
+    def test_digits_preserved(self):
+        """Digits are alphanumeric and must not be replaced."""
+        result = cwd_to_project_slug("/Users/x/project123")
+        assert result == "-Users-x-project123"
+
+    def test_existing_hyphens_preserved(self):
+        """Already-hyphenated paths must remain hyphenated (idempotent on '-')."""
+        result = cwd_to_project_slug("/Users/x/my-project")
+        assert result == "-Users-x-my-project"
+
+    def test_trailing_slash_produces_trailing_dash(self):
+        """With NO rstrip, a trailing '/' becomes a trailing '-'."""
+        result = cwd_to_project_slug("/Users/x/myproject/")
+        # Lead decision: NO rstrip — trailing slash → trailing dash
+        assert result == "-Users-x-myproject-", (
+            f"Got {result!r}. Expected trailing '-' from trailing '/'."
+        )
+
+    def test_none_cwd_uses_os_getcwd(self):
+        """None cwd delegates to os.getcwd()."""
+        with patch("cozempic.session.os.getcwd", return_value="/Users/x/foo"):
+            result = cwd_to_project_slug(None)
+        assert result == "-Users-x-foo"
+
+    def test_unicode_char_maps_to_dash(self):
+        """Non-ASCII characters (e.g. accented letters) must be replaced."""
+        # re.sub(r'[^a-zA-Z0-9]', '-', ...) replaces 'é' with '-'
+        result = cwd_to_project_slug("/Users/x/café")
+        expected = re.sub(r"[^a-zA-Z0-9]", "-", "/Users/x/café")
+        assert result == expected, (
+            f"Got {result!r}, expected {expected!r}. Unicode char not replaced."
+        )
 
 
 class TestGetClaudeDir:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -71,12 +71,25 @@ class TestCwdToProjectSlug:
         result = cwd_to_project_slug("/Users/x/my-project")
         assert result == "-Users-x-my-project"
 
-    def test_trailing_slash_produces_trailing_dash(self):
-        """With NO rstrip, a trailing '/' becomes a trailing '-'."""
+    def test_trailing_slash_normalized(self):
+        """normpath strips trailing slash before regex — no trailing dash in output."""
         result = cwd_to_project_slug("/Users/x/myproject/")
-        # Lead decision: NO rstrip — trailing slash → trailing dash
-        assert result == "-Users-x-myproject-", (
-            f"Got {result!r}. Expected trailing '-' from trailing '/'."
+        assert result == "-Users-x-myproject", (
+            f"Got {result!r}. normpath should have stripped the trailing slash."
+        )
+
+    def test_dot_segment_normalized(self):
+        """`./` and embedded `.` segments are collapsed by normpath."""
+        result = cwd_to_project_slug("/Users/x/./p")
+        assert result == "-Users-x-p", (
+            f"Got {result!r}. normpath should collapse the dot segment."
+        )
+
+    def test_double_slash_normalized(self):
+        """Double slashes are collapsed by normpath."""
+        result = cwd_to_project_slug("/Users/x//p")
+        assert result == "-Users-x-p", (
+            f"Got {result!r}. normpath should collapse double slash."
         )
 
     def test_none_cwd_uses_os_getcwd(self):


### PR DESCRIPTION
## Problem

After a `/compact`, the **PostCompact** hook could inject a **different project's** `team-checkpoint.md` into the recovered context. A session in project `foo_bar` (underscore in the dir name) would recover another, unrelated project's team state if that other project's session was more recently active at compaction time.

Root cause is two stacked bugs:

1. **Slug normalization mismatch.** `cwd_to_project_slug` did `cwd.replace("/", "-")` — it only normalized `/`, not `_` or `.`. Claude Code stores project dirs replacing **every non-alphanumeric** character with `-`:

   ```
   cwd  = /Users/me/Algo/foo_bar
   dir  = -Users-me-Algo-foo-bar      (Claude: '_' -> '-')
   slug = -Users-me-Algo-foo_bar      (old code: '_' kept)
   ```

   So for any project whose path contains `_` or `.` (worktrees included — `/.claude/` -> `--claude-`), the computed slug never matched the project directory.

2. **Non-strict resolution falls through to a global guess.** With Strategy 3 (cwd-slug match) missing, `find_current_session(..., strict=False)` fell through to Strategy 4 — *"return the most-recently-modified session across **all** projects"* — and several context-injection / write call sites resolved non-strict. PostCompact then read whichever project was most recently active.

This was deterministic for every underscore/dot-named project and triggered whenever a second session was more recently active. The same broken slug also made the behavioral-digest memory directory silently resolve to `None` (digest no-op), and the PreCompact `checkpoint` write path had the same non-strict resolution (write-side of the same chain).

## Fix

- **`session.py` `cwd_to_project_slug`** → `re.sub(r"[^a-zA-Z0-9]", "-", cwd)`, matching Claude Code's normalization exactly (verified against real `~/.claude/projects/` directory names: underscore, dot/worktree, space, hyphen, plain — all reproduced 1:1, case and digits preserved).
- **`session.py` Strategy 3** → exact-match (`s["project"] == slug`) instead of substring, eliminating prefix collisions (`-x-foo` ⊂ `-x-foobar`).
- **Strict resolution on every cross-project-sensitive call site** (`find_current_session(cwd, strict=True)`): `cmd_post_compact` (recovery read), `_digest_session` (digest flush/inject write), `checkpoint_team` (PreCompact write), `start_guard_daemon` and `reload_self_daemon` (daemon lifecycle). On an ambiguous resolution these now return `None` / fall back to the local project instead of guessing across projects. The daemon paths are behavior-preserving (they degrade to the pre-existing no-session-id fallback).
- **`digest.py` `_get_memdir`** routed through the corrected `cwd_to_project_slug` with exact-match (it had its own independent, identically-broken inline slug derivation — not fixed transitively).
- **`team.py` `read_team_checkpoint`** gains an `include_global: bool = True` parameter (backward-compatible); PostCompact recovery now passes `include_global=False` so it never falls back to the shared global `~/.claude/team-checkpoint.md` on the recovery path.

No new dependencies — `re`/`os` are stdlib; the package stays zero-dependency.

## Tests

- **Slug parity** (table-driven): underscore, dot/double-dash, worktree, space, unicode, digits, existing-hyphens, trailing-slash — each asserted against the literal directory name Claude Code creates.
- **Cross-project isolation**: `cmd_post_compact` and `checkpoint_team` with two projects (the other more recently active) never resolve/return/​write the wrong project; positive resolution to the correct project is covered too.
- **Strategy-4 regression**: `find_current_session(cwd, strict=True)` returns `None` (not most-recent) when no slug matches.
- **Digest**: `_get_memdir` resolves an underscore project (was `None`) and never prefix-collides.
- **Daemon strict→None**: `start_guard_daemon` / `reload_self_daemon` degrade gracefully with no behavior change.

Bug-capture tests were confirmed RED against the base commit before the fix. Full suite: **979 passed, 5 skipped, 0 failed** (excluding the 3 pre-existing `test_model_detection` failures unrelated to this change).

An end-to-end before/after reproduction of the original scenario confirms it: against the unpatched code, `cmd_post_compact` for an underscore project emitted the *other* project's checkpoint; after the fix it emits the correct project's checkpoint (or nothing), the resolver returns the correct project, and the digest memory directory resolves.

## Scope (intentionally not changed)

- `project_slug_to_path` (`slug.replace("-", "/")`) — pre-existing, documented lossy round-trip; the authoritative sidecar CWD fallback already covers it.
- `cmd_current` — interactive display; a wrong guess is visible to the user, so non-strict is appropriate.
- `doctor.py` substring matches — those slugs come from guard PID-file stems (session-id namespace), not the cwd project slug.

## Deployment note

Merging is necessary but not sufficient for the fix to take effect for an installed user: it lands once a new release is published to PyPI (or via `pip install --upgrade cozempic`).
