### PR TITLE
feat: add team recovery receipt primitive

### DIFF
--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -214,6 +214,85 @@ class TeamState:
         return "\n".join(parts)
 
 
+def _count_by_status(items: list[object]) -> dict[str, int]:
+    """Return stable status counts for receipt/debug output."""
+    counts: dict[str, int] = {}
+    for item in items:
+        status = (getattr(item, "status", "unknown") or "unknown").strip().lower()
+        counts[status] = counts.get(status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def build_team_recovery_receipt(state: TeamState) -> dict:
+    """Build a privacy-safe receipt for post-compact team recovery.
+
+    The receipt is intentionally count/flag based: it proves what recovery
+    state was available without copying team names, task subjects, prompts,
+    cwd values, result summaries, or raw session text into a shareable artifact.
+    """
+    active_tasks, completed_tasks, blank_tasks = state._task_groups()
+    running_subagents = [s for s in state.subagents if (s.status or "").lower() == "running"]
+    active_teammates = [t for t in state.teammates if (t.status or "").lower() not in {"done", "completed"}]
+
+    gaps: list[str] = []
+    if state.is_empty():
+        gaps.append("no_team_state")
+    if not state.config_source:
+        gaps.append("missing_config_source")
+    if state.last_coordination_index < 0:
+        gaps.append("missing_last_coordination_cursor")
+    if not state.tasks:
+        gaps.append("no_task_assignment_table")
+
+    # Cozempic can currently identify the last coordination line, but it does
+    # not yet expose a per-teammate event/message cursor. Marking active teams
+    # as partial until that exists prevents a phantom-team recovery from being
+    # presented as complete.
+    event_cursors_recorded = False
+    has_active_work = bool(active_tasks or running_subagents or active_teammates)
+    if has_active_work and not event_cursors_recorded:
+        gaps.append("per_teammate_event_cursors_not_recorded")
+
+    if state.is_empty():
+        verdict = "unsafe-to-resume"
+    elif has_active_work and not event_cursors_recorded:
+        verdict = "partial"
+    elif gaps:
+        verdict = "partial"
+    else:
+        verdict = "complete"
+
+    return {
+        "event": "team.recovery.receipt.v1",
+        "recovery_verdict": verdict,
+        "source": {
+            "config_source": state.config_source or "unknown",
+            "team_identity_present": bool(state.team_name or state.lead_agent_id or state.lead_session_id),
+            "last_coordination_cursor_present": state.last_coordination_index >= 0,
+            "per_teammate_event_cursors_recorded": event_cursors_recorded,
+        },
+        "counts": {
+            "team_messages": state.message_count,
+            "teammates_total": len(state.teammates),
+            "teammates_by_status": _count_by_status(state.teammates),
+            "subagents_total": len(state.subagents),
+            "subagents_by_status": _count_by_status(state.subagents),
+            "tasks_active": len(active_tasks),
+            "tasks_completed": completed_tasks,
+            "tasks_blank": blank_tasks,
+            "tasks_by_status": _count_by_status(state.tasks),
+        },
+        "privacy": {
+            "raw_team_name_recorded": False,
+            "raw_agent_ids_recorded": False,
+            "raw_task_subjects_recorded": False,
+            "raw_prompts_or_results_recorded": False,
+            "raw_paths_recorded": False,
+        },
+        "audit_gaps": gaps,
+    }
+
+
 # ─── Patterns for team message detection ─────────────────────────────────────
 
 # Tool names that indicate team/agent coordination

--- a/tests/test_team_schema.py
+++ b/tests/test_team_schema.py
@@ -6,10 +6,13 @@ import json
 import unittest
 
 from cozempic.team import (
+    SubagentInfo,
     TaskInfo,
+    TeammateInfo,
     TeamState,
     _is_team_message,
     _is_task_tool_result,
+    build_team_recovery_receipt,
     extract_team_state,
     inject_team_recovery,
     merge_config_into_state,
@@ -142,6 +145,58 @@ class TestMergeConfigStrongJoin(unittest.TestCase):
         state = self._state(team_name="Existing")
         result = merge_config_into_state(state, [])
         self.assertEqual(result.team_name, "Existing")
+
+
+class TestTeamRecoveryReceipt(unittest.TestCase):
+
+    def test_empty_state_is_unsafe_to_resume(self):
+        receipt = build_team_recovery_receipt(TeamState())
+
+        self.assertEqual(receipt["event"], "team.recovery.receipt.v1")
+        self.assertEqual(receipt["recovery_verdict"], "unsafe-to-resume")
+        self.assertIn("no_team_state", receipt["audit_gaps"])
+        self.assertFalse(receipt["privacy"]["raw_task_subjects_recorded"])
+
+    def test_active_team_without_event_cursors_is_partial(self):
+        state = TeamState(
+            team_name="Private GTM Team",
+            config_source="both",
+            message_count=7,
+            last_coordination_index=42,
+            teammates=[TeammateInfo("agent-secret-1", "private-name", status="running")],
+            subagents=[SubagentInfo("subagent-secret-2", "private desc", status="running")],
+            tasks=[TaskInfo("task-secret-3", "private task subject", "in_progress", owner="private-owner")],
+        )
+
+        receipt = build_team_recovery_receipt(state)
+
+        self.assertEqual(receipt["recovery_verdict"], "partial")
+        self.assertEqual(receipt["counts"]["teammates_total"], 1)
+        self.assertEqual(receipt["counts"]["subagents_by_status"], {"running": 1})
+        self.assertEqual(receipt["counts"]["tasks_active"], 1)
+        self.assertIn("per_teammate_event_cursors_not_recorded", receipt["audit_gaps"])
+
+        rendered = json.dumps(receipt)
+        self.assertNotIn("Private GTM Team", rendered)
+        self.assertNotIn("agent-secret-1", rendered)
+        self.assertNotIn("private task subject", rendered)
+        self.assertNotIn("private-owner", rendered)
+
+    def test_completed_team_state_can_be_complete(self):
+        state = TeamState(
+            team_name="Done Team",
+            config_source="both",
+            message_count=4,
+            last_coordination_index=10,
+            teammates=[TeammateInfo("agent-1", "builder", status="done")],
+            tasks=[TaskInfo("task-1", "finished", "completed")],
+        )
+
+        receipt = build_team_recovery_receipt(state)
+
+        self.assertEqual(receipt["recovery_verdict"], "complete")
+        self.assertEqual(receipt["counts"]["tasks_completed"], 1)
+        self.assertEqual(receipt["audit_gaps"], [])
 
 
 class TestTeamRecoveryRendering(unittest.TestCase):


### PR DESCRIPTION
## What
Adds a small `build_team_recovery_receipt(state)` primitive for Agent Team recovery.

The receipt is deliberately count/flag based so it can be shared in bug reports or guard logs without copying raw team names, agent IDs, task subjects, prompts, cwd paths, or result text.

It emits:
- `recovery_verdict`: `complete`, `partial`, or `unsafe-to-resume`
- source flags: config source, team identity present, last coordination cursor present
- counts by teammate/subagent/task status
- privacy booleans proving raw details were not recorded
- `audit_gaps` such as `per_teammate_event_cursors_not_recorded`

## Why
This follows up on the discussion in anthropics/claude-code#23620 and Cozempic issue #101: a team recovery checkpoint should not only re-inject state; it should also prove whether recovery is complete enough to trust.

The current implementation is intentionally conservative: active teams are marked `partial` until per-teammate event/message cursors are actually recorded. That avoids the “phantom team” case where the lead remembers the roster but not the task/event state.

## Tests
- `PYTHONPATH=src python3 -m unittest tests.test_team_schema -v`

I kept this as a primitive + tests, not CLI wiring, so you can decide whether it belongs on `treat`, guard runs, or PostCompact output.
