### PR TITLE
fix(validation): reject NaN/inf and non-representable ints in positive-number coercion

### DIFF
--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -24,6 +24,7 @@ Design goals:
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 from typing import Any
@@ -111,7 +112,7 @@ def coerce_positive_float(config: dict, key: str, default: float) -> float:
     """Return `config[key]` as a strictly-positive float, or `default` if absent.
 
     Accepts int in addition to float (users write `threshold=50`). Rejects
-    bool, str, None, negative, and zero.
+    bool, str, None, negative, zero, NaN, and infinity.
     """
     if key not in config:
         return default
@@ -119,6 +120,10 @@ def coerce_positive_float(config: dict, key: str, default: float) -> float:
     if not _is_strict_number(value):
         raise ConfigError(
             f"config[{key!r}] must be a number, got {type(value).__name__} {value!r}"
+        )
+    if math.isnan(value) or math.isinf(value):
+        raise ConfigError(
+            f"config[{key!r}] must be a finite number, got {value!r}"
         )
     if value <= 0:
         raise ConfigError(

--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -122,7 +122,7 @@ def coerce_positive_float(config: dict, key: str, default: float) -> float:
             f"config[{key!r}] must be a number, got {type(value).__name__} {value!r}"
         )
     try:
-        _nonfinite = math.isnan(value) or math.isinf(value)
+        _nonfinite = not math.isfinite(value)
     except OverflowError:
         # int too large to convert to float (e.g. 10**400) — treat as non-finite
         _nonfinite = True

--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -121,7 +121,12 @@ def coerce_positive_float(config: dict, key: str, default: float) -> float:
         raise ConfigError(
             f"config[{key!r}] must be a number, got {type(value).__name__} {value!r}"
         )
-    if math.isnan(value) or math.isinf(value):
+    try:
+        _nonfinite = math.isnan(value) or math.isinf(value)
+    except OverflowError:
+        # int too large to convert to float (e.g. 10**400) — treat as non-finite
+        _nonfinite = True
+    if _nonfinite:
         raise ConfigError(
             f"config[{key!r}] must be a finite number, got {value!r}"
         )

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -50,7 +50,7 @@ def _positive_int(val: str) -> int:
 
 def _positive_float(val: str) -> float:
     """argparse type= for strictly-positive floats. Used for --threshold
-    and --soft-threshold (MB thresholds)."""
+    and --soft-threshold (MB thresholds). Rejects NaN and infinity."""
     try:
         f = float(val)
     except ValueError:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -55,7 +55,7 @@ def _positive_float(val: str) -> float:
         f = float(val)
     except ValueError:
         raise argparse.ArgumentTypeError(f"{val!r} is not a valid number")
-    if math.isnan(f) or math.isinf(f):
+    if not math.isfinite(f):
         raise argparse.ArgumentTypeError(f"must be a finite number, got {f}")
     if f <= 0:
         raise argparse.ArgumentTypeError(f"must be positive, got {f}")

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import platform
 import subprocess
@@ -54,6 +55,8 @@ def _positive_float(val: str) -> float:
         f = float(val)
     except ValueError:
         raise argparse.ArgumentTypeError(f"{val!r} is not a valid number")
+    if math.isnan(f) or math.isinf(f):
+        raise argparse.ArgumentTypeError(f"must be a finite number, got {f}")
     if f <= 0:
         raise argparse.ArgumentTypeError(f"must be positive, got {f}")
     return f

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -344,18 +344,16 @@ def _validate_finite_thresholds(
     threshold_tokens=None,
     soft_threshold_tokens=None,
 ) -> None:
-    """Reject NaN/inf in any float-typed threshold parameter.
+    """Reject NaN, inf, and huge ints in numeric threshold parameters.
 
     Belt-and-braces guard for direct Python callers that bypass argparse.
-    Mirrors coerce_positive_float's finite contract. Raises ConfigError with
-    'must be a finite number' when any float param is nan or inf.
+    Mirrors coerce_positive_float's finite contract (P0-A + P0-F). Raises
+    ConfigError with 'must be a finite number' when any numeric param is
+    nan, inf, or a huge int (e.g. 10**400) that would overflow on conversion.
 
-    Int params (e.g. threshold_tokens=10_000) are naturally skipped via the
-    isinstance(..., float) check — they cannot be nan/inf, and math.isfinite
-    on a huge int (e.g. 10**400) would raise OverflowError.  The try/except
-    below mirrors coerce_positive_float's P0-F guard for class-of-bug parity;
-    in practice the isinstance gate makes it unreachable, but defensive code
-    should not rely on call-site discipline.
+    Bools are excluded (they are int subclasses in Python; True/False are
+    validated separately by type checks downstream). None is also skipped
+    (optional params default to None when not supplied by the caller).
     """
     from ._validation import ConfigError
 
@@ -366,13 +364,13 @@ def _validate_finite_thresholds(
         ("threshold_tokens", threshold_tokens),
         ("soft_threshold_tokens", soft_threshold_tokens),
     ):
-        if not isinstance(_v, float):
+        if _v is None or isinstance(_v, bool) or not isinstance(_v, (int, float)):
             continue
         try:
-            _nonfinite = not math.isfinite(_v)
+            _finite = math.isfinite(_v)
         except OverflowError:
-            _nonfinite = True  # int too large to convert to float — treat as non-finite
-        if _nonfinite:
+            _finite = False  # int too large to convert to float (e.g. 10**400)
+        if not _finite:
             raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
 
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2835,6 +2835,17 @@ def reload_self_daemon(
 
     Returns dict: {reloaded: bool, old_pid, new_pid, log_file, reason}.
     """
+    # Validate BEFORE any destructive action — a NaN/inf threshold must not
+    # kill the live daemon and then fail to spawn a replacement, leaving the
+    # session unprotected.  Mirrors the belt-and-braces checks in start_guard
+    # and start_guard_daemon.
+    _validate_finite_thresholds(
+        threshold_mb=threshold_mb,
+        soft_threshold_mb=soft_threshold_mb,
+        interval=interval,
+        threshold_tokens=threshold_tokens,
+        soft_threshold_tokens=soft_threshold_tokens,
+    )
     cwd = cwd or os.getcwd()
 
     if not session_id:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -362,7 +362,7 @@ def _validate_finite_thresholds(
         ("threshold_tokens", threshold_tokens),
         ("soft_threshold_tokens", soft_threshold_tokens),
     ):
-        if isinstance(_v, float) and (math.isnan(_v) or math.isinf(_v)):
+        if isinstance(_v, float) and not math.isfinite(_v):
             raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
 
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -336,6 +336,36 @@ def prune_with_team_protect(
 
 # ─── Guard daemon ─────────────────────────────────────────────────────────────
 
+
+def _validate_finite_thresholds(
+    threshold_mb=None,
+    soft_threshold_mb=None,
+    interval=None,
+    threshold_tokens=None,
+    soft_threshold_tokens=None,
+) -> None:
+    """Reject NaN/inf in any float-typed threshold parameter.
+
+    Belt-and-braces guard for direct Python callers that bypass argparse.
+    Mirrors coerce_positive_float's finite contract. Raises ConfigError with
+    'must be a finite number' when any float param is nan or inf.
+
+    Int params (e.g. threshold_tokens=10_000) are naturally skipped via the
+    isinstance(..., float) check — they cannot be nan/inf.
+    """
+    from ._validation import ConfigError
+
+    for _name, _v in (
+        ("threshold_mb", threshold_mb),
+        ("soft_threshold_mb", soft_threshold_mb),
+        ("interval", interval),
+        ("threshold_tokens", threshold_tokens),
+        ("soft_threshold_tokens", soft_threshold_tokens),
+    ):
+        if isinstance(_v, float) and (math.isnan(_v) or math.isinf(_v)):
+            raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
+
+
 def start_guard(
     cwd: str | None = None,
     threshold_mb: float = 50.0,
@@ -379,15 +409,13 @@ def start_guard(
     # swapped soft/hard threshold is much worse than a clean upfront error.
     # Argparse already rejects non-positive values, but direct Python callers
     # (guard.start_guard(...)) bypass argparse, so belt-and-braces check.
-    for _name, _v in (
-        ("threshold_mb", threshold_mb),
-        ("soft_threshold_mb", soft_threshold_mb),
-        ("interval", interval),
-        ("threshold_tokens", threshold_tokens),
-        ("soft_threshold_tokens", soft_threshold_tokens),
-    ):
-        if isinstance(_v, float) and (math.isnan(_v) or math.isinf(_v)):
-            raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
+    _validate_finite_thresholds(
+        threshold_mb=threshold_mb,
+        soft_threshold_mb=soft_threshold_mb,
+        interval=interval,
+        threshold_tokens=threshold_tokens,
+        soft_threshold_tokens=soft_threshold_tokens,
+    )
     if threshold_mb <= 0:
         raise ConfigError(f"threshold_mb must be positive, got {threshold_mb}")
     if soft_threshold_mb is not None and soft_threshold_mb <= 0:
@@ -2163,17 +2191,13 @@ def start_guard_daemon(
     Returns dict with: started (bool), pid (int|None), pid_file, log_file,
     already_running (bool).
     """
-    from ._validation import ConfigError
-
-    for _name, _v in (
-        ("threshold_mb", threshold_mb),
-        ("soft_threshold_mb", soft_threshold_mb),
-        ("interval", interval),
-        ("threshold_tokens", threshold_tokens),
-        ("soft_threshold_tokens", soft_threshold_tokens),
-    ):
-        if isinstance(_v, float) and (math.isnan(_v) or math.isinf(_v)):
-            raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
+    _validate_finite_thresholds(
+        threshold_mb=threshold_mb,
+        soft_threshold_mb=soft_threshold_mb,
+        interval=interval,
+        threshold_tokens=threshold_tokens,
+        soft_threshold_tokens=soft_threshold_tokens,
+    )
     if threshold_mb is not None and threshold_mb <= 0:
         raise ConfigError(f"threshold_mb must be positive, got {threshold_mb}")
     if soft_threshold_mb is not None and soft_threshold_mb <= 0:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -379,6 +379,15 @@ def start_guard(
     # swapped soft/hard threshold is much worse than a clean upfront error.
     # Argparse already rejects non-positive values, but direct Python callers
     # (guard.start_guard(...)) bypass argparse, so belt-and-braces check.
+    for _name, _v in (
+        ("threshold_mb", threshold_mb),
+        ("soft_threshold_mb", soft_threshold_mb),
+        ("interval", interval),
+        ("threshold_tokens", threshold_tokens),
+        ("soft_threshold_tokens", soft_threshold_tokens),
+    ):
+        if isinstance(_v, float) and (math.isnan(_v) or math.isinf(_v)):
+            raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
     if threshold_mb <= 0:
         raise ConfigError(f"threshold_mb must be positive, got {threshold_mb}")
     if soft_threshold_mb is not None and soft_threshold_mb <= 0:
@@ -2156,6 +2165,15 @@ def start_guard_daemon(
     """
     from ._validation import ConfigError
 
+    for _name, _v in (
+        ("threshold_mb", threshold_mb),
+        ("soft_threshold_mb", soft_threshold_mb),
+        ("interval", interval),
+        ("threshold_tokens", threshold_tokens),
+        ("soft_threshold_tokens", soft_threshold_tokens),
+    ):
+        if isinstance(_v, float) and (math.isnan(_v) or math.isinf(_v)):
+            raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
     if threshold_mb is not None and threshold_mb <= 0:
         raise ConfigError(f"threshold_mb must be positive, got {threshold_mb}")
     if soft_threshold_mb is not None and soft_threshold_mb <= 0:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -351,7 +351,11 @@ def _validate_finite_thresholds(
     'must be a finite number' when any float param is nan or inf.
 
     Int params (e.g. threshold_tokens=10_000) are naturally skipped via the
-    isinstance(..., float) check — they cannot be nan/inf.
+    isinstance(..., float) check — they cannot be nan/inf, and math.isfinite
+    on a huge int (e.g. 10**400) would raise OverflowError.  The try/except
+    below mirrors coerce_positive_float's P0-F guard for class-of-bug parity;
+    in practice the isinstance gate makes it unreachable, but defensive code
+    should not rely on call-site discipline.
     """
     from ._validation import ConfigError
 
@@ -362,7 +366,13 @@ def _validate_finite_thresholds(
         ("threshold_tokens", threshold_tokens),
         ("soft_threshold_tokens", soft_threshold_tokens),
     ):
-        if isinstance(_v, float) and not math.isfinite(_v):
+        if not isinstance(_v, float):
+            continue
+        try:
+            _nonfinite = not math.isfinite(_v)
+        except OverflowError:
+            _nonfinite = True  # int too large to convert to float — treat as non-finite
+        if _nonfinite:
             raise ConfigError(f"{_name} must be a finite number, got {_v!r}")
 
 

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -213,10 +213,38 @@ class TestGuardArgparseValidation:
         self._assert_argparse_rejects(["remind", "--interval", "-5"])
 
 
+def _assert_raises_like(exc_type, substr):
+    """Context manager: assert exc_type is raised and substr appears in str(e).
+
+    Module-level helper shared by TestStartGuardOrderingValidation,
+    TestStartGuardNanInfValidation, and TestReloadSelfDaemonNanInfValidation.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        try:
+            yield
+        except exc_type as e:
+            assert substr in str(e), f"expected {substr!r} in {e!r}"
+            return
+        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
+
+    return _ctx()
+
+
 class TestStartGuardOrderingValidation:
     """After argparse, soft thresholds may be resolved from defaults
     (60% of threshold). The soft < hard invariant must hold at that point
     too — checked inside start_guard, not just at argparse."""
+
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="_cozempic_ordering_test_")
+
+    def teardown_method(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def _call_start_guard(self, **kwargs):
         from cozempic.guard import start_guard
@@ -224,43 +252,31 @@ class TestStartGuardOrderingValidation:
 
     def test_soft_mb_equal_hard_mb_rejected(self):
         from cozempic._validation import ConfigError
-        with self.assertRaisesLike(ConfigError, "strictly less"):
+        with _assert_raises_like(ConfigError, "strictly less"):
             self._call_start_guard(
                 threshold_mb=50.0,
                 soft_threshold_mb=50.0,
-                cwd="/tmp/_cozempic_test_nonexistent_session",
+                cwd=self._tmpdir,
             )
 
     def test_soft_mb_greater_than_hard_mb_rejected(self):
         from cozempic._validation import ConfigError
-        with self.assertRaisesLike(ConfigError, "strictly less"):
+        with _assert_raises_like(ConfigError, "strictly less"):
             self._call_start_guard(
                 threshold_mb=50.0,
                 soft_threshold_mb=100.0,
-                cwd="/tmp/_cozempic_test_nonexistent_session",
+                cwd=self._tmpdir,
             )
 
     def test_soft_tokens_greater_than_threshold_tokens_rejected(self):
         from cozempic._validation import ConfigError
-        with self.assertRaisesLike(ConfigError, "strictly less"):
+        with _assert_raises_like(ConfigError, "strictly less"):
             self._call_start_guard(
                 threshold_mb=50.0,
                 threshold_tokens=10_000,
                 soft_threshold_tokens=20_000,
-                cwd="/tmp/_cozempic_test_nonexistent_session",
+                cwd=self._tmpdir,
             )
-
-    # pytest-style: contextmanager mimic
-    from contextlib import contextmanager
-
-    @contextmanager
-    def assertRaisesLike(self, exc_type, substr):
-        try:
-            yield
-        except exc_type as e:
-            assert substr in str(e), f"expected {substr!r} in {e!r}"
-            return
-        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
 
 
 class TestStartGuardNanInfValidation:
@@ -300,25 +316,13 @@ class TestStartGuardNanInfValidation:
         import shutil
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    # pytest-style: contextmanager mimic (same pattern as TestStartGuardOrderingValidation)
-    from contextlib import contextmanager
-
-    @contextmanager
-    def assertRaisesLike(self, exc_type, substr):
-        try:
-            yield
-        except exc_type as e:
-            assert substr in str(e), f"expected {substr!r} in {e!r}"
-            return
-        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
-
     def test_start_guard_threshold_mb_nan_raises_config_error(self):
         """start_guard(threshold_mb=float('nan')) must raise ConfigError with 'finite'.
         RED at base: nan <= 0 is False, validation bypassed; ValueError raised downstream
         at int(nan * 1024 * 1024) instead of ConfigError at the validation block."""
         from cozempic.guard import start_guard
         from cozempic._validation import ConfigError
-        with self.assertRaisesLike(ConfigError, "finite"):
+        with _assert_raises_like(ConfigError, "finite"):
             start_guard(threshold_mb=float("nan"), cwd=self._tmpdir)
 
     def test_start_guard_threshold_mb_inf_raises_config_error(self):
@@ -327,7 +331,7 @@ class TestStartGuardNanInfValidation:
         instead of ConfigError at the validation block."""
         from cozempic.guard import start_guard
         from cozempic._validation import ConfigError
-        with self.assertRaisesLike(ConfigError, "finite"):
+        with _assert_raises_like(ConfigError, "finite"):
             start_guard(threshold_mb=float("inf"), cwd=self._tmpdir)
 
     def test_start_guard_daemon_threshold_mb_nan_raises_config_error(self):
@@ -357,7 +361,7 @@ class TestStartGuardNanInfValidation:
             patch("cozempic.spawn_lock.DaemonSpawnClaim"),
             patch("cozempic.guard.subprocess.Popen"),
         ):
-            with self.assertRaisesLike(ConfigError, "finite"):
+            with _assert_raises_like(ConfigError, "finite"):
                 start_guard_daemon(
                     threshold_mb=float("nan"), cwd=self._tmpdir
                 )
@@ -379,7 +383,7 @@ class TestStartGuardNanInfValidation:
             patch("cozempic.spawn_lock.DaemonSpawnClaim"),
             patch("cozempic.guard.subprocess.Popen"),
         ):
-            with self.assertRaisesLike(ConfigError, "finite"):
+            with _assert_raises_like(ConfigError, "finite"):
                 start_guard_daemon(
                     threshold_mb=float("inf"), cwd=self._tmpdir
                 )
@@ -394,25 +398,12 @@ class TestReloadSelfDaemonNanInfValidation:
     ConfigError (from start_guard_daemon's validator), leaving the session
     completely unprotected.
 
-    RED at base: reload_self_daemon calls os.kill before raising — daemon is
-    killed even though the new config is invalid. These tests must FAIL at
-    base and PASS after _validate_finite_thresholds() is called at the top
-    of reload_self_daemon.
+    Regression guard: _validate_finite_thresholds() is called at the top of
+    reload_self_daemon before any I/O, so a NaN/inf threshold_mb raises
+    ConfigError before os.kill is reached — the live daemon is never orphaned.
 
     All I/O between entry and the kill is mocked per isolate-subprocess-tests-by-design.
     """
-
-    # pytest-style: contextmanager mimic
-    from contextlib import contextmanager
-
-    @contextmanager
-    def assertRaisesLike(self, exc_type, substr):
-        try:
-            yield
-        except exc_type as e:
-            assert substr in str(e), f"expected {substr!r} in {e!r}"
-            return
-        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
 
     def _make_mocks(self):
         """Return a context manager that mocks all I/O in reload_self_daemon
@@ -449,13 +440,12 @@ class TestReloadSelfDaemonNanInfValidation:
     def test_reload_self_daemon_threshold_mb_nan_raises_before_kill(self):
         """reload_self_daemon(threshold_mb=nan) must raise ConfigError BEFORE os.kill.
 
-        RED at base: no finite check exists at entry; os.kill fires on the live
-        daemon (99999), THEN start_guard_daemon raises ConfigError — session orphaned.
-        After fix: _validate_finite_thresholds fires first, os.kill is never called."""
+        Regression guard: _validate_finite_thresholds() fires at entry, ConfigError
+        is raised before os.kill — the live daemon (99999) is never orphaned."""
         from cozempic.guard import reload_self_daemon
         from cozempic._validation import ConfigError
         with self._make_mocks() as mock_kill:
-            with self.assertRaisesLike(ConfigError, "finite"):
+            with _assert_raises_like(ConfigError, "finite"):
                 reload_self_daemon(
                     threshold_mb=float("nan"),
                     session_id="00000000-0000-0000-0000-000000000001",
@@ -467,11 +457,12 @@ class TestReloadSelfDaemonNanInfValidation:
     def test_reload_self_daemon_threshold_mb_inf_raises_before_kill(self):
         """reload_self_daemon(threshold_mb=inf) must raise ConfigError BEFORE os.kill.
 
-        RED at base: inf <= 0 is False; same orphan-daemon failure mode as nan."""
+        Regression guard: same orphan-daemon scenario with inf — ConfigError
+        fires before os.kill, daemon survives."""
         from cozempic.guard import reload_self_daemon
         from cozempic._validation import ConfigError
         with self._make_mocks() as mock_kill:
-            with self.assertRaisesLike(ConfigError, "finite"):
+            with _assert_raises_like(ConfigError, "finite"):
                 reload_self_daemon(
                     threshold_mb=float("inf"),
                     session_id="00000000-0000-0000-0000-000000000001",

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -274,12 +274,23 @@ class TestStartGuardNanInfValidation:
     RED at base: NaN/inf bypass `<= 0` (IEEE 754 semantics), no ConfigError raised.
     These are bug-capture tests — must FAIL against the unmodified source.
 
-    start_guard: validation fires before session I/O; no mocking needed for nan/inf
-    (the raise happens at the top of the validation block, before find_current_session).
-    start_guard_daemon: validation fires before Popen, but we mock _cleanup_legacy_pid
-    and subprocess.Popen anyway — per isolate-subprocess-tests-by-design, never rely on
-    environmental accident (nonexistent cwd) for isolation.
+    Isolation (per isolate-subprocess-tests-by-design memory):
+      start_guard:        validation fires before any I/O (before find_current_session).
+                          A tempdir is still created and cleaned up in teardown to
+                          defend against future code reorderings.
+      start_guard_daemon: ALL I/O primitives between function entry and Popen are mocked:
+                            _cleanup_legacy_pid, _reload_sentinel_active,
+                            _is_guard_running_for_session, subprocess.Popen.
+                          Teardown removes the tempdir unconditionally.
     """
+
+    def setup_method(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="_cozempic_guard_nan_test_")
+
+    def teardown_method(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     # pytest-style: contextmanager mimic (same pattern as TestStartGuardOrderingValidation)
     from contextlib import contextmanager
@@ -300,7 +311,7 @@ class TestStartGuardNanInfValidation:
         from cozempic.guard import start_guard
         from cozempic._validation import ConfigError
         with self.assertRaisesLike(ConfigError, "finite"):
-            start_guard(threshold_mb=float("nan"), cwd="/tmp/_cozempic_guard_nan_test")
+            start_guard(threshold_mb=float("nan"), cwd=self._tmpdir)
 
     def test_start_guard_threshold_mb_inf_raises_config_error(self):
         """start_guard(threshold_mb=float('inf')) must raise ConfigError with 'finite'.
@@ -309,38 +320,48 @@ class TestStartGuardNanInfValidation:
         from cozempic.guard import start_guard
         from cozempic._validation import ConfigError
         with self.assertRaisesLike(ConfigError, "finite"):
-            start_guard(threshold_mb=float("inf"), cwd="/tmp/_cozempic_guard_nan_test")
+            start_guard(threshold_mb=float("inf"), cwd=self._tmpdir)
 
     def test_start_guard_daemon_threshold_mb_nan_raises_config_error(self):
         """start_guard_daemon(threshold_mb=float('nan')) must raise ConfigError before spawn.
         RED at base: nan <= 0 is False, validation silently passes, daemon spawned with nan.
-        Subprocess spawn is mocked per isolate-subprocess-tests-by-design."""
+
+        All I/O primitives between function entry and Popen are mocked:
+          - _cleanup_legacy_pid      (first I/O: legacy pid file cleanup)
+          - _reload_sentinel_active  (sentinel file check)
+          - _is_guard_running_for_session (pid file read)
+          - subprocess.Popen         (daemon spawn — must never be reached)
+        """
         from cozempic.guard import start_guard_daemon
         from cozempic._validation import ConfigError
         with (
             patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard._reload_sentinel_active", return_value=False),
             patch("cozempic.guard._is_guard_running_for_session", return_value=None),
             patch("cozempic.guard.subprocess.Popen"),
         ):
             with self.assertRaisesLike(ConfigError, "finite"):
                 start_guard_daemon(
-                    threshold_mb=float("nan"), cwd="/tmp/_cozempic_guard_nan_test"
+                    threshold_mb=float("nan"), cwd=self._tmpdir
                 )
 
     def test_start_guard_daemon_threshold_mb_inf_raises_config_error(self):
         """start_guard_daemon(threshold_mb=float('inf')) must raise ConfigError before spawn.
         RED at base: inf <= 0 is False, validation silently passes, daemon spawned with inf.
-        Subprocess spawn is mocked per isolate-subprocess-tests-by-design."""
+
+        All I/O primitives between function entry and Popen are mocked.
+        """
         from cozempic.guard import start_guard_daemon
         from cozempic._validation import ConfigError
         with (
             patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard._reload_sentinel_active", return_value=False),
             patch("cozempic.guard._is_guard_running_for_session", return_value=None),
             patch("cozempic.guard.subprocess.Popen"),
         ):
             with self.assertRaisesLike(ConfigError, "finite"):
                 start_guard_daemon(
-                    threshold_mb=float("inf"), cwd="/tmp/_cozempic_guard_nan_test"
+                    threshold_mb=float("inf"), cwd=self._tmpdir
                 )
 
 

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -278,10 +278,18 @@ class TestStartGuardNanInfValidation:
       start_guard:        validation fires before any I/O (before find_current_session).
                           A tempdir is still created and cleaned up in teardown to
                           defend against future code reorderings.
-      start_guard_daemon: ALL I/O primitives between function entry and Popen are mocked:
-                            _cleanup_legacy_pid, _reload_sentinel_active,
-                            _is_guard_running_for_session, subprocess.Popen.
+      start_guard_daemon: ALL I/O primitives between function entry and Popen are mocked
+                          to prevent any /tmp/cozempic_guard_* file creation at base:
+                            _cleanup_legacy_pid      (legacy pid cleanup)
+                            _reload_sentinel_active  (sentinel file read)
+                            find_current_session     (jsonl directory scan)
+                            _is_guard_running_for_session (pid file read)
+                            _guard_tmp_root          (redirects pid/log path construction)
+                            cozempic.spawn_lock.DaemonSpawnClaim (O_CREAT|O_EXCL on .pid)
+                            subprocess.Popen         (daemon spawn)
                           Teardown removes the tempdir unconditionally.
+                          Acceptance: BEFORE/AFTER ls /tmp/cozempic_guard_* count equal
+                          when daemon tests run against unpatched (base) source.
     """
 
     def setup_method(self):
@@ -324,12 +332,18 @@ class TestStartGuardNanInfValidation:
 
     def test_start_guard_daemon_threshold_mb_nan_raises_config_error(self):
         """start_guard_daemon(threshold_mb=float('nan')) must raise ConfigError before spawn.
-        RED at base: nan <= 0 is False, validation silently passes, daemon spawned with nan.
+        RED at base: nan <= 0 is False, validation silently passes; execution reaches
+        DaemonSpawnClaim which creates /tmp/cozempic_guard_*.pid via O_CREAT|O_EXCL,
+        and open(log_file) creates /tmp/cozempic_guard_*.log — two real /tmp artifacts.
 
-        All I/O primitives between function entry and Popen are mocked:
-          - _cleanup_legacy_pid      (first I/O: legacy pid file cleanup)
-          - _reload_sentinel_active  (sentinel file check)
+        All I/O primitives between function entry and Popen are mocked to guarantee
+        zero /tmp/cozempic_guard_* files even when running against the unpatched source:
+          - _cleanup_legacy_pid      (legacy pid cleanup)
+          - _reload_sentinel_active  (sentinel file read — only fires when session_id set)
+          - find_current_session     (jsonl directory scan — fires when no session_id)
           - _is_guard_running_for_session (pid file read)
+          - _guard_tmp_root          (redirects pid/log path construction to self._tmpdir)
+          - cozempic.spawn_lock.DaemonSpawnClaim (O_CREAT|O_EXCL on .pid — the leak source)
           - subprocess.Popen         (daemon spawn — must never be reached)
         """
         from cozempic.guard import start_guard_daemon
@@ -337,7 +351,10 @@ class TestStartGuardNanInfValidation:
         with (
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard._reload_sentinel_active", return_value=False),
+            patch("cozempic.guard.find_current_session", return_value=None),
             patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+            patch("cozempic.guard._guard_tmp_root", return_value=Path(self._tmpdir)),
+            patch("cozempic.spawn_lock.DaemonSpawnClaim"),
             patch("cozempic.guard.subprocess.Popen"),
         ):
             with self.assertRaisesLike(ConfigError, "finite"):
@@ -347,16 +364,19 @@ class TestStartGuardNanInfValidation:
 
     def test_start_guard_daemon_threshold_mb_inf_raises_config_error(self):
         """start_guard_daemon(threshold_mb=float('inf')) must raise ConfigError before spawn.
-        RED at base: inf <= 0 is False, validation silently passes, daemon spawned with inf.
+        RED at base: inf <= 0 is False; same leak pattern as nan (two /tmp artifacts).
 
-        All I/O primitives between function entry and Popen are mocked.
+        All I/O primitives mocked — see test_start_guard_daemon_threshold_mb_nan for details.
         """
         from cozempic.guard import start_guard_daemon
         from cozempic._validation import ConfigError
         with (
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard._reload_sentinel_active", return_value=False),
+            patch("cozempic.guard.find_current_session", return_value=None),
             patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+            patch("cozempic.guard._guard_tmp_root", return_value=Path(self._tmpdir)),
+            patch("cozempic.spawn_lock.DaemonSpawnClaim"),
             patch("cozempic.guard.subprocess.Popen"),
         ):
             with self.assertRaisesLike(ConfigError, "finite"):

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -338,8 +338,9 @@ class TestStartGuardNanInfValidation:
         """start_guard(threshold_mb=10**400) must raise ConfigError with 'finite'.
 
         RED at base: isinstance gate skips ints entirely; 10**400 passes the float
-        guard, then int(10**400 * 1024 * 1024) raises a bare OverflowError downstream
-        instead of ConfigError at the validation block. Same class of bug as P0-F
+        guard, then `round(threshold_mb * 0.6, 1)` (the soft-threshold default) does
+        an int*float multiply that raises a bare OverflowError downstream instead of
+        ConfigError at the validation block. Same class of bug as P0-F
         (coerce_positive_float). Fix: widen the gate to isinstance(_v, (int, float))
         so huge ints enter the try/except OverflowError path."""
         from cozempic.guard import start_guard

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -25,25 +25,32 @@ class TestPositiveFloatArgparseHelper:
 
     def test_positive_float_rejects_nan(self):
         """'nan' → float('nan') → bypasses <= 0 → silently returned.
-        RED at base: no exception raised."""
+        RED at base: no exception raised.
+        Also asserts the specific 'finite' discriminating word — ensures the NaN/inf
+        guard fires (not the generic type-guard or positivity check)."""
         try:
             result = _positive_float("nan")
             raise AssertionError(
                 f"Expected ArgumentTypeError but _positive_float returned {result!r}"
             )
-        except argparse.ArgumentTypeError:
-            pass  # expected
+        except argparse.ArgumentTypeError as e:
+            assert "finite" in str(e), (
+                f"expected 'finite' in error message, got: {e!r}"
+            )
 
     def test_positive_float_rejects_inf(self):
         """'inf' → float('inf') → bypasses <= 0 → silently returned.
-        RED at base: no exception raised."""
+        RED at base: no exception raised.
+        Also asserts the specific 'finite' discriminating word."""
         try:
             result = _positive_float("inf")
             raise AssertionError(
                 f"Expected ArgumentTypeError but _positive_float returned {result!r}"
             )
-        except argparse.ArgumentTypeError:
-            pass  # expected
+        except argparse.ArgumentTypeError as e:
+            assert "finite" in str(e), (
+                f"expected 'finite' in error message, got: {e!r}"
+            )
 
     def test_positive_float_rejects_negative_inf(self):
         """-inf is already caught by `f <= 0` at base (-inf <= 0 is True).
@@ -254,6 +261,87 @@ class TestStartGuardOrderingValidation:
             assert substr in str(e), f"expected {substr!r} in {e!r}"
             return
         raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
+
+
+class TestStartGuardNanInfValidation:
+    """NaN/inf bypass in guard.py belt-and-braces validators (H-1 fold).
+
+    start_guard and start_guard_daemon both validate thresholds before any
+    subprocess spawn, so direct-Python callers passing NaN/inf are the audience.
+    Argparse (now fixed via P0-B) only covers the CLI string path; these tests
+    cover the direct-Python-caller contract documented in start_guard's docstring.
+
+    RED at base: NaN/inf bypass `<= 0` (IEEE 754 semantics), no ConfigError raised.
+    These are bug-capture tests — must FAIL against the unmodified source.
+
+    start_guard: validation fires before session I/O; no mocking needed for nan/inf
+    (the raise happens at the top of the validation block, before find_current_session).
+    start_guard_daemon: validation fires before Popen, but we mock _cleanup_legacy_pid
+    and subprocess.Popen anyway — per isolate-subprocess-tests-by-design, never rely on
+    environmental accident (nonexistent cwd) for isolation.
+    """
+
+    # pytest-style: contextmanager mimic (same pattern as TestStartGuardOrderingValidation)
+    from contextlib import contextmanager
+
+    @contextmanager
+    def assertRaisesLike(self, exc_type, substr):
+        try:
+            yield
+        except exc_type as e:
+            assert substr in str(e), f"expected {substr!r} in {e!r}"
+            return
+        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
+
+    def test_start_guard_threshold_mb_nan_raises_config_error(self):
+        """start_guard(threshold_mb=float('nan')) must raise ConfigError with 'finite'.
+        RED at base: nan <= 0 is False, validation bypassed; ValueError raised downstream
+        at int(nan * 1024 * 1024) instead of ConfigError at the validation block."""
+        from cozempic.guard import start_guard
+        from cozempic._validation import ConfigError
+        with self.assertRaisesLike(ConfigError, "finite"):
+            start_guard(threshold_mb=float("nan"), cwd="/tmp/_cozempic_guard_nan_test")
+
+    def test_start_guard_threshold_mb_inf_raises_config_error(self):
+        """start_guard(threshold_mb=float('inf')) must raise ConfigError with 'finite'.
+        RED at base: inf <= 0 is False; OverflowError raised downstream at int(inf)
+        instead of ConfigError at the validation block."""
+        from cozempic.guard import start_guard
+        from cozempic._validation import ConfigError
+        with self.assertRaisesLike(ConfigError, "finite"):
+            start_guard(threshold_mb=float("inf"), cwd="/tmp/_cozempic_guard_nan_test")
+
+    def test_start_guard_daemon_threshold_mb_nan_raises_config_error(self):
+        """start_guard_daemon(threshold_mb=float('nan')) must raise ConfigError before spawn.
+        RED at base: nan <= 0 is False, validation silently passes, daemon spawned with nan.
+        Subprocess spawn is mocked per isolate-subprocess-tests-by-design."""
+        from cozempic.guard import start_guard_daemon
+        from cozempic._validation import ConfigError
+        with (
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+            patch("cozempic.guard.subprocess.Popen"),
+        ):
+            with self.assertRaisesLike(ConfigError, "finite"):
+                start_guard_daemon(
+                    threshold_mb=float("nan"), cwd="/tmp/_cozempic_guard_nan_test"
+                )
+
+    def test_start_guard_daemon_threshold_mb_inf_raises_config_error(self):
+        """start_guard_daemon(threshold_mb=float('inf')) must raise ConfigError before spawn.
+        RED at base: inf <= 0 is False, validation silently passes, daemon spawned with inf.
+        Subprocess spawn is mocked per isolate-subprocess-tests-by-design."""
+        from cozempic.guard import start_guard_daemon
+        from cozempic._validation import ConfigError
+        with (
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+            patch("cozempic.guard.subprocess.Popen"),
+        ):
+            with self.assertRaisesLike(ConfigError, "finite"):
+                start_guard_daemon(
+                    threshold_mb=float("inf"), cwd="/tmp/_cozempic_guard_nan_test"
+                )
 
 
 class TestReloadSessionFlag:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import io
 import contextlib
 import os
@@ -9,7 +10,59 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from cozempic.cli import _prescan_argv, build_parser, _digest_session
+from cozempic.cli import _prescan_argv, _positive_float, build_parser, _digest_session
+
+
+class TestPositiveFloatArgparseHelper:
+    """Direct unit tests for cli._positive_float argparse type= helper.
+
+    NaN/inf bypass: float("nan") and float("inf") both pass `f <= 0` (False
+    in IEEE 754), so the validator silently returns nan/inf.
+    RED at base: _positive_float("nan") returns nan instead of raising.
+    RED at base: _positive_float("inf") returns inf instead of raising.
+    These are bug-capture tests — must FAIL against the unmodified source.
+    """
+
+    def test_positive_float_rejects_nan(self):
+        """'nan' → float('nan') → bypasses <= 0 → silently returned.
+        RED at base: no exception raised."""
+        try:
+            result = _positive_float("nan")
+            raise AssertionError(
+                f"Expected ArgumentTypeError but _positive_float returned {result!r}"
+            )
+        except argparse.ArgumentTypeError:
+            pass  # expected
+
+    def test_positive_float_rejects_inf(self):
+        """'inf' → float('inf') → bypasses <= 0 → silently returned.
+        RED at base: no exception raised."""
+        try:
+            result = _positive_float("inf")
+            raise AssertionError(
+                f"Expected ArgumentTypeError but _positive_float returned {result!r}"
+            )
+        except argparse.ArgumentTypeError:
+            pass  # expected
+
+    def test_positive_float_rejects_negative_inf(self):
+        """-inf is already caught by `f <= 0` at base (-inf <= 0 is True).
+        GREEN at base — regression guard, not a RED/bug-capture test."""
+        try:
+            result = _positive_float("-inf")
+            raise AssertionError(
+                f"Expected ArgumentTypeError but _positive_float returned {result!r}"
+            )
+        except argparse.ArgumentTypeError:
+            pass  # expected
+
+    def test_positive_float_accepts_valid(self):
+        """Positive finite float must still be accepted after the fix."""
+        assert _positive_float("50.5") == 50.5
+
+    def test_positive_float_accepts_int_string(self):
+        """'50' (int string) is valid — user may write --threshold 50."""
+        assert _positive_float("50") == 50.0
 
 
 class TestPrescanArgvValidation:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -344,6 +344,102 @@ class TestStartGuardNanInfValidation:
                 )
 
 
+class TestReloadSelfDaemonNanInfValidation:
+    """NaN/inf bypass in reload_self_daemon — the critical third entry point (P0-D).
+
+    reload_self_daemon SIGTERMs/SIGKILLs the old daemon THEN calls
+    start_guard_daemon. Without a finite check BEFORE the kill, passing
+    threshold_mb=float('nan') kills the live daemon and then raises
+    ConfigError (from start_guard_daemon's validator), leaving the session
+    completely unprotected.
+
+    RED at base: reload_self_daemon calls os.kill before raising — daemon is
+    killed even though the new config is invalid. These tests must FAIL at
+    base and PASS after _validate_finite_thresholds() is called at the top
+    of reload_self_daemon.
+
+    All I/O between entry and the kill is mocked per isolate-subprocess-tests-by-design.
+    """
+
+    # pytest-style: contextmanager mimic
+    from contextlib import contextmanager
+
+    @contextmanager
+    def assertRaisesLike(self, exc_type, substr):
+        try:
+            yield
+        except exc_type as e:
+            assert substr in str(e), f"expected {substr!r} in {e!r}"
+            return
+        raise AssertionError(f"expected {exc_type.__name__}, nothing raised")
+
+    def _make_mocks(self):
+        """Return a context manager that mocks all I/O in reload_self_daemon
+        between the function entry and the os.kill call (inclusive).
+
+        Mocked:
+          - _is_guard_running_for_session → 99999 (fake PID — daemon appears running)
+          - _is_cozempic_guard_process     → True  (PID identity verified)
+          - os.kill                         → recorded, must NOT be called on nan/inf
+          - _wait_for_exit                  → True  (clean exit on SIGTERM)
+          - _pid_file_points_to             → False (CAS: leave pid file alone)
+          - _pid_file_for_session           → MagicMock (avoid real filesystem)
+          - start_guard_daemon              → {"started": True, "pid": 88888}
+        """
+        import contextlib
+        from unittest.mock import MagicMock, patch, call
+
+        @contextlib.contextmanager
+        def ctx():
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=99999),
+                patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+                patch("cozempic.guard.os.kill") as mock_kill,
+                patch("cozempic.guard._wait_for_exit", return_value=True),
+                patch("cozempic.guard._pid_file_points_to", return_value=False),
+                patch("cozempic.guard._pid_file_for_session", return_value=MagicMock()),
+                patch("cozempic.guard.start_guard_daemon",
+                      return_value={"started": True, "pid": 88888, "log_file": "/tmp/x.log"}),
+            ):
+                yield mock_kill
+
+        return ctx()
+
+    def test_reload_self_daemon_threshold_mb_nan_raises_before_kill(self):
+        """reload_self_daemon(threshold_mb=nan) must raise ConfigError BEFORE os.kill.
+
+        RED at base: no finite check exists at entry; os.kill fires on the live
+        daemon (99999), THEN start_guard_daemon raises ConfigError — session orphaned.
+        After fix: _validate_finite_thresholds fires first, os.kill is never called."""
+        from cozempic.guard import reload_self_daemon
+        from cozempic._validation import ConfigError
+        with self._make_mocks() as mock_kill:
+            with self.assertRaisesLike(ConfigError, "finite"):
+                reload_self_daemon(
+                    threshold_mb=float("nan"),
+                    session_id="00000000-0000-0000-0000-000000000001",
+                )
+        assert not mock_kill.called, (
+            "os.kill was called before ConfigError — daemon was killed with an invalid config"
+        )
+
+    def test_reload_self_daemon_threshold_mb_inf_raises_before_kill(self):
+        """reload_self_daemon(threshold_mb=inf) must raise ConfigError BEFORE os.kill.
+
+        RED at base: inf <= 0 is False; same orphan-daemon failure mode as nan."""
+        from cozempic.guard import reload_self_daemon
+        from cozempic._validation import ConfigError
+        with self._make_mocks() as mock_kill:
+            with self.assertRaisesLike(ConfigError, "finite"):
+                reload_self_daemon(
+                    threshold_mb=float("inf"),
+                    session_id="00000000-0000-0000-0000-000000000001",
+                )
+        assert not mock_kill.called, (
+            "os.kill was called before ConfigError — daemon was killed with an invalid config"
+        )
+
+
 class TestReloadSessionFlag:
     """Reload must accept --session as an escape hatch when auto-detect fails."""
 

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -334,6 +334,19 @@ class TestStartGuardNanInfValidation:
         with _assert_raises_like(ConfigError, "finite"):
             start_guard(threshold_mb=float("inf"), cwd=self._tmpdir)
 
+    def test_start_guard_threshold_mb_huge_int_raises_config_error(self):
+        """start_guard(threshold_mb=10**400) must raise ConfigError with 'finite'.
+
+        RED at base: isinstance gate skips ints entirely; 10**400 passes the float
+        guard, then int(10**400 * 1024 * 1024) raises a bare OverflowError downstream
+        instead of ConfigError at the validation block. Same class of bug as P0-F
+        (coerce_positive_float). Fix: widen the gate to isinstance(_v, (int, float))
+        so huge ints enter the try/except OverflowError path."""
+        from cozempic.guard import start_guard
+        from cozempic._validation import ConfigError
+        with _assert_raises_like(ConfigError, "finite"):
+            start_guard(threshold_mb=10**400, cwd=self._tmpdir)
+
     def test_start_guard_daemon_threshold_mb_nan_raises_config_error(self):
         """start_guard_daemon(threshold_mb=float('nan')) must raise ConfigError before spawn.
         RED at base: nan <= 0 is False, validation silently passes; execution reaches

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -85,6 +85,38 @@ class TestCoercePositiveFloat(unittest.TestCase):
         with self.assertRaises(ConfigError):
             coerce_positive_float({"mb": True}, "mb", default=10.0)
 
+    # ── NaN/inf bug-capture tests (RED at base — return nan/inf instead of raising) ──
+
+    def test_rejects_nan(self):
+        """NaN bypasses `<= 0` check (IEEE 754: NaN comparisons are always False).
+        RED at base: coerce_positive_float returns nan silently instead of raising."""
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": float("nan")}, "mb", default=1.0)
+
+    def test_rejects_positive_inf(self):
+        """Positive infinity bypasses `<= 0` check (inf <= 0 is False).
+        RED at base: coerce_positive_float returns inf silently instead of raising."""
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": float("inf")}, "mb", default=1.0)
+
+    def test_json_roundtrip_nan_raises(self):
+        """json.loads accepts NaN literals by default (CPython behaviour), so a
+        config.json with {"memory_threshold_mb": NaN} flows a real float('nan')
+        into config dicts.  This test documents and guards that real-world vector.
+        RED at base: json.loads succeeds, coerce_positive_float returns nan silently."""
+        import json
+        d = json.loads('{"x": NaN}')
+        with self.assertRaises(ConfigError):
+            coerce_positive_float(d, "x", default=1.0)
+
+    def test_rejects_negative_inf(self):
+        """Negative infinity is already caught at base via `value <= 0`
+        (-inf <= 0 is True).  Included as a regression guard to ensure the
+        NaN/inf fix does not accidentally un-guard this path.
+        GREEN at base — NOT a RED/bug-capture test."""
+        with self.assertRaises(ConfigError):
+            coerce_positive_float({"mb": float("-inf")}, "mb", default=1.0)
+
 
 class TestParseEnvPositiveInt(unittest.TestCase):
     """Env var helper: warn+fallback (does NOT raise). Used for

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -117,6 +117,20 @@ class TestCoercePositiveFloat(unittest.TestCase):
         with self.assertRaises(ConfigError):
             coerce_positive_float({"mb": float("-inf")}, "mb", default=1.0)
 
+    def test_rejects_huge_int_overflow(self):
+        """10**400 is a valid Python int but cannot be converted to float.
+
+        math.isnan(10**400) raises OverflowError ('int too large to convert to
+        float') rather than returning True/False.  Without an OverflowError
+        catch, the exception propagates as a bare OverflowError instead of a
+        ConfigError — wrong exception type, wrong message.
+
+        RED at base: math.isnan(10**400) raises OverflowError (uncaught);
+        the function does NOT raise ConfigError with 'finite'.
+        """
+        with self.assertRaisesRegex(ConfigError, "finite"):
+            coerce_positive_float({"mb": 10**400}, "mb", default=1.0)
+
 
 class TestParseEnvPositiveInt(unittest.TestCase):
     """Env var helper: warn+fallback (does NOT raise). Used for

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -90,23 +90,23 @@ class TestCoercePositiveFloat(unittest.TestCase):
     def test_rejects_nan(self):
         """NaN bypasses `<= 0` check (IEEE 754: NaN comparisons are always False).
         RED at base: coerce_positive_float returns nan silently instead of raising."""
-        with self.assertRaises(ConfigError):
+        with self.assertRaisesRegex(ConfigError, "finite"):
             coerce_positive_float({"mb": float("nan")}, "mb", default=1.0)
 
     def test_rejects_positive_inf(self):
         """Positive infinity bypasses `<= 0` check (inf <= 0 is False).
         RED at base: coerce_positive_float returns inf silently instead of raising."""
-        with self.assertRaises(ConfigError):
+        with self.assertRaisesRegex(ConfigError, "finite"):
             coerce_positive_float({"mb": float("inf")}, "mb", default=1.0)
 
     def test_json_roundtrip_nan_raises(self):
-        """json.loads accepts NaN literals by default (CPython behaviour), so a
-        config.json with {"memory_threshold_mb": NaN} flows a real float('nan')
+        """json.loads accepts NaN literals by default (CPython behaviour — allow_nan=True),
+        so a config.json with {"memory_threshold_mb": NaN} flows a real float('nan')
         into config dicts.  This test documents and guards that real-world vector.
         RED at base: json.loads succeeds, coerce_positive_float returns nan silently."""
         import json
-        d = json.loads('{"x": NaN}')
-        with self.assertRaises(ConfigError):
+        d = json.loads('{"x": NaN}')  # CPython json.loads accepts NaN (allow_nan=True default)
+        with self.assertRaisesRegex(ConfigError, "finite"):
             coerce_positive_float(d, "x", default=1.0)
 
     def test_rejects_negative_inf(self):


### PR DESCRIPTION
## Problem

`coerce_positive_float` (and its siblings) gate positivity with `value <= 0`. By IEEE-754, **every comparison with `NaN` is `False`**, and `inf <= 0` is also `False` — so `NaN`/`inf` slip past the guard and are returned/used as if valid. This silently poisons downstream numeric thresholds (a `NaN` threshold compares `False` to everything, effectively disabling the gate it controls).

The bypass exists at every place user-supplied positive numbers are coerced:

- **Config-dict path** — `_validation.coerce_positive_float`. Reachable via `~/.cozempic/config.json`: CPython's `json.loads` accepts the bare `NaN`/`Infinity` tokens by default, so `{"...": NaN}` flows a real `NaN` into a strategy/threshold config.
- **CLI path** — `cli._positive_float` (argparse `type=` for `--threshold` / `--soft-threshold`). `float("inf")`/`float("nan")` parse fine, so `cozempic guard --threshold inf` silently sets a non-finite MB threshold.
- **Guard daemon validators** — `start_guard`, `start_guard_daemon`, and `reload_self_daemon`. These belt-and-braces checks exist specifically to validate **direct Python callers that bypass argparse** (per their own docstrings), but `nan <= 0` / `nan >= hard` defeat them. `reload_self_daemon` is the worst case: it SIGTERMs/SIGKILLs the live daemon **first**, then would raise downstream — orphaning the session with no protection.

A non-representable huge `int` (e.g. `10**400`) is the same class: it survives the numeric type guard, then raises a bare `OverflowError` deep in arithmetic instead of a clean `ConfigError`.

## Fix

Reject non-finite (and non-representable) values **before** the positivity check, with a clear `"must be a finite number"` error — mirroring the existing `config.py:_clamp_float` convention. Zero new dependencies (`math.isfinite`, stdlib).

- `_validation.coerce_positive_float` → `ConfigError` for `NaN`/`inf`/huge-int.
- `cli._positive_float` → `argparse.ArgumentTypeError` for `NaN`/`inf`.
- `guard.py` → one shared `_validate_finite_thresholds(...)` helper (DRYs two previously byte-identical loops), called at the **top** of `start_guard`, `start_guard_daemon`, and `reload_self_daemon` — i.e. **before** `reload_self_daemon`'s destructive kill, so an invalid config can never orphan a live daemon.

## Tests

- Strict TDD: every bug-capture test proven RED at the PR base (returns `nan`/`inf` / raises `OverflowError`) before the fix, GREEN after.
- Daemon tests are isolated **by design** (mocked spawn claim + `mkdtemp`/teardown) — verified to create **zero** real `/tmp/cozempic_guard_*` pidfiles even when run against unpatched source.
- Full suite: **1104 passed, 0 failed, 5 skipped**.

## Scope

In scope: the positive-number coercion `NaN`/`inf`/huge-int bug class, at all four entry points.

Explicitly out of scope (intentional or pre-existing, different bug class):
- `config.py:_clamp_float` uses a clamp-to-default shape (degrade gracefully) vs the raise shape here — deliberate, not merged.
- Accepting `threshold_mb=True` (bool) — pre-existing type-validation gap, separate concern.
- numpy / `Decimal` numeric types — cozempic is zero-dependency; argparse/JSON produce builtin `float`/`int`, and there are no such callers.
