### PR TITLE
fix: suppress local auto-init when global hooks exist

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed — $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed — $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       }

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1652,7 +1652,8 @@ def _maybe_auto_init(argv: list[str]) -> None:
       1. COZEMPIC_NO_AUTO_INIT=1 in env (also set by --no-auto-init via _prescan_argv)
       2. cwd has no .claude/ directory (not a Claude project)
       3. Subcommand is in _AUTO_INIT_SKIP_CMDS or no subcommand was given
-      4. Cozempic hooks are already wired in this project's settings
+      4. Global hooks are current in ~/.claude/settings.json (local would be redundant)
+      5. Cozempic hooks are already wired in this project's settings
 
     Otherwise: runs init silently and prints a single one-line notice to stderr.
     Failures are non-fatal — the user's original command still runs.
@@ -1666,6 +1667,20 @@ def _maybe_auto_init(argv: list[str]) -> None:
 
     cmd = next((tok for tok in argv if tok in _SUBCOMMANDS), None)
     if cmd is None or cmd in _AUTO_INIT_SKIP_CMDS:
+        return
+
+    # Skip local init when global hooks are already current (avoids double-firing).
+    # Guard: if cwd IS the home dir, home_claude == claude_dir -- fall through
+    # to the normal local check instead.
+    home_claude = Path.home() / ".claude"
+    if home_claude != claude_dir and _project_is_cozempic_current(home_claude):
+        # Warn if redundant local hooks are also present.
+        if _project_is_cozempic_current(claude_dir):
+            print(
+                "  Cozempic: local hooks redundant (global hooks active). "
+                "Remove with `cozempic init --uninstall` in this project.",
+                file=sys.stderr,
+            )
         return
 
     if _project_is_cozempic_current(claude_dir):

--- a/src/cozempic/data/hooks.json
+++ b/src/cozempic/data/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed — $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed — $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v11"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v10"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true # cozempic-hook-schema=v11"
           }
         ]
       }

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -39,7 +39,7 @@ def _c(args: str) -> str:
 # at the end of every canonical hook command (e.g. "# cozempic-hook-schema=v2")
 # is what `_is_current_cozempic_hook` looks for — old hooks without the current
 # marker are treated as stale and get refreshed on next init.
-HOOK_SCHEMA_VERSION = "v10"
+HOOK_SCHEMA_VERSION = "v11"
 HOOK_SCHEMA_MARKER = f"cozempic-hook-schema={HOOK_SCHEMA_VERSION}"
 
 

--- a/tests/test_atomic_writes_wave1.py
+++ b/tests/test_atomic_writes_wave1.py
@@ -310,7 +310,7 @@ class TestHookSchemaV9(unittest.TestCase):
 
     def test_schema_marker_bumped(self):
         from cozempic.init import HOOK_SCHEMA_VERSION
-        self.assertEqual(HOOK_SCHEMA_VERSION, "v10")
+        self.assertEqual(HOOK_SCHEMA_VERSION, "v11")
 
     def test_no_unflocked_foreground_guard_daemon_call(self):
         """The unflocked foreground `cozempic guard --daemon` call stays removed.

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -1,0 +1,179 @@
+"""Tests for _maybe_auto_init() skipping local init when global hooks are current."""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+class TestAutoInitGlobalSkip(unittest.TestCase):
+    """_maybe_auto_init() must skip local init when global hooks are current."""
+
+    def _make_project(self, tmpdir):
+        """Create a fake project with .claude/ dir under tmpdir."""
+        project = Path(tmpdir) / "myproject"
+        (project / ".claude").mkdir(parents=True)
+        return project
+
+    def _write_current_hooks(self, claude_dir):
+        """Write a settings.json with current-schema cozempic hooks."""
+        from cozempic.init import HOOK_SCHEMA_MARKER
+        settings = claude_dir / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": f"cozempic guard --daemon # {HOOK_SCHEMA_MARKER}",
+                    }],
+                }],
+            }
+        }))
+
+    def _write_stale_hooks(self, claude_dir):
+        """Write a settings.json with stale (pre-schema) cozempic hooks."""
+        settings = claude_dir / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "{ cozempic guard --daemon 2>/dev/null || python3 -m cozempic guard --daemon 2>/dev/null; } || true",
+                    }],
+                }],
+            }
+        }))
+
+    def test_skips_when_global_hooks_current(self):
+        """Global hooks current -> no local init."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_current_hooks(home_claude)
+
+            project = self._make_project(tmp)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init") as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_not_called()
+
+    def test_fires_when_global_hooks_absent(self):
+        """No global hooks -> local auto-init should fire."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            # No hooks written to global settings
+
+            project = self._make_project(tmp)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init", return_value={"hooks": {"added": ["SessionStart[]"], "updated": []}}) as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_called_once()
+
+    def test_fires_when_global_hooks_stale(self):
+        """Global hooks stale (old schema) -> local auto-init should fire."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_stale_hooks(home_claude)
+
+            project = self._make_project(tmp)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init", return_value={"hooks": {"added": ["SessionStart[]"], "updated": []}}) as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_called_once()
+
+    def test_warns_when_global_current_and_local_hooks_present(self):
+        """Global hooks current + local hooks exist -> warn to stderr."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_current_hooks(home_claude)
+
+            project = self._make_project(tmp)
+            # Write local hooks too
+            self._write_current_hooks(project / ".claude")
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch("sys.stderr") as mock_stderr:
+                        with mock.patch.object(cli, "run_init") as ri:
+                            cli._maybe_auto_init(["list"])
+                            ri.assert_not_called()
+                        # Check warning was printed
+                        mock_stderr.write.assert_called()
+                        output = "".join(
+                            call.args[0] for call in mock_stderr.write.call_args_list
+                            if call.args
+                        )
+                        self.assertIn("redundant", output.lower())
+
+    def test_no_warn_when_global_current_and_no_local_hooks(self):
+        """Global hooks current + no local hooks -> skip silently, no warning."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_current_hooks(home_claude)
+
+            project = self._make_project(tmp)
+            # No local hooks written
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch("sys.stderr") as mock_stderr:
+                        with mock.patch.object(cli, "run_init") as ri:
+                            cli._maybe_auto_init(["list"])
+                            ri.assert_not_called()
+                        # No warning should be printed
+                        output = "".join(
+                            call.args[0] for call in mock_stderr.write.call_args_list
+                            if call.args
+                        )
+                        self.assertNotIn("redundant", output.lower())
+
+    def test_no_skip_when_cwd_is_home(self):
+        """When cwd is home dir, global == local -- guard must prevent
+        the global-skip branch from firing. We verify by making
+        _project_is_cozempic_current return False so run_init is called,
+        proving the global-skip branch (which would return early) was NOT taken."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_current_hooks(home_claude)
+
+            # cwd IS the home dir -- home_claude == claude_dir
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=home):
+                    # Return False so the local check falls through to run_init.
+                    # If the guard were missing, the global-skip branch would fire
+                    # (real hooks ARE current) and return early -- run_init would
+                    # never be called. So run_init being called proves the guard works.
+                    with mock.patch.object(cli, "_project_is_cozempic_current", return_value=False):
+                        with mock.patch.object(cli, "run_init", return_value={"hooks": {"added": ["SessionStart[]"], "updated": []}}) as ri:
+                            cli._maybe_auto_init(["list"])
+                            ri.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -559,8 +559,8 @@ class TestPolishPR93_HookSchemaV9(unittest.TestCase):
     def test_hook_schema_version_v9(self):
         from cozempic.init import HOOK_SCHEMA_VERSION
         self.assertIn(
-            HOOK_SCHEMA_VERSION, ("v9", "v10"),
-            "HOOK_SCHEMA_VERSION must be v9 or higher (PR #93 head -1 change, PR #94 Phase B bump)",
+            HOOK_SCHEMA_VERSION, ("v9", "v10", "v11"),
+            "HOOK_SCHEMA_VERSION must be v9 or higher (PR #93 head -1 change, PR #94 Phase B bump, #109 NO_AUTO_INIT)",
         )
 
     def test_hooks_json_uses_head_minus_1(self):
@@ -599,13 +599,13 @@ class TestPolishPR93_HookSchemaV9(unittest.TestCase):
             with self.subTest(path=hooks_rel):
                 body = hooks_path.read_text()
                 self.assertTrue(
-                    "cozempic-hook-schema=v9" in body or "cozempic-hook-schema=v10" in body,
-                    f"{hooks_rel}: schema marker must be v9 or v10",
+                    "cozempic-hook-schema=v9" in body or "cozempic-hook-schema=v10" in body or "cozempic-hook-schema=v11" in body,
+                    f"{hooks_rel}: schema marker must be v9 or higher",
                 )
                 self.assertNotIn(
                     "cozempic-hook-schema=v8",
                     body,
-                    f"{hooks_rel}: v8 marker must be migrated to v9/v10",
+                    f"{hooks_rel}: v8 marker must be migrated to v9+",
                 )
 
 

--- a/tests/test_guard_reload_watcher_poll.py
+++ b/tests/test_guard_reload_watcher_poll.py
@@ -328,11 +328,12 @@ class TestSessionStartHookSurfacesPriorStatus(unittest.TestCase):
         """Hook prints failure reason and removes status file."""
         import json as _json
         cmd = self._load_session_start_command()
-        # Status file surface requires v10 hook schema
+        # Status file surface requires v10+ hook schema
+        from cozempic.init import HOOK_SCHEMA_MARKER
         self.assertIn(
-            "v10",
+            HOOK_SCHEMA_MARKER,
             cmd,
-            "Hook schema is not v10 — status file surfacing not yet in hooks.json. "
+            "Hook schema marker not current — status file surfacing not yet in hooks.json. "
             "Expected RED until Phase B adds status surface to hooks.json.",
         )
         hook_data = _json.dumps({"session_id": self.sid, "transcript_path": ""})

--- a/tests/test_guard_transient_race.py
+++ b/tests/test_guard_transient_race.py
@@ -227,11 +227,12 @@ class TestSessionStartHookSkipsSpawnDuringSentinel(unittest.TestCase):
     def test_session_start_hook_skips_spawn_during_reload(self):
         """Hook must skip guard --daemon when sentinel is present (v10 behavior)."""
         cmd = self._load_session_start_command()
-        # Sentinel check requires v10 hook schema — if not present, this RED is expected
+        # Sentinel check requires v10+ hook schema — if not present, this RED is expected
+        from cozempic.init import HOOK_SCHEMA_MARKER
         self.assertIn(
-            "v10",
+            HOOK_SCHEMA_MARKER,
             cmd,
-            "Hook schema is not v10 — sentinel check not yet in hooks.json. "
+            "Hook schema marker not current — sentinel check not yet in hooks.json. "
             "This test RED until Phase B adds sentinel skip to hooks.json.",
         )
         hook_data = json.dumps({"session_id": self.sid, "transcript_path": ""})

--- a/tests/test_hooks_sync.py
+++ b/tests/test_hooks_sync.py
@@ -35,5 +35,33 @@ class TestHooksSync(unittest.TestCase):
         )
 
 
+    def test_all_hooks_export_no_auto_init(self):
+        """Every hook command must set COZEMPIC_NO_AUTO_INIT=1."""
+        canonical = json.loads(DATA_HOOKS.read_text(encoding="utf-8"))
+        for event, entries in canonical.get("hooks", {}).items():
+            for entry in entries:
+                for h in entry.get("hooks", []):
+                    cmd = h.get("command", "")
+                    self.assertIn(
+                        "COZEMPIC_NO_AUTO_INIT=1",
+                        cmd,
+                        msg=f"Hook {event}[{entry.get('matcher', '')}] missing COZEMPIC_NO_AUTO_INIT=1",
+                    )
+
+    def test_schema_marker_is_current(self):
+        """Every hook command must have the current schema marker."""
+        from cozempic.init import HOOK_SCHEMA_MARKER
+        canonical = json.loads(DATA_HOOKS.read_text(encoding="utf-8"))
+        for event, entries in canonical.get("hooks", {}).items():
+            for entry in entries:
+                for h in entry.get("hooks", []):
+                    cmd = h.get("command", "")
+                    self.assertIn(
+                        HOOK_SCHEMA_MARKER,
+                        cmd,
+                        msg=f"Hook {event}[{entry.get('matcher', '')}] has stale schema marker",
+                    )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`cozempic init --global` writes hooks to `~/.claude/settings.json`. When Claude Code runs in any project directory, the global SessionStart hook fires cozempic CLI commands (`guard --daemon`, `digest inject`, `checkpoint`, etc.). Each command enters `main()` -> `_maybe_auto_init()`, which sees `.claude/` in cwd and writes hooks into the local project's `.claude/settings.json`.

This causes:
- **Duplicate hooks** in every project's local settings
- **Double-firing** of every hook event (global + local)
- **Pollution** of project settings files that may be committed to git

## Root Cause

- `_maybe_auto_init()` is blind to global hooks -- it only checks whether the LOCAL `.claude/` has current cozempic hooks.
- The SessionStart hook sets `COZEMPIC_NO_GLOBAL_INIT=1` but NOT `COZEMPIC_NO_AUTO_INIT=1`.

## Fix (two layers, defense in depth)

### 1. `_maybe_auto_init()` checks for global hooks (root cause fix)

New bail-out in `_maybe_auto_init()`: if `~/.claude/settings.json` has current-schema cozempic hooks, skip local auto-init. Also warns to stderr when local hooks are redundant.

New flow:
1. `COZEMPIC_NO_AUTO_INIT=1`? -> return
2. cwd has no `.claude/`? -> return
3. subcommand in skip list? -> return
4. **global hooks are current?** -> warn if local hooks exist, then return
5. local hooks are current? -> return
6. `run_init(cwd)`

### 2. Hook commands export `COZEMPIC_NO_AUTO_INIT=1` (belt-and-suspenders)

All hook shell commands now prepend `export COZEMPIC_NO_AUTO_INIT=1;` so the auto-init check never even runs when invoked by a hook.

### 3. Schema bump v10 -> v11

Existing installations auto-refresh stale hooks on next cozempic invocation via `wire_hooks()`.

## Migration

- Global hooks refresh automatically on first post-upgrade invocation
- Existing local hooks are NOT removed -- a stderr warning tells users to run `cozempic init --uninstall` per project
- Explicit `cozempic init` (without `--global`) still works for users who specifically want local hooks

## Test Plan

- [x] 6 new tests in `test_auto_init_global_skip.py` (skip/fire/warn scenarios + edge cases)
- [x] 2 new tests in `test_hooks_sync.py` (NO_AUTO_INIT present, schema marker current)
- [x] 4 existing tests updated for v11 schema version
- [x] Full suite: 1037 passed, 0 failed
