### PR TITLE
fix(guard): safe-point reload gate is blind to Agent-spawned agent teams

### DIFF
--- a/docs/qa-fleet.md
+++ b/docs/qa-fleet.md
@@ -76,14 +76,19 @@ validation + a floor (don't over-prune below a safe ratio). Refuse to prune an a
 in-flight session. Metadata-singleton protection. Team state survives compaction
 (checkpoint + PostCompact re-inject). *Motivating PRs: #114, #102, #22, #110.*
 
-### L8 — Reload safety (the 1.8.x guard line)  ·  standing tests: `tests/test_guard_safe_point.py`, `tests/test_interactive_*`
+### L8 — Reload safety (the 1.8.x guard line)  ·  standing tests: `tests/test_guard_safe_point.py`, `tests/test_interactive_*`, `tests/test_guard_team_agent_spawn.py`
 A reload SIGKILLs + resumes, so: NEVER reload through in-flight work (running Workflow
 / background `Agent` subagent / agent team / open tool call) — defer instead.
 Interactive: warn-before-reload, reload only at a sustained idle breakpoint, force only
 near the wall. Armed-sentinel lifecycle: cleared on **every** reload path
 (`_terminate_and_resume` choke point), atomic writes, no stale `warned` survives a
 reload. Markers must be matched to the REAL harness output (verify against live
-transcripts, not fixtures). *Motivating: the 1.8.19–1.8.23 guard line.*
+transcripts, not fixtures).
+Agent-spawn team visibility: `extract_team_state` must see teammates created via the
+`Agent` tool (not just `TeamCreate`). `safe_to_reload` must block when any teammate is
+non-benign/non-terminal, and must NOT be wedged by a stale cross-session TeamState
+(session anti-wedge). Standing test: `tests/test_guard_team_agent_spawn.py`.
+*Motivating: the 1.8.19–1.8.23 guard line; F1 fix (v1.8.24).*
 
 ### L9 — Error handling & hook protocol
 Hook commands NEVER block and ALWAYS exit 0 (a crash must not break the session); no

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2425,6 +2425,25 @@ def detect_in_flight(messages) -> dict:
     }
 
 
+def _team_is_current_session(team_state, session_path) -> bool:
+    """True if the TeamState belongs to the session currently being guarded.
+
+    A stale config.json from a prior session can present a non-quiescent
+    team_state (teammates still "running") long after those agents exited.
+    Comparing the state's lead_session_id to the guarded session's stem prevents
+    that stale state from wedging a reload of a completely different session.
+    Conservative: unknown session (None lead_session_id or None session_path)
+    is treated as current-session — we block the reload rather than skip the
+    check.
+    """
+    if not (team_state and team_state.lead_session_id):
+        return True  # unknown → conservative: treat as current
+    if session_path is None:
+        return True  # no path to compare → conservative
+    guarded = Path(session_path).stem
+    return team_state.lead_session_id == guarded
+
+
 def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
     """Validate-BEFORE-terminate safe-point gate (1.8.22 component B).
 
@@ -2472,8 +2491,13 @@ def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
             # terminal; if a completion never arrives the teammate stays non-benign
             # and we keep deferring — safe (PreCompact/PostCompact re-injects the
             # checkpoint at the wall).
-            if any((t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
-                   for t in (team_state.teammates or [])):
+            # Session anti-wedge (P0-E): stale config.json from a prior session
+            # must not hold the current session's reload hostage. Only enforce the
+            # teammate check when this TeamState actually belongs to our session.
+            if (_team_is_current_session(team_state, session_path)
+                    and any((t.status or "").strip().lower()
+                            not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+                            for t in (team_state.teammates or []))):
                 return (False, "teammate mid-execution")
             active_tasks, _, _ = team_state._task_groups()
             if active_tasks:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2447,14 +2447,18 @@ def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
         return (False, "background subagent running")
     if inflight["open_call"]:
         return (False, "open tool call (result not yet flushed)")
-    # Tracked team quiescence (TeamState). NOTE: we deliberately do NOT hard-block
-    # on teammate.status — TeamCreate sets it "running" and nothing in the
-    # extractor ever transitions it to terminal, so blocking on it wedged EVERY
-    # team session forever (the guard's primary use case). The reliable liveness
-    # signals are: subagent entries (which ARE updated by task-notification
-    # completions), active todo tasks (TaskUpdate-maintained), and the in-flight
-    # detector above — an actually-working teammate always shows up as one of
-    # those (a running subagent / open Agent call / un-completed Agent launch).
+    # Tracked team quiescence (TeamState). We DO hard-block on a non-benign
+    # teammate status: an Agent-spawned agent team (the guard's primary use case)
+    # is NOT reliably visible via subagent entries / open calls / un-completed
+    # launches — those markers fire for background subagents, not for `Agent`-tool
+    # teammates — so the teammate roster is the only signal that catches it, and
+    # this block is load-bearing (closing the F1 destroy-active-team gap). The
+    # extractor transitions a teammate to a terminal/idle (benign) status via
+    # task-notification + idle_notification (chronology-aware), and the
+    # idle-notification carrier is prune-protected (_is_team_message), so the
+    # clear signal survives a prune and the block no longer wedges. Subagent
+    # entries, active todo tasks, and the in-flight detector above remain
+    # complementary signals checked alongside it.
     if team_state is not None and not team_state.is_empty():
         try:
             # Subagent block — DENYLIST: any non-terminal status is treated as

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2425,25 +2425,6 @@ def detect_in_flight(messages) -> dict:
     }
 
 
-def _team_is_current_session(team_state, session_path) -> bool:
-    """True if the TeamState belongs to the session currently being guarded.
-
-    A stale config.json from a prior session can present a non-quiescent
-    team_state (teammates still "running") long after those agents exited.
-    Comparing the state's lead_session_id to the guarded session's stem prevents
-    that stale state from wedging a reload of a completely different session.
-    Conservative: unknown session (None lead_session_id or None session_path)
-    is treated as current-session — we block the reload rather than skip the
-    check.
-    """
-    if not (team_state and team_state.lead_session_id):
-        return True  # unknown → conservative: treat as current
-    if session_path is None:
-        return True  # no path to compare → conservative
-    guarded = Path(session_path).stem
-    return team_state.lead_session_id == guarded
-
-
 def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
     """Validate-BEFORE-terminate safe-point gate (1.8.22 component B).
 
@@ -2482,22 +2463,25 @@ def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
             if any((s.status or "").strip().lower() not in _STATUS_TERMINAL
                    for s in (team_state.subagents or [])):
                 return (False, "subagent mid-execution")
-            # Teammate block — DENYLIST too, but with a small benign-marker exempt
-            # set so an idle/config membership row can't wedge the gate. A teammate
-            # actively working (and with no subagent entry yet, in the
-            # SendMessage→completion window) reads "running" → caught HERE, closing
-            # the destroy-active-teammate gap. extract_team_state propagates
-            # completions to teammates (chronology-aware), so a finished team reads
-            # terminal; if a completion never arrives the teammate stays non-benign
-            # and we keep deferring — safe (PreCompact/PostCompact re-injects the
-            # checkpoint at the wall).
-            # Session anti-wedge (P0-E): stale config.json from a prior session
-            # must not hold the current session's reload hostage. Only enforce the
-            # teammate check when this TeamState actually belongs to our session.
-            if (_team_is_current_session(team_state, session_path)
-                    and any((t.status or "").strip().lower()
-                            not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
-                            for t in (team_state.teammates or []))):
+            # Teammate block — DENYLIST with a benign-marker exempt set so an
+            # idle/config membership row never wedges the gate.
+            #
+            # Safety invariant (replaces the removed P0-E _team_is_current_session
+            # gate, 2026-06-08):
+            #   A non-benign teammate status ("running") can ONLY originate from
+            #   THIS session's JSONL (Agent spawn / TeamCreate-inline / SendMessage).
+            #   merge_config_into_state hardcodes status="config" (∈ _TEAMMATE_BENIGN)
+            #   for members added from config.json — config-only members are always
+            #   benign and never block. Therefore the block can fire unconditionally
+            #   on any non-benign status without risk of a stale-config false-block.
+            #
+            #   The P0-E session-ID gate was removed because it was redundant (the
+            #   status mechanism is sufficient) AND could MISFIRE: a stale same-name
+            #   config.json could inject a different leadSessionId, causing the gate
+            #   to skip the block for a LIVE "running" teammate → false-safe SIGKILL.
+            if any((t.status or "").strip().lower()
+                   not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+                   for t in (team_state.teammates or [])):
                 return (False, "teammate mid-execution")
             active_tasks, _, _ = team_state._task_groups()
             if active_tasks:

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -914,9 +914,9 @@ def merge_config_into_state(state: TeamState, configs: list[dict] | None = None)
     #   A name-only match is unreliable for session-identity fields: team names are
     #   frequently reused across sessions (same project, same team composition). A
     #   stale config.json with the same name but an OLD leadSessionId would overwrite
-    #   state.lead_session_id, causing _team_is_current_session to return False for
-    #   the LIVE session → safe_to_reload returns (True, "quiescent") → SIGKILL of
-    #   a working live team (F1 reborn via the anti-wedge path).
+    #   state.lead_session_id; because safe_to_reload's teammate block fires on
+    #   status alone (not session ID) this would not cause a missed block, but it
+    #   pollutes the state with a stale identity field (F1 reborn via config path).
     #
     #   Strong joins (session ID / agent ID / member ID intersection) are anchored
     #   on identity that is guaranteed unique per session. Only a strong match
@@ -960,8 +960,8 @@ def merge_config_into_state(state: TeamState, configs: list[dict] | None = None)
     # Merge authoritative fields.
     # lead_session_id is session-identity — only overwrite from a strong join.
     # A name-only match may carry a STALE leadSessionId from a prior session that
-    # happened to use the same team name; importing it would corrupt the anti-wedge
-    # gate in safe_to_reload (_team_is_current_session). C-1 fix (2026-06-08).
+    # happened to use the same team name; importing it would pollute session-identity
+    # fields in TeamState with stale data. C-1 fix (2026-06-08).
     state.team_name = matched_config.get("name", state.team_name)
     state.lead_agent_id = matched_config.get("leadAgentId", state.lead_agent_id)
     if not _name_only_match:

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -525,7 +525,10 @@ def extract_team_state(messages: list[Message]) -> TeamState:
 
                 # TeamCreate (explicit team)
                 elif name == "TeamCreate":
-                    state.team_name = inp.get("name", state.team_name)
+                    # Real TeamCreate tool emits "team_name" key (verified from
+                    # production transcripts, 2026-06-08); "name" is the legacy key
+                    # kept as a fallback for backward compat.
+                    state.team_name = inp.get("name", inp.get("team_name", state.team_name))
                     for tm in inp.get("teammates", []):
                         agent_id = tm.get("agentId", tm.get("agent_id", ""))
                         tm_name = tm.get("name", agent_id)

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -386,6 +386,25 @@ _IDLE_NOTIFICATION_RE = re.compile(
 )
 
 
+def _extract_block_text(block: dict) -> str:
+    """Return the text payload of a tool-result block.
+
+    Handles both string content and the list-of-sub-blocks form
+    (``[{"type": "text", "text": "..."}]``).  Callers use this to avoid
+    duplicating the same isinstance chain for result_text extraction.
+    """
+    content = block.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            sub.get("text", "")
+            for sub in content
+            if isinstance(sub, dict) and sub.get("type") == "text"
+        )
+    return ""
+
+
 def _is_team_message(msg_dict: dict, pending_task_ids: set[str] | None = None) -> bool:
     """Check if a message is related to agent team coordination.
 
@@ -683,15 +702,7 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                 # Task tool result = subagent finished, capture result
                 if tool_name == "Task" or tool_use_id in tool_use_id_to_subagent:
                     subagent_key = tool_use_id_to_subagent.get(tool_use_id, "")
-                    result_text = ""
-
-                    result_content = block.get("content", "")
-                    if isinstance(result_content, str):
-                        result_text = result_content
-                    elif isinstance(result_content, list):
-                        for sub in result_content:
-                            if isinstance(sub, dict) and sub.get("type") == "text":
-                                result_text += sub.get("text", "")
+                    result_text = _extract_block_text(block)
 
                     if subagent_key and subagent_key in seen_subagents:
                         seen_subagents[subagent_key].status = "completed"
@@ -709,14 +720,7 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                 # Format: "Spawned successfully.\nagent_id: NAME@TEAM\n..."
                 # (verified from production transcripts 2026-06-08).
                 if tool_name == "Agent":
-                    result_text = ""
-                    rc = block.get("content", "")
-                    if isinstance(rc, str):
-                        result_text = rc
-                    elif isinstance(rc, list):
-                        for sub in rc:
-                            if isinstance(sub, dict) and sub.get("type") == "text":
-                                result_text += sub.get("text", "")
+                    result_text = _extract_block_text(block)
 
                     agent_id_m = _AGENT_SPAWN_ID_RE.search(result_text)
                     if agent_id_m:

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -391,11 +391,11 @@ def _is_team_message(msg_dict: dict, pending_task_ids: set[str] | None = None) -
 
     Handles these JSONL message types:
     - type='assistant': Tool use calls (Task, TaskCreate, etc.)
-    - type='user': Nested content with task-notification XML
+    - type='user': Nested content with task-notification or teammate-message XML
     - type='queue-operation': Root-level content with task-notification XML
     - Tool results matching known Task tool_use IDs (via pending_task_ids)
 
-    Detection is schema-first: tool_use block names and task-notification XML.
+    Detection is schema-first: tool_use block names and team XML patterns.
     TEAM_KEYWORDS is NOT used here — it is for enrichment (extract_team_state)
     only, to avoid false positives on messages that merely mention team concepts.
     """
@@ -429,8 +429,12 @@ def _is_team_message(msg_dict: dict, pending_task_ids: set[str] | None = None) -
                     return True
 
     elif isinstance(content, str):
-        # task-notification XML in user messages (agent results) — definitive signal
-        if "<task-notification>" in content:
+        # task-notification XML in user messages (agent results) — definitive signal.
+        # teammate-message XML (idle_notification, etc.) — also team-coordination:
+        # this carrier MUST be prune-protected so that idle transitions are not lost
+        # (a pruned idle_notification leaves the teammate permanently "running" →
+        # permanent safe_to_reload wedge — C-2 fix, 2026-06-08).
+        if "<task-notification>" in content or "<teammate-message" in content:
             return True
 
     return False
@@ -736,6 +740,16 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                             )
                             if bare and bare != real_agent_id:
                                 _name_to_agent_id[bare] = real_agent_id
+                    else:
+                        # No agent_id: in result → spawn failed or was rejected.
+                        # A tool_result with no parseable agentId is a completed-
+                        # with-no-agent event (quota error, harness rejection, etc.),
+                        # NOT an in-flight spawn. Drop/mark-terminal the placeholder
+                        # so the safe_to_reload gate is not permanently wedged.
+                        # H-1 fix (2026-06-08).
+                        placeholder = tool_use_id_to_subagent.get(tool_use_id, "")
+                        if placeholder and placeholder in seen_teammates:
+                            seen_teammates[placeholder].status = "failed"
                     # Parse team_name from result if not yet set
                     team_m = _AGENT_SPAWN_TEAM_RE.search(result_text)
                     if team_m and not state.team_name:
@@ -882,42 +896,65 @@ def merge_config_into_state(state: TeamState, configs: list[dict] | None = None)
             state.config_source = "jsonl"
         return state
 
-    # Match by team name if we have one from JSONL
+    # Match configs in two phases: strong joins first (session-identity-anchored),
+    # then name-only as a weaker fallback.
+    #
+    # Why two phases (C-1 fix, 2026-06-08):
+    #   A name-only match is unreliable for session-identity fields: team names are
+    #   frequently reused across sessions (same project, same team composition). A
+    #   stale config.json with the same name but an OLD leadSessionId would overwrite
+    #   state.lead_session_id, causing _team_is_current_session to return False for
+    #   the LIVE session → safe_to_reload returns (True, "quiescent") → SIGKILL of
+    #   a working live team (F1 reborn via the anti-wedge path).
+    #
+    #   Strong joins (session ID / agent ID / member ID intersection) are anchored
+    #   on identity that is guaranteed unique per session. Only a strong match
+    #   authorises overwriting lead_session_id; a name-only match may carry member
+    #   details (model, cwd) but must NOT overwrite session-identity fields.
     matched_config = None
+    _name_only_match = False  # True when matched by team name alone (weak join)
+
+    # Phase 1: strong joins — leadSessionId > leadAgentId > member ID intersection
+    known_agent_ids = (
+        {s.agent_id for s in state.subagents}
+        | {t.agent_id for t in state.teammates}
+    )
     for cfg in configs:
-        if state.team_name and cfg.get("name") == state.team_name:
+        if state.lead_session_id and cfg.get("leadSessionId") == state.lead_session_id:
             matched_config = cfg
             break
+        if state.lead_agent_id and cfg.get("leadAgentId") == state.lead_agent_id:
+            matched_config = cfg
+            break
+        if known_agent_ids:
+            cfg_member_ids = {m.get("agentId", "") for m in cfg.get("members", [])}
+            if known_agent_ids & cfg_member_ids:
+                matched_config = cfg
+                break
 
     if matched_config is None:
-        # Attempt strong joins: leadSessionId → leadAgentId → member ID intersection
-        known_agent_ids = (
-            {s.agent_id for s in state.subagents}
-            | {t.agent_id for t in state.teammates}
-        )
+        # Phase 2: name-only fallback — weaker; must not overwrite session-identity fields
         for cfg in configs:
-            if state.lead_session_id and cfg.get("leadSessionId") == state.lead_session_id:
+            if state.team_name and cfg.get("name") == state.team_name:
                 matched_config = cfg
+                _name_only_match = True
                 break
-            if state.lead_agent_id and cfg.get("leadAgentId") == state.lead_agent_id:
-                matched_config = cfg
-                break
-            if known_agent_ids:
-                cfg_member_ids = {m.get("agentId", "") for m in cfg.get("members", [])}
-                if known_agent_ids & cfg_member_ids:
-                    matched_config = cfg
-                    break
 
     if matched_config is None:
-        # No strong join — skip merge to avoid importing wrong team config
+        # No match on any join — skip merge
         if not state.config_source:
             state.config_source = "jsonl"
         return state
 
-    # Merge authoritative fields
+    # Merge authoritative fields.
+    # lead_session_id is session-identity — only overwrite from a strong join.
+    # A name-only match may carry a STALE leadSessionId from a prior session that
+    # happened to use the same team name; importing it would corrupt the anti-wedge
+    # gate in safe_to_reload (_team_is_current_session). C-1 fix (2026-06-08).
     state.team_name = matched_config.get("name", state.team_name)
     state.lead_agent_id = matched_config.get("leadAgentId", state.lead_agent_id)
-    state.lead_session_id = matched_config.get("leadSessionId", state.lead_session_id)
+    if not _name_only_match:
+        state.lead_session_id = matched_config.get("leadSessionId", state.lead_session_id)
     state.config_source = "both" if state.message_count > 0 else "config.json"
 
     # Merge member details

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -623,8 +623,10 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                 elif name == "TeamCreate":
                     # Real TeamCreate tool emits "team_name" key (verified from
                     # production transcripts, 2026-06-08); "name" is the legacy key
-                    # kept as a fallback for backward compat.
-                    state.team_name = inp.get("name", inp.get("team_name", state.team_name))
+                    # kept as a fallback for backward compat. Prefer the real key
+                    # so a transcript carrying BOTH (rollout overlap) uses the
+                    # authoritative "team_name", not the stale legacy "name".
+                    state.team_name = inp.get("team_name") or inp.get("name") or state.team_name
                     for tm in inp.get("teammates", []):
                         agent_id = tm.get("agentId", tm.get("agent_id", ""))
                         tm_name = tm.get("name", agent_id)
@@ -925,11 +927,16 @@ def merge_config_into_state(state: TeamState, configs: list[dict] | None = None)
     matched_config = None
     _name_only_match = False  # True when matched by team name alone (weak join)
 
-    # Phase 1: strong joins — leadSessionId > leadAgentId > member ID intersection
-    known_agent_ids = (
-        {s.agent_id for s in state.subagents}
-        | {t.agent_id for t in state.teammates}
-    )
+    # Phase 1: strong joins — leadSessionId > leadAgentId > member ID intersection.
+    # Empty ids are dropped: a malformed spawn (agent_id="") and a config member
+    # with no "agentId" both yield "", and {""} ∩ {""} would be a false strong
+    # match against an unrelated team's config.
+    known_agent_ids = {
+        aid for aid in (
+            {s.agent_id for s in state.subagents}
+            | {t.agent_id for t in state.teammates}
+        ) if aid
+    }
     for cfg in configs:
         if state.lead_session_id and cfg.get("leadSessionId") == state.lead_session_id:
             matched_config = cfg
@@ -938,7 +945,7 @@ def merge_config_into_state(state: TeamState, configs: list[dict] | None = None)
             matched_config = cfg
             break
         if known_agent_ids:
-            cfg_member_ids = {m.get("agentId", "") for m in cfg.get("members", [])}
+            cfg_member_ids = {m.get("agentId", "") for m in cfg.get("members", []) if m.get("agentId")}
             if known_agent_ids & cfg_member_ids:
                 matched_config = cfg
                 break

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -376,8 +376,15 @@ _AGENT_SPAWN_TEAM_RE = re.compile(
 
 # <teammate-message teammate_id="X">…</teammate-message> blocks in user messages.
 # Used in the second pass to parse idle_notification transitions (P0-D).
+#
+# Body group uses a negative-lookahead to stop before any nested <teammate-message
+# opening tag (M-1 fix, 2026-06-08). DOTALL alone was greedy enough to eat a nested
+# block, mis-attributing the inner idle_notification to the OUTER teammate_id.
+# The lookahead `(?!<teammate-message)` makes the body stop at the first inner tag.
 _TEAMMATE_MSG_RE = re.compile(
-    r'<teammate-message\s[^>]*teammate_id="([^"]+)"[^>]*>(.*?)</teammate-message>',
+    r'<teammate-message\s[^>]*teammate_id="([^"]+)"[^>]*>'
+    r'((?:(?!<teammate-message).)*?)'
+    r'</teammate-message>',
     re.DOTALL | re.IGNORECASE,
 )
 _IDLE_NOTIFICATION_RE = re.compile(

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -323,7 +323,12 @@ def build_team_recovery_receipt(state: TeamState) -> dict:
 
 # ─── Patterns for team message detection ─────────────────────────────────────
 
-# Tool names that indicate team/agent coordination
+# Tool names that indicate team/agent coordination.
+# NOTE: "Agent" is intentionally NOT included here. Adding it would cause
+# prune_with_team_protect (and _is_team_message) to protect ALL Agent tool_uses,
+# including plain non-team subagent calls — over-protecting non-team sessions.
+# extract_team_state uses _TEAM_EXTRACT_TOOL_NAMES (a superset) for its own
+# pre-pass; prune_with_team_protect uses this set via _is_team_message.
 TEAM_TOOL_NAMES = {
     # Explicit team coordination
     "TeamCreate", "TeamDelete", "TeamMessage", "SendMessage",
@@ -333,6 +338,11 @@ TEAM_TOOL_NAMES = {
     # Subagent spawning and results (Claude Code's Task tool)
     "Task", "TaskOutput", "TaskStop",
 }
+
+# Extended set for extract_team_state's pre-pass only — includes "Agent" so that
+# Agent tool_use + tool_result pairs are scanned for teammate creation. Must NOT
+# be used in _is_team_message (prune_with_team_protect path).
+_TEAM_EXTRACT_TOOL_NAMES = TEAM_TOOL_NAMES | {"Agent"}
 
 
 # Patterns for parsing task-notification XML in user messages
@@ -348,6 +358,30 @@ _TASK_NOTIFICATION_RE = re.compile(
 # Pattern for agent progress notifications in system-reminder tags
 _AGENT_PROGRESS_RE = re.compile(
     r"Agent\s+([a-f0-9]+)\s+progress:.*?(\d+)\s+new\s+tool",
+    re.IGNORECASE,
+)
+
+# Agent-spawn result format: "Spawned successfully.\nagent_id: NAME@TEAM\n..."
+# Verified from production transcripts 2026-06-08 (transcript 371f5917, line 196).
+# If the harness changes this format the regex will gracefully miss (fallback:
+# placeholder key retained; only terminal transitions are affected).
+_AGENT_SPAWN_ID_RE = re.compile(
+    r"agent_id:\s*([A-Za-z0-9@._-]+)",
+    re.IGNORECASE,
+)
+_AGENT_SPAWN_TEAM_RE = re.compile(
+    r"^team_name:\s*([A-Za-z0-9_-]+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# <teammate-message teammate_id="X">…</teammate-message> blocks in user messages.
+# Used in the second pass to parse idle_notification transitions (P0-D).
+_TEAMMATE_MSG_RE = re.compile(
+    r'<teammate-message\s[^>]*teammate_id="([^"]+)"[^>]*>(.*?)</teammate-message>',
+    re.DOTALL | re.IGNORECASE,
+)
+_IDLE_NOTIFICATION_RE = re.compile(
+    r'"type"\s*:\s*"idle_notification"',
     re.IGNORECASE,
 )
 
@@ -447,20 +481,52 @@ def extract_team_state(messages: list[Message]) -> TeamState:
     tool_use_id_to_name: dict[str, str] = {}
     # Track tool_use_id -> subagent key for Task tool results
     tool_use_id_to_subagent: dict[str, str] = {}
+    # Track bare teammate name -> agentId for SendMessage bare-name resolution (P0-C)
+    # and idle_notification resolution (P0-D). Populated when a TeammateInfo is
+    # inserted into seen_teammates with a known bare name.
+    _name_to_agent_id: dict[str, str] = {}
 
     # Pre-pass: collect all team tool_use IDs so _is_team_message can match
-    # their corresponding tool_result messages (task completions, etc.)
+    # their corresponding tool_result messages (task completions, etc.).
+    # Uses _TEAM_EXTRACT_TOOL_NAMES (includes "Agent") so Agent spawn results
+    # are also scanned; _is_team_message itself still uses TEAM_TOOL_NAMES only.
     pending_task_ids: set[str] = set()
     for _, msg, _ in messages:
         inner = msg.get("message", {})
         for block in (inner.get("content", []) if isinstance(inner.get("content"), list) else []):
-            if block.get("type") == "tool_use" and block.get("name") in TEAM_TOOL_NAMES:
+            if block.get("type") == "tool_use" and block.get("name") in _TEAM_EXTRACT_TOOL_NAMES:
                 uid = block.get("id", "")
                 if uid:
                     pending_task_ids.add(uid)
 
+    def _is_extract_message(m: dict) -> bool:
+        """Like _is_team_message but uses _TEAM_EXTRACT_TOOL_NAMES (includes 'Agent').
+
+        Used only inside extract_team_state so that Agent tool_use blocks are
+        processed for teammate creation. prune_with_team_protect's call to
+        _is_team_message is unaffected (uses TEAM_TOOL_NAMES only).
+        """
+        if m.get("type") == "queue-operation":
+            rc = m.get("content", "")
+            return isinstance(rc, str) and "<task-notification>" in rc
+        inner_m = m.get("message", {})
+        c = inner_m.get("content", [])
+        if isinstance(c, list):
+            for blk in c:
+                if not isinstance(blk, dict):
+                    continue
+                bt = blk.get("type", "")
+                if bt == "tool_use" and blk.get("name") in _TEAM_EXTRACT_TOOL_NAMES:
+                    return True
+                if bt == "tool_result" and pending_task_ids:
+                    if blk.get("tool_use_id", "") in pending_task_ids:
+                        return True
+        elif isinstance(c, str):
+            return "<task-notification>" in c
+        return False
+
     for line_idx, msg, byte_size in messages:
-        if not _is_team_message(msg, pending_task_ids):
+        if not _is_extract_message(msg):
             continue
 
         state.message_count += 1
@@ -540,6 +606,29 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                                 role=role,
                                 status="running",
                             )
+                            # Populate name → agentId index for bare-name lookups
+                            if tm_name and tm_name != agent_id:
+                                _name_to_agent_id[tm_name] = agent_id
+
+                # Agent tool = teammate spawn via the Agent tool (not Task tool).
+                # The real agentId and team_name are in the tool_result text;
+                # create a placeholder entry now so the spawn is immediately
+                # visible; the result handler below upgrades to the real agentId.
+                elif name == "Agent":
+                    agent_name = inp.get("name", "")
+                    agent_role = inp.get("role", inp.get("description", ""))
+                    # Placeholder key: use tool_use_id if available, else name.
+                    # The result handler re-keys by the real agentId.
+                    placeholder = tool_use_id or agent_name or f"agent-{len(seen_teammates)}"
+                    if placeholder not in seen_teammates:
+                        seen_teammates[placeholder] = TeammateInfo(
+                            agent_id=placeholder,
+                            name=agent_name,
+                            role=agent_role,
+                            status="running",  # non-benign, non-terminal → blocks reload
+                        )
+                    if tool_use_id:
+                        tool_use_id_to_subagent[tool_use_id] = placeholder
 
                 # TaskCreate (shared todo list)
                 elif name == "TaskCreate":
@@ -573,9 +662,14 @@ def extract_team_state(messages: list[Message]) -> TeamState:
 
                 elif name in ("SendMessage", "TeamMessage"):
                     target = inp.get("to", inp.get("agentId", ""))
-                    if target and target in seen_teammates:
-                        seen_teammates[target].status = "running"
-                        last_send_line[target] = line_idx
+                    # Resolve bare name to agentId (P0-C): SendMessage carries a
+                    # bare name ("alice") but seen_teammates is keyed by full
+                    # agentId ("alice@myteam"). The _name_to_agent_id index bridges
+                    # the gap; fall back to the literal target if not in index.
+                    resolved = _name_to_agent_id.get(target, target)
+                    if resolved in seen_teammates:
+                        seen_teammates[resolved].status = "running"
+                        last_send_line[resolved] = line_idx
 
             # ── Tool result blocks ───────────────────────────────────
             elif block_type == "tool_result":
@@ -607,11 +701,53 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                         agent.agent_id = real_id
                         seen_subagents[real_id] = agent
 
-    # ── Second pass: scan for task-notification messages ────────────
-    # These appear in two places:
-    #   1. User messages: msg['message']['content'] as string with XML
-    #   2. Queue-operation messages: msg['content'] at root level with XML
-    # Both carry the real result text (not just "Async agent launched").
+                # Agent tool result: parse real agentId + team_name from spawn text.
+                # Format: "Spawned successfully.\nagent_id: NAME@TEAM\n..."
+                # (verified from production transcripts 2026-06-08).
+                if tool_name == "Agent":
+                    result_text = ""
+                    rc = block.get("content", "")
+                    if isinstance(rc, str):
+                        result_text = rc
+                    elif isinstance(rc, list):
+                        for sub in rc:
+                            if isinstance(sub, dict) and sub.get("type") == "text":
+                                result_text += sub.get("text", "")
+
+                    agent_id_m = _AGENT_SPAWN_ID_RE.search(result_text)
+                    if agent_id_m:
+                        real_agent_id = agent_id_m.group(1).strip()
+                        # Re-key placeholder entry by real agentId
+                        placeholder = tool_use_id_to_subagent.get(tool_use_id, "")
+                        if placeholder and placeholder in seen_teammates:
+                            tm = seen_teammates.pop(placeholder)
+                            tm.agent_id = real_agent_id
+                            seen_teammates[real_agent_id] = tm
+                            # Populate name → agentId index for bare-name resolution
+                            if tm.name and tm.name != real_agent_id:
+                                _name_to_agent_id[tm.name] = real_agent_id
+                        elif real_agent_id not in seen_teammates:
+                            # No placeholder — insert directly (robustness)
+                            bare = real_agent_id.split("@")[0] if "@" in real_agent_id else real_agent_id
+                            seen_teammates[real_agent_id] = TeammateInfo(
+                                agent_id=real_agent_id,
+                                name=bare,
+                                status="running",
+                            )
+                            if bare and bare != real_agent_id:
+                                _name_to_agent_id[bare] = real_agent_id
+                    # Parse team_name from result if not yet set
+                    team_m = _AGENT_SPAWN_TEAM_RE.search(result_text)
+                    if team_m and not state.team_name:
+                        state.team_name = team_m.group(1).strip()
+
+    # ── Second pass: scan for task-notifications and idle-notifications ──
+    # Both XML patterns live in string content (user messages or queue-operations).
+    # Combining them in one pass avoids a third full-transcript scan.
+    #
+    # Sources:
+    #   task-notification — <task-notification>…</task-notification> (subagent done)
+    #   idle_notification — <teammate-message teammate_id="X">{"type":"idle_notification"…}
     for line_idx, msg, byte_size in messages:
         # Extract content string from either schema
         if msg.get("type") == "queue-operation":
@@ -620,10 +756,10 @@ def extract_team_state(messages: list[Message]) -> TeamState:
             inner = msg.get("message", {})
             content = inner.get("content", "")
 
-        # task-notifications are string content
-        if not isinstance(content, str) or "<task-notification>" not in content:
+        if not isinstance(content, str):
             continue
 
+        # ── task-notifications ────────────────────────────────────────────
         for match in _TASK_NOTIFICATION_RE.finditer(content):
             task_id = match.group(1).strip()
             status = match.group(2).strip()
@@ -645,19 +781,34 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                     result_summary=result[:300],
                 )
 
-            # Propagate the terminal status to the TEAMMATE of the same agent_id.
-            # Without this, TeamCreate/SendMessage left teammate.status stuck at
-            # "running" forever (nothing transitioned it), so the safe-point reload
-            # gate could never recognize a finished team as quiesced — every
-            # agent-team session (the guard's primary use case) would never reload.
-            if task_id in seen_teammates and line_idx >= last_send_line.get(task_id, -1):
-                # Only mark terminal if this completion is the teammate's LATEST
-                # event. A SendMessage after this notification means the teammate
-                # was re-activated (working phase 2) → keep it 'running' so the
-                # safe-point gate still blocks a reload (don't destroy live work).
-                seen_teammates[task_id].status = status
+            # Propagate terminal status to the matching TEAMMATE.
+            # Resolve bare task_id → real agentId when the notification carries
+            # only the bare name (e.g. "alice" instead of "alice@myteam").
+            resolved_tid = _name_to_agent_id.get(task_id, task_id)
+            for candidate in (task_id, resolved_tid):
+                if candidate in seen_teammates and line_idx >= last_send_line.get(candidate, -1):
+                    # Only mark terminal when this is the teammate's LATEST event.
+                    # A SendMessage after this notification means re-activation
+                    # (phase 2) → keep "running" so the gate keeps blocking.
+                    seen_teammates[candidate].status = status
+                    break
 
             state.message_count += 1
+
+        # ── idle-notifications (P0-D) ────────────────────────────────────
+        # <teammate-message teammate_id="X">{"type":"idle_notification",...}</teammate-message>
+        # Transition status to "idle" UNLESS a later SendMessage re-activated it.
+        for tm_match in _TEAMMATE_MSG_RE.finditer(content):
+            tm_id = tm_match.group(1).strip()
+            tm_body = tm_match.group(2)
+            if not _IDLE_NOTIFICATION_RE.search(tm_body):
+                continue
+            resolved = _name_to_agent_id.get(tm_id, tm_id)
+            if resolved in seen_teammates:
+                # Chronology guard: SendMessage after this line re-activates
+                # the teammate — don't clobber "running" back to "idle".
+                if line_idx >= last_send_line.get(resolved, -1):
+                    seen_teammates[resolved].status = "idle"
 
     state.teammates = list(seen_teammates.values())
     state.subagents = list(seen_subagents.values())

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -507,7 +507,12 @@ class TestFullScenario(unittest.TestCase):
     """
 
     def _pure_sendmessage_msgs(self, n_spawns=3):
-        """Build a message list with n Agent spawns + SendMessages, no TaskCreate."""
+        """Build a message list with n Agent spawns + SendMessages, no TaskCreate.
+
+        Every tool_use must have a matching tool_result so that
+        detect_in_flight.open_call stays False; otherwise open-call detection
+        returns False for the wrong reason, masking the teammate gate under test.
+        """
         msgs = []
         idx = 0
         # TeamCreate with 'team_name' key (P0-A trigger)
@@ -515,6 +520,9 @@ class TestFullScenario(unittest.TestCase):
             "team_name": "myteam",
             "description": "test team",
         }), 100))
+        idx += 1
+        # TeamCreate result (required to close the open_call for u0)
+        msgs.append((idx, _tool_result("u0", "Team created successfully."), 50))
         idx += 1
         # n Agent spawns (P0-B trigger)
         for i in range(1, n_spawns + 1):
@@ -532,12 +540,19 @@ class TestFullScenario(unittest.TestCase):
             idx += 1
             msgs.append((idx, _tool_result(f"us{i}", spawn_result), 300))
             idx += 1
-        # SendMessages to each (P0-C trigger: bare names)
+        # SendMessages to each (P0-C trigger: bare names).
+        # Each SendMessage must have a matching tool_result so that
+        # detect_in_flight.open_call stays False.  Without the result the
+        # un-paired tool_use id lands in use_ids - res_ids → open_call=True →
+        # safe_to_reload returns False for the WRONG reason (open tool call
+        # instead of active teammate), masking the teammate-based gate under test.
         for i in range(1, n_spawns + 1):
             msgs.append((idx, _tool_use(f"um{i}", "SendMessage", {
                 "to": f"finder-p{i}",
                 "message": "start your task",
             }), 100))
+            idx += 1
+            msgs.append((idx, _tool_result(f"um{i}", "Message delivered."), 50))
             idx += 1
         return msgs
 

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -5,12 +5,17 @@ any fix is applied; characterization / invariant-preservation tests that pass at
 base are clearly labelled as such in their docstrings.
 
 Test classes:
-  TestTeamNameExtraction         — P0-A: team_name key mismatch
-  TestAgentSpawnRecognition      — P0-B: Agent tool recognition in extract_team_state
-  TestSendMessageByNameLookup    — P0-C: by-name SendMessage resolution
-  TestIdleNotificationTransition — P0-D: idle_notification terminal transition
-  TestSessionScopedAntiWedge     — P0-E: session-scoped anti-wedge in safe_to_reload
-  TestFullScenario               — integration: pure-SendMessage team, no shared tasks
+  TestTeamNameExtraction           — P0-A: team_name key mismatch
+  TestAgentSpawnRecognition        — P0-B: Agent tool recognition in extract_team_state
+  TestSendMessageByNameLookup      — P0-C: by-name SendMessage resolution
+  TestIdleNotificationTransition   — P0-D: idle_notification terminal transition
+  TestStatusBasedSafetyInvariant   — documents status-only invariant (P0-E gate removed)
+  TestFullScenario                 — integration: pure-SendMessage team, no shared tasks
+  TestStaleConfigAntiWedge         — C-1: stale config can't inject "running" status
+  TestIdleNotificationPruneProtection — C-2: idle carrier prune protection
+  TestFailedAgentSpawnNoWedge      — H-1: failed spawn placeholder cleanup
+  TestGateRemoval                  — C-1 gate-removal regression guards
+  TestNestedTeammateMessageRegex   — M-1: nested teammate-message regex tightening
 
 Isolation:
   All tests go through _extract() which patches load_team_configs to return []
@@ -413,84 +418,84 @@ class TestIdleNotificationTransition(unittest.TestCase):
                          f"Prose teammate-message must NOT transition to benign, got {s!r}")
 
 
-# ─── TestSessionScopedAntiWedge (P0-E) ───────────────────────────────────────
+# ─── TestStatusBasedSafetyInvariant (documents gate-removal safety) ───────────
 
-class TestSessionScopedAntiWedge(unittest.TestCase):
-    """P0-E: stale/cross-session config must NOT block safe_to_reload.
+class TestStatusBasedSafetyInvariant(unittest.TestCase):
+    """Documents the safety invariant that makes removing _team_is_current_session safe.
 
-    A stale team's config.json persisting on disk with non-benign teammates
-    must be silently bypassed when the team belongs to a different session.
+    The invariant: a non-benign ("running") teammate status can ONLY originate from
+    THIS session's JSONL (Agent spawn / TeamCreate / SendMessage in this transcript).
+    merge_config_into_state always assigns status="config" (∈ _TEAMMATE_BENIGN) to
+    config-only members. So "running" = current-session, always. No session-ID
+    comparison is needed.
+
+    The removed P0-E gate was both redundant AND a source of false-safes (C-1): a
+    stale same-name config could inject a different leadSessionId, causing the gate to
+    skip the block for a LIVE "running" teammate → (True,'quiescent') → SIGKILL.
     """
 
-    def test_stale_cross_session_team_does_not_wedge_reload(self):
-        """REGRESSION GUARD — RED at base: no session-scope check; 'running' teammate wedges.
+    def test_running_teammate_always_blocks_regardless_of_session_id(self):
+        """INVARIANT: any non-benign status blocks, regardless of lead_session_id.
 
-        A TeamState with lead_session_id that does NOT match the session_path.stem
-        must NOT block safe_to_reload. Only the current session's team matters.
+        No session-ID comparison needed — "running" can only come from this session.
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        # Even with a completely arbitrary lead_session_id, "running" must block.
+        for session_id in ("", "old-session", "aabbccdd", None):
+            state = TeamState(
+                team_name="myteam",
+                lead_session_id=session_id or "",
+                teammates=[TeammateInfo("alice@myteam", "alice", status="running")],
+            )
+            safe, reason = safe_to_reload(state, [], Path("/tmp/anysession.jsonl"))
+            self.assertFalse(
+                safe,
+                f"'running' teammate must block regardless of lead_session_id={session_id!r}; "
+                f"got safe={safe}, reason={reason!r}"
+            )
+
+    def test_config_only_teammate_never_blocks(self):
+        """INVARIANT: config-only member (status='config', from merge_config_into_state)
+        must never block safe_to_reload.
+
+        merge_config_into_state assigns status='config' to members not seen in JSONL.
+        'config' ∈ _TEAMMATE_BENIGN. This is the mechanism that prevents stale
+        configs from wedging reloads — not a session-ID comparison.
         """
         from cozempic.guard import safe_to_reload
         from cozempic.team import TeamState, TeammateInfo
         state = TeamState(
             team_name="old-team",
-            lead_session_id="deadbeef-0000-0000-0000-000000000000",
-            teammates=[TeammateInfo("alice@old-team", "alice", status="running")],
+            teammates=[TeammateInfo("alice@old-team", "alice", status="config")],
         )
-        # Current session has a DIFFERENT id in the path stem
-        session_path = Path("/tmp/aabbccdd1234abcd.jsonl")
-        safe, reason = safe_to_reload(state, [], session_path)
+        safe, _ = safe_to_reload(state, [], Path("/tmp/anysession.jsonl"))
         self.assertTrue(safe,
-                        "Stale/cross-session running teammate must NOT wedge reload; "
-                        f"got safe={safe}, reason={reason!r}")
+                        "config-only member (status='config') must never block reload")
 
-    def test_same_session_running_teammate_blocks_reload(self):
-        """INVARIANT (GREEN at base — blocks; correct reason after fix):
-        when lead_session_id matches the guarded session, a running teammate blocks.
-
-        This is an invariant-preservation test, not a regression guard.
-        """
+    def test_idle_teammate_never_blocks(self):
+        """INVARIANT: idle teammate (status='idle', from idle_notification) is benign."""
         from cozempic.guard import safe_to_reload
         from cozempic.team import TeamState, TeammateInfo
         state = TeamState(
-            team_name="live-team",
-            lead_session_id="aabbccdd1234abcd",
-            teammates=[TeammateInfo("alice@live-team", "alice", status="running")],
+            team_name="myteam",
+            teammates=[TeammateInfo("alice@myteam", "alice", status="idle")],
         )
-        session_path = Path("/tmp/aabbccdd1234abcd.jsonl")
-        safe, reason = safe_to_reload(state, [], session_path)
-        self.assertFalse(safe,
-                         "Same-session running teammate must block reload")
-        self.assertIn("teammate", reason)
+        safe, _ = safe_to_reload(state, [], Path("/tmp/anysession.jsonl"))
+        self.assertTrue(safe, "idle teammate must not block reload")
 
-    def test_no_session_id_in_state_is_conservative(self):
-        """INVARIANT (GREEN at base): empty lead_session_id → conservative → blocks.
-
-        Unknown session → assume it IS the current session → block if running.
-        Safe-fail mode.
-        """
-        from cozempic.guard import safe_to_reload
+    def test_terminal_teammate_never_blocks(self):
+        """INVARIANT: terminal status (completed/failed/done) never blocks."""
+        from cozempic.guard import safe_to_reload, _STATUS_TERMINAL
         from cozempic.team import TeamState, TeammateInfo
-        state = TeamState(
-            team_name="unknown-team",
-            lead_session_id="",
-            teammates=[TeammateInfo("alice@unknown-team", "alice", status="running")],
-        )
-        session_path = Path("/tmp/aabbccdd1234abcd.jsonl")
-        safe, _ = safe_to_reload(state, [], session_path)
-        self.assertFalse(safe,
-                         "Unknown lead_session_id must be conservative → blocks reload")
-
-    def test_none_session_path_is_conservative(self):
-        """INVARIANT: session_path=None → cannot compare → conservative → blocks."""
-        from cozempic.guard import safe_to_reload
-        from cozempic.team import TeamState, TeammateInfo
-        state = TeamState(
-            team_name="t",
-            lead_session_id="some-session-id",
-            teammates=[TeammateInfo("a1", "alice", status="running")],
-        )
-        safe, _ = safe_to_reload(state, [], None)
-        self.assertFalse(safe,
-                         "session_path=None must be conservative → blocks reload")
+        for status in sorted(_STATUS_TERMINAL)[:3]:
+            state = TeamState(
+                team_name="myteam",
+                teammates=[TeammateInfo("alice@myteam", "alice", status=status)],
+            )
+            safe, _ = safe_to_reload(state, [], Path("/tmp/anysession.jsonl"))
+            self.assertTrue(safe,
+                            f"terminal status={status!r} must not block reload")
 
 
 # ─── TestFullScenario (integration) ──────────────────────────────────────────
@@ -612,12 +617,16 @@ class TestFullScenario(unittest.TestCase):
 # ─── TestStaleConfigAntiWedge (C-1 regression guards) ───────────────────────
 
 class TestStaleConfigAntiWedge(unittest.TestCase):
-    """C-1 (CRITICAL): Stale same-name config.json overwrites lead_session_id →
-    _team_is_current_session returns False for the LIVE session →
-    safe_to_reload returns (True, 'quiescent') → SIGKILL of working team.
+    """C-1 (CRITICAL): The now-removed P0-E _team_is_current_session gate could be
+    fooled by a stale same-name config.json injecting an old leadSessionId, causing
+    it to return (True,'quiescent') for a live team → SIGKILL.
 
-    These tests are REGRESSION GUARDs — RED at base (confirmed: stale config
-    overwrites lead_session_id via merge_config_into_state name-join).
+    The fix (gate removal + C-1 name-join guard in merge_config_into_state) means:
+    - extract_team_state still returns teammates with "running" status (from JSONL)
+    - safe_to_reload blocks unconditionally on any non-benign status
+    - stale config can inject at most "config" status members (benign) — never "running"
+
+    These tests are REGRESSION GUARDs proving the fix end-to-end.
     """
 
     _SPAWN_RESULT = (

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -609,5 +609,218 @@ class TestFullScenario(unittest.TestCase):
                         "After ALL idle_notifications, safe_to_reload must return True")
 
 
+# ─── TestStaleConfigAntiWedge (C-1 regression guards) ───────────────────────
+
+class TestStaleConfigAntiWedge(unittest.TestCase):
+    """C-1 (CRITICAL): Stale same-name config.json overwrites lead_session_id →
+    _team_is_current_session returns False for the LIVE session →
+    safe_to_reload returns (True, 'quiescent') → SIGKILL of working team.
+
+    These tests are REGRESSION GUARDs — RED at base (confirmed: stale config
+    overwrites lead_session_id via merge_config_into_state name-join).
+    """
+
+    _SPAWN_RESULT = (
+        "Spawned successfully.\n"
+        "agent_id: finder-p1@myteam\n"
+        "name: finder-p1\n"
+        "team_name: myteam\n"
+        "The agent is now running."
+    )
+
+    _STALE_CONFIG = {
+        "name": "myteam",
+        "leadSessionId": "OLD-SESSION-1111",
+        "leadAgentId": "team-lead@myteam",
+        "members": [],
+    }
+
+    def _stale_spawn_msgs(self):
+        return [
+            (0, _tool_use("u0", "TeamCreate", {"team_name": "myteam"}), 100),
+            (1, _tool_result("u0", "Team created."), 50),
+            (2, _tool_use("u1", "Agent", {"name": "finder-p1"}), 200),
+            (3, _tool_result("u1", self._SPAWN_RESULT), 300),
+        ]
+
+    def test_stale_same_name_config_does_not_allow_false_safe_reload(self):
+        """REGRESSION GUARD — RED at base: stale same-name config overwrites
+        lead_session_id → _team_is_current_session(live_path) returns False →
+        safe_to_reload returns (True, 'quiescent') → SIGKILL of live team.
+
+        The live session JSONL stem ('LIVE-SESSION-2222') differs from the
+        stale config's leadSessionId ('OLD-SESSION-1111'). After the C-1 fix,
+        merge_config_into_state must NOT overwrite lead_session_id when the
+        config was matched only by team name (not by session identity).
+        """
+        from cozempic.guard import safe_to_reload
+        msgs = self._stale_spawn_msgs()
+        live_path = Path("/tmp/LIVE-SESSION-2222.jsonl")
+
+        with unittest.mock.patch(
+            "cozempic.team.load_team_configs", return_value=[self._STALE_CONFIG]
+        ):
+            from cozempic.team import extract_team_state
+            state = extract_team_state(msgs)
+
+        # After fix: lead_session_id must NOT be overwritten by stale config's value
+        # (or _team_is_current_session must otherwise still block correctly)
+        safe, reason = safe_to_reload(state, msgs, live_path)
+        self.assertFalse(
+            safe,
+            "Stale same-name config must NOT cause safe_to_reload to return True "
+            f"for a live session with active teammates; got safe={safe}, reason={reason!r}"
+        )
+
+    def test_live_matching_config_still_blocks(self):
+        """INVARIANT: a config.json that IS the live session (leadSessionId matches
+        session_path.stem) must still cause safe_to_reload to block.
+
+        This test is GREEN at base (wrong reason); after fix it must stay GREEN
+        for the right reason (same session → block).
+        """
+        from cozempic.guard import safe_to_reload
+        msgs = self._stale_spawn_msgs()
+        live_path = Path("/tmp/LIVE-SESSION-2222.jsonl")
+        matching_config = {
+            "name": "myteam",
+            "leadSessionId": "LIVE-SESSION-2222",  # matches the live path
+            "leadAgentId": "team-lead@myteam",
+            "members": [],
+        }
+        with unittest.mock.patch(
+            "cozempic.team.load_team_configs", return_value=[matching_config]
+        ):
+            from cozempic.team import extract_team_state
+            state = extract_team_state(msgs)
+
+        safe, reason = safe_to_reload(state, msgs, live_path)
+        self.assertFalse(
+            safe,
+            "Live-matching config must still cause safe_to_reload to block; "
+            f"got safe={safe}, reason={reason!r}"
+        )
+
+
+# ─── TestIdleNotificationPruneProtection (C-2 regression guards) ─────────────
+
+class TestIdleNotificationPruneProtection(unittest.TestCase):
+    """C-2 (CRITICAL): idle_notification carrier message is not prune-protected
+    (_is_team_message returns False for it). If pruned, the teammate stays
+    'running' forever → permanent safe_to_reload wedge.
+
+    The fix: add '<teammate-message' string pattern to _is_team_message alongside
+    the existing '<task-notification' pattern.
+    """
+
+    def test_idle_notification_carrier_is_team_message(self):
+        """REGRESSION GUARD — RED at base: _is_team_message returns False for a
+        user message whose content is a <teammate-message> XML string.
+
+        After fix: _is_team_message returns True → carrier is prune-protected.
+        """
+        from cozempic.team import _is_team_message
+        idle_carrier = _user_content(
+            '<teammate-message teammate_id="finder-p1@myteam" summary="idle">'
+            '{"type":"idle_notification","from":"finder-p1","idleReason":"available"}'
+            '</teammate-message>'
+        )
+        self.assertTrue(
+            _is_team_message(idle_carrier, set()),
+            "_is_team_message must return True for an idle_notification carrier "
+            "so it is prune-protected and cannot be lost to compaction"
+        )
+
+    def test_idle_notification_pruned_away_does_not_wedge(self):
+        """REGRESSION GUARD — RED at base: if idle_notification is dropped from
+        the message list, the teammate stays 'running' → permanent reload wedge.
+
+        After fix: either the carrier is prune-protected (C-2 fix) or the extract
+        logic handles the absent carrier gracefully (out-of-scope for this PR).
+        This test verifies the PROTECTION path: after fix, the carrier survives
+        prune_with_team_protect and idle_notification is correctly parsed.
+        """
+        from cozempic.team import _is_team_message
+        # The assertion is that the carrier message is protected (is_team_message=True).
+        # If the carrier is protected, it cannot be dropped by prune → wedge can't occur.
+        # This is the same assertion as test_idle_notification_carrier_is_team_message
+        # but framed from the wedge-prevention perspective.
+        idle_carrier = _user_content(
+            '<teammate-message teammate_id="p1@team" summary="idle">'
+            '{"type":"idle_notification","from":"p1","idleReason":"available"}'
+            '</teammate-message>'
+        )
+        self.assertTrue(
+            _is_team_message(idle_carrier, set()),
+            "idle_notification carrier must be tagged as a team message to prevent "
+            "the safe_to_reload permanent-wedge via pruned-idle scenario"
+        )
+
+
+# ─── TestFailedAgentSpawnNoWedge (H-1 regression guards) ─────────────────────
+
+class TestFailedAgentSpawnNoWedge(unittest.TestCase):
+    """H-1 (HIGH): Failed Agent spawn (result has no 'agent_id:' line) leaves a
+    status='running' placeholder → safe_to_reload returns False indefinitely.
+
+    The fix: in the Agent tool_result handler, when no agent_id_m matches,
+    remove or mark-terminal the placeholder so a failed spawn is not blocking.
+    """
+
+    def test_failed_agent_spawn_does_not_block_reload(self):
+        """REGRESSION GUARD — RED at base: failed Agent spawn → placeholder
+        status='running' → safe_to_reload returns (False, 'teammate mid-execution').
+
+        After fix: a spawn result with no 'agent_id:' line transitions the
+        placeholder to a terminal status → safe_to_reload returns (True, ...).
+        """
+        from cozempic.guard import safe_to_reload
+        msgs = [
+            (0, _tool_use("u1", "Agent", {"name": "finder-p1", "description": "find"}), 200),
+            (1, _tool_result("u1", "Error: quota exceeded. No agent was created."), 300),
+        ]
+        state = _extract(msgs)
+        # After fix: no teammates (or all terminal) → safe to reload
+        if state.teammates:
+            all_terminal = all(
+                (t.status or "").strip().lower()
+                in {"completed", "failed", "error", "stopped", "cancelled", "done"}
+                for t in state.teammates
+            )
+            self.assertTrue(
+                all_terminal,
+                "Failed spawn placeholder must have a terminal status; "
+                f"got teammates={[(t.agent_id, t.status) for t in state.teammates]}"
+            )
+        safe, reason = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertTrue(
+            safe,
+            "Failed Agent spawn must not block safe_to_reload; "
+            f"got safe={safe}, reason={reason!r}"
+        )
+
+    def test_successful_spawn_still_blocks(self):
+        """INVARIANT: a successful spawn (has 'agent_id:' line) must still block.
+
+        This is GREEN at base (wrong reason); must stay GREEN after H-1 fix.
+        """
+        from cozempic.guard import safe_to_reload
+        spawn_result = (
+            "Spawned successfully.\nagent_id: finder-p1@myteam\n"
+            "name: finder-p1\nteam_name: myteam\nRunning."
+        )
+        msgs = [
+            (0, _tool_use("u1", "Agent", {"name": "finder-p1"}), 200),
+            (1, _tool_result("u1", spawn_result), 300),
+        ]
+        state = _extract(msgs)
+        safe, reason = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertFalse(
+            safe,
+            "Successful Agent spawn must block safe_to_reload; "
+            f"got safe={safe}, reason={reason!r}"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -731,31 +731,6 @@ class TestIdleNotificationPruneProtection(unittest.TestCase):
             "so it is prune-protected and cannot be lost to compaction"
         )
 
-    def test_idle_notification_pruned_away_does_not_wedge(self):
-        """REGRESSION GUARD — RED at base: if idle_notification is dropped from
-        the message list, the teammate stays 'running' → permanent reload wedge.
-
-        After fix: either the carrier is prune-protected (C-2 fix) or the extract
-        logic handles the absent carrier gracefully (out-of-scope for this PR).
-        This test verifies the PROTECTION path: after fix, the carrier survives
-        prune_with_team_protect and idle_notification is correctly parsed.
-        """
-        from cozempic.team import _is_team_message
-        # The assertion is that the carrier message is protected (is_team_message=True).
-        # If the carrier is protected, it cannot be dropped by prune → wedge can't occur.
-        # This is the same assertion as test_idle_notification_carrier_is_team_message
-        # but framed from the wedge-prevention perspective.
-        idle_carrier = _user_content(
-            '<teammate-message teammate_id="p1@team" summary="idle">'
-            '{"type":"idle_notification","from":"p1","idleReason":"available"}'
-            '</teammate-message>'
-        )
-        self.assertTrue(
-            _is_team_message(idle_carrier, set()),
-            "idle_notification carrier must be tagged as a team message to prevent "
-            "the safe_to_reload permanent-wedge via pruned-idle scenario"
-        )
-
 
 # ─── TestFailedAgentSpawnNoWedge (H-1 regression guards) ─────────────────────
 

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -654,8 +654,8 @@ class TestStaleConfigAntiWedge(unittest.TestCase):
 
     def test_stale_same_name_config_does_not_allow_false_safe_reload(self):
         """REGRESSION GUARD — RED at base: stale same-name config overwrites
-        lead_session_id → _team_is_current_session(live_path) returns False →
-        safe_to_reload returns (True, 'quiescent') → SIGKILL of live team.
+        lead_session_id (now guarded by _name_only_match) → safe_to_reload
+        returns (True, 'quiescent') → SIGKILL of live team.
 
         The live session JSONL stem ('LIVE-SESSION-2222') differs from the
         stale config's leadSessionId ('OLD-SESSION-1111'). After the C-1 fix,
@@ -672,8 +672,8 @@ class TestStaleConfigAntiWedge(unittest.TestCase):
             from cozempic.team import extract_team_state
             state = extract_team_state(msgs)
 
-        # After fix: lead_session_id must NOT be overwritten by stale config's value
-        # (or _team_is_current_session must otherwise still block correctly)
+        # After fix: lead_session_id must NOT be overwritten by stale config's value;
+        # safe_to_reload blocks unconditionally on "running" status regardless.
         safe, reason = safe_to_reload(state, msgs, live_path)
         self.assertFalse(
             safe,

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -138,6 +138,23 @@ class TestTeamNameExtraction(unittest.TestCase):
         self.assertEqual(state.team_name, "myteam",
                          "'name' key fallback must still work for backward compat")
 
+    def test_teamcreate_both_keys_prefers_team_name(self):
+        """REGRESSION GUARD (code-review max): when BOTH keys are present
+        (rollout overlap), the authoritative 'team_name' must win over the
+        legacy 'name'. Old priority `inp.get('name', inp.get('team_name'))`
+        picked the stale legacy value → a wrong name-join in merge_config.
+        """
+        msgs = [
+            (0, _tool_use("u1", "TeamCreate", {
+                "name": "stale-legacy-name",
+                "team_name": "real-team",
+                "description": "rollout overlap",
+            }), 100),
+        ]
+        state = _extract(msgs)
+        self.assertEqual(state.team_name, "real-team",
+                         "authoritative 'team_name' must win over legacy 'name'")
+
     def test_teamcreate_team_name_key_with_inline_teammates(self):
         """REGRESSION GUARD — RED at base: team_name="" when key is 'team_name'.
 

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -1,0 +1,598 @@
+"""F1 fix — RED→GREEN regression guards for Agent-spawned team visibility.
+
+Each test that is a genuine regression guard is PROVEN RED at base 4f15d6d before
+any fix is applied; characterization / invariant-preservation tests that pass at
+base are clearly labelled as such in their docstrings.
+
+Test classes:
+  TestTeamNameExtraction         — P0-A: team_name key mismatch
+  TestAgentSpawnRecognition      — P0-B: Agent tool recognition in extract_team_state
+  TestSendMessageByNameLookup    — P0-C: by-name SendMessage resolution
+  TestIdleNotificationTransition — P0-D: idle_notification terminal transition
+  TestSessionScopedAntiWedge     — P0-E: session-scoped anti-wedge in safe_to_reload
+  TestFullScenario               — integration: pure-SendMessage team, no shared tasks
+
+Isolation:
+  All tests go through _extract() which patches load_team_configs to return []
+  (no live ~/.claude/teams/ config merge contamination — L11 isolation principle).
+  No real 'cozempic guard --daemon', no os.kill on real PIDs.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+def _extract(msgs):
+    """Call extract_team_state with config isolation (no live ~/.claude/teams/ merge).
+
+    All tests in this module must go through this wrapper to avoid contamination
+    from the test machine's real team config.json files — which can cause tests to
+    pass at base for the wrong reason (config-merge finding the live config before
+    the JSONL extraction bug is fixed). L11 isolation principle.
+    """
+    from cozempic.team import extract_team_state
+    with patch("cozempic.team.load_team_configs", return_value=[]):
+        return extract_team_state(msgs)
+
+
+def _tool_use(id_, name, inp):
+    return {"message": {"role": "assistant", "content": [
+        {"type": "tool_use", "id": id_, "name": name, "input": inp}
+    ]}}
+
+
+def _tool_result(tool_use_id, text):
+    return {"message": {"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": tool_use_id,
+         "content": text}
+    ]}}
+
+
+def _user_content(text):
+    """A user message with a plain-string content (e.g. teammate-message XML)."""
+    return {"message": {"role": "user", "content": text}}
+
+
+# Canonical Agent-spawn result text as observed in real transcripts (2026-06-08)
+_SPAWN_RESULT_P1 = (
+    "Spawned successfully.\n"
+    "agent_id: finder-p1@myteam\n"
+    "name: finder-p1\n"
+    "team_name: myteam\n"
+    "The agent is now running and will receive instructions via mailbox."
+)
+
+_SPAWN_RESULT_P2 = (
+    "Spawned successfully.\n"
+    "agent_id: finder-p2@myteam\n"
+    "name: finder-p2\n"
+    "team_name: myteam\n"
+    "The agent is now running and will receive instructions via mailbox."
+)
+
+_IDLE_NOTIFICATION_P2 = (
+    '<teammate-message teammate_id="finder-p2" summary="idle">'
+    '{"type":"idle_notification","from":"finder-p2","timestamp":"2026-06-08T10:00:00Z","idleReason":"available"}'
+    '</teammate-message>'
+)
+
+
+def _spawn_msgs_p1(idx_offset=0):
+    """Two messages: Agent tool_use + Agent tool_result for finder-p1."""
+    return [
+        (idx_offset, _tool_use("u1", "Agent", {"name": "finder-p1", "description": "find bugs"}), 200),
+        (idx_offset + 1, _tool_result("u1", _SPAWN_RESULT_P1), 300),
+    ]
+
+
+# ─── TestTeamNameExtraction (P0-A) ──────────────────────────────────────────
+
+class TestTeamNameExtraction(unittest.TestCase):
+    """P0-A: TeamCreate emits 'team_name' key, but extract_team_state reads 'name'.
+
+    Regression guard: test_teamcreate_team_name_key_extracted is RED at base
+    (extract_team_state returns team_name="" before the fix).
+
+    Invariant test: test_teamcreate_name_key_still_works is GREEN at base
+    (backward compat — sessions that already used 'name' keep working).
+    """
+
+    def test_teamcreate_team_name_key_extracted(self):
+        """REGRESSION GUARD — RED at base: inp.get('name') misses 'team_name' key.
+
+        Before fix: state.team_name == "" (the key 'name' is absent; only
+        'team_name' is present, so the fallback in the old code is the empty
+        default).  After fix: state.team_name == "myteam".
+        """
+        msgs = [
+            (0, _tool_use("u1", "TeamCreate", {
+                "team_name": "myteam",
+                "description": "test team",
+            }), 100),
+        ]
+        state = _extract(msgs)
+        self.assertEqual(state.team_name, "myteam",
+                         "TeamCreate with 'team_name' key must set state.team_name")
+
+    def test_teamcreate_name_key_still_works(self):
+        """INVARIANT (GREEN at base): backward compat — 'name' key still works.
+
+        This test documents that sessions using the 'name' key continue to work
+        after the fix. It is NOT a regression guard (passes at base).
+        """
+        msgs = [
+            (0, _tool_use("u1", "TeamCreate", {
+                "name": "myteam",
+                "description": "test team",
+            }), 100),
+        ]
+        state = _extract(msgs)
+        self.assertEqual(state.team_name, "myteam",
+                         "'name' key fallback must still work for backward compat")
+
+    def test_teamcreate_team_name_key_with_inline_teammates(self):
+        """REGRESSION GUARD — RED at base: team_name="" when key is 'team_name'.
+
+        Asserts team_name is set correctly; the teammate is a secondary check.
+        """
+        msgs = [
+            (0, _tool_use("u1", "TeamCreate", {
+                "team_name": "audit-team",
+                "description": "audit team",
+                "teammates": [{"agentId": "finder-p1@audit-team", "name": "finder-p1"}],
+            }), 200),
+        ]
+        state = _extract(msgs)
+        self.assertEqual(state.team_name, "audit-team",
+                         "team_name must be extracted from 'team_name' key")
+        self.assertTrue(any(t.name == "finder-p1" for t in state.teammates),
+                        "inline teammate must still be populated")
+
+
+# ─── TestAgentSpawnRecognition (P0-B) ────────────────────────────────────────
+
+class TestAgentSpawnRecognition(unittest.TestCase):
+    """P0-B: 'Agent' tool-use is unrecognised; teammates stay empty.
+
+    All tests in this class are REGRESSION GUARDs — RED at base because
+    'Agent' ∉ TEAM_TOOL_NAMES so the spawn is completely invisible.
+    """
+
+    def test_agent_spawn_creates_teammate_with_running_status(self):
+        """REGRESSION GUARD — RED at base: Agent spawn not recognised; teammates=[].
+
+        After fix: len(state.teammates) >= 1, with a non-benign, non-terminal
+        status ('running') that blocks safe_to_reload.
+        """
+        from cozempic.guard import _TEAMMATE_BENIGN, _STATUS_TERMINAL
+        state = _extract(_spawn_msgs_p1())
+        self.assertGreaterEqual(len(state.teammates), 1,
+                                "Agent spawn must create a TeammateInfo entry")
+        mate = next((t for t in state.teammates if t.name == "finder-p1"), None)
+        self.assertIsNotNone(mate, "teammate must have name 'finder-p1'")
+        s = (mate.status or "").strip().lower()
+        self.assertNotIn(s, _TEAMMATE_BENIGN,
+                         f"spawn status {s!r} must not be benign; must block reload")
+        self.assertNotIn(s, _STATUS_TERMINAL,
+                         f"spawn status {s!r} must not be terminal; work is ongoing")
+
+    def test_agent_spawn_sets_team_name_from_result(self):
+        """REGRESSION GUARD — RED at base: Agent spawn result not parsed; team_name=''.
+
+        After fix: state.team_name == 'myteam' (parsed from spawn result).
+        Only fires if no prior TeamCreate set team_name.
+        """
+        state = _extract(_spawn_msgs_p1())
+        self.assertEqual(state.team_name, "myteam",
+                         "team_name must be extracted from the Agent spawn result")
+
+    def test_agent_spawn_real_agent_id_extracted(self):
+        """REGRESSION GUARD — RED at base: spawn result not parsed; agentId stays placeholder.
+
+        After fix: the TeammateInfo's agent_id is 'finder-p1@myteam' (the real
+        agentId from the result text), not the tool_use_id placeholder.
+        """
+        state = _extract(_spawn_msgs_p1())
+        self.assertGreaterEqual(len(state.teammates), 1)
+        # The real agentId format includes the @team suffix
+        agent_ids = {t.agent_id for t in state.teammates}
+        self.assertIn("finder-p1@myteam", agent_ids,
+                      "real agentId 'finder-p1@myteam' must be parsed from spawn result")
+
+    def test_agent_spawn_triggers_unsafe_reload(self):
+        """REGRESSION GUARD — RED at base: spawn invisible; safe_to_reload returns True.
+
+        This is the core bug scenario: an active Agent-spawned teammate with no
+        completion signal must block safe_to_reload (return False).
+        After fix: safe_to_reload returns (False, reason) with 'teammate' in reason.
+        """
+        from cozempic.guard import safe_to_reload
+        msgs = _spawn_msgs_p1()
+        state = _extract(msgs)
+        safe, reason = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertFalse(safe,
+                         "Active Agent-spawned teammate must block safe_to_reload")
+        self.assertIn("teammate", reason,
+                      f"block reason must mention 'teammate', got: {reason!r}")
+
+    def test_agent_spawn_pruning_non_regression(self):
+        """INVARIANT (GREEN at base, must stay GREEN): 'Agent' must NOT be in TEAM_TOOL_NAMES.
+
+        Q-A decision: 'Agent' is NOT added to TEAM_TOOL_NAMES. It is only used in
+        extract_team_state's own scope via _TEAM_EXTRACT_TOOL_NAMES. This ensures
+        prune_with_team_protect does NOT over-protect non-team Agent calls.
+        """
+        from cozempic.team import TEAM_TOOL_NAMES
+        self.assertNotIn("Agent", TEAM_TOOL_NAMES,
+                         "'Agent' must NOT be in TEAM_TOOL_NAMES (would over-protect "
+                         "non-team Agent calls in prune_with_team_protect)")
+
+    def test_non_team_agent_call_not_protected_by_is_team_message(self):
+        """INVARIANT (GREEN at base, must stay GREEN): _is_team_message returns False
+        for Agent tool_use (since 'Agent' ∉ TEAM_TOOL_NAMES).
+
+        Proves the decouple invariant: extract_team_state can recognize Agent spawns
+        via its own internal predicate, while prune_with_team_protect's
+        _is_team_message call does NOT tag them as team-protected.
+        """
+        from cozempic.team import _is_team_message
+        agent_msg = {"message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "u99", "name": "Agent",
+             "input": {"name": "solo-agent", "description": "one-off task"}}
+        ]}}
+        # With no pending_task_ids, _is_team_message must return False for Agent tool_use
+        result = _is_team_message(agent_msg, pending_task_ids=set())
+        self.assertFalse(result,
+                         "_is_team_message must return False for Agent tool_use "
+                         "(Agent ∉ TEAM_TOOL_NAMES — decouple invariant)")
+
+
+# ─── TestSendMessageByNameLookup (P0-C) ─────────────────────────────────────
+
+class TestSendMessageByNameLookup(unittest.TestCase):
+    """P0-C: SendMessage to: bare name misses seen_teammates keyed by agentId.
+
+    Regression guards: RED at base because SendMessage to="alice" (bare name)
+    misses seen_teammates keyed by "alice@myteam" (full agentId).
+    """
+
+    def test_sendmessage_bare_name_reactivates_after_completion(self):
+        """REGRESSION GUARD — RED at base: bare-name lookup misses agentId-keyed teammate.
+
+        TeamCreate → SendMessage → completion → SendMessage (re-activate by bare name).
+        The second SendMessage must resolve "alice" → "alice@myteam" and set
+        status="running" (chronology: last SendMessage is AFTER the completion).
+
+        Before fix: seen_teammates keyed by "alice@myteam"; to="alice" misses
+        → the re-activation at line 3 is lost → status stays "completed"
+        → safe_to_reload incorrectly says safe (but the teammate was re-activated).
+        """
+        msgs = [
+            (0, _tool_use("u1", "TeamCreate", {
+                "team_name": "myteam",
+                "teammates": [{"agentId": "alice@myteam", "name": "alice"}],
+            }), 100),
+            (1, _tool_use("u2", "SendMessage", {"to": "alice", "message": "phase1"}), 100),
+            (2, {"type": "queue-operation",
+                 "content": ("<task-notification><task-id>alice@myteam</task-id>"
+                             "<status>completed</status><summary>done</summary>"
+                             "<result>r</result></task-notification>")}, 100),
+            (3, _tool_use("u3", "SendMessage", {"to": "alice", "message": "phase2"}), 100),
+        ]
+        state = _extract(msgs)
+        mate = next((t for t in state.teammates
+                     if t.name == "alice" or t.agent_id == "alice@myteam"), None)
+        self.assertIsNotNone(mate, "alice must be in teammates")
+        self.assertEqual(mate.status, "running",
+                         "SendMessage to bare 'alice' after completion must re-activate "
+                         "teammate back to 'running'")
+
+    def test_sendmessage_to_agent_spawn_by_name(self):
+        """REGRESSION GUARD — RED at base: Agent-spawn + SendMessage by bare name.
+
+        After Agent spawns finder-p1 (agentId = "finder-p1@myteam"),
+        a SendMessage to="finder-p1" (bare name) must be recognized
+        (bare-name → agentId index) and the teammate must remain active.
+        """
+        msgs = list(_spawn_msgs_p1()) + [
+            (2, _tool_use("u2", "SendMessage", {"to": "finder-p1", "message": "start work"}), 100),
+        ]
+        state = _extract(msgs)
+        mate = next((t for t in state.teammates
+                     if t.name == "finder-p1" or "finder-p1" in t.agent_id), None)
+        self.assertIsNotNone(mate, "finder-p1 must be in teammates after spawn")
+        s = (mate.status or "").strip().lower()
+        from cozempic.guard import _TEAMMATE_BENIGN, _STATUS_TERMINAL
+        self.assertNotIn(s, _TEAMMATE_BENIGN,
+                         f"After spawn + SendMessage, status must not be benign, got {s!r}")
+        self.assertNotIn(s, _STATUS_TERMINAL,
+                         f"After spawn + SendMessage, status must not be terminal, got {s!r}")
+
+
+# ─── TestIdleNotificationTransition (P0-D) ───────────────────────────────────
+
+class TestIdleNotificationTransition(unittest.TestCase):
+    """P0-D: <teammate-message> idle_notification in user messages must transition
+    the teammate to 'idle' (benign) status.
+
+    All tests in this class are REGRESSION GUARDs — RED at base because:
+    (a) P0-B makes Agent spawns invisible (teammates=[]), and
+    (b) the second pass does not scan for idle_notification blocks.
+    """
+
+    def _msgs_with_idle(self):
+        """Spawn + spawn result + user message with idle_notification for finder-p2."""
+        return [
+            (0, _tool_use("u1", "Agent", {"name": "finder-p2", "description": "find issues"}), 200),
+            (1, _tool_result("u1", _SPAWN_RESULT_P2), 300),
+            (2, _user_content(_IDLE_NOTIFICATION_P2), 200),
+        ]
+
+    def test_idle_notification_transitions_to_idle(self):
+        """REGRESSION GUARD — RED at base: idle_notification invisible; teammate stays 'running'.
+
+        After fix: the teammate's status becomes 'idle' (∈ _TEAMMATE_BENIGN).
+        """
+        from cozempic.guard import _TEAMMATE_BENIGN
+        state = _extract(self._msgs_with_idle())
+        mate = next((t for t in state.teammates
+                     if t.name == "finder-p2" or "finder-p2" in t.agent_id), None)
+        self.assertIsNotNone(mate,
+                             "finder-p2 must be in teammates after Agent spawn + result")
+        s = (mate.status or "").strip().lower()
+        self.assertIn(s, _TEAMMATE_BENIGN,
+                      f"idle_notification must transition status to benign, got {s!r}")
+
+    def test_idle_notification_allows_safe_reload(self):
+        """REGRESSION GUARD — RED at base: spawn invisible; 'safe' for wrong reason (is_empty).
+
+        After fix: the correct path — teammate exists + is idle → safe.
+        The test also verifies state is NOT empty (proving the correct path is taken).
+        """
+        from cozempic.guard import safe_to_reload
+        msgs = self._msgs_with_idle()
+        state = _extract(msgs)
+        self.assertFalse(state.is_empty(),
+                         "state must not be empty after Agent spawn + idle_notification")
+        safe, _ = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertTrue(safe,
+                        "After idle_notification, safe_to_reload must return True")
+
+    def test_idle_notification_not_applied_if_later_sendmessage(self):
+        """REGRESSION GUARD — RED at base: all events invisible; cannot test chronology.
+
+        After fix: a SendMessage AFTER the idle_notification (re-activation) must
+        keep the teammate's status as 'running' (not 'idle'). Chronology guard:
+        the SendMessage at line 3 is AFTER the idle at line 2 → stays blocking.
+        """
+        from cozempic.guard import safe_to_reload, _TEAMMATE_BENIGN
+        msgs = [
+            (0, _tool_use("u1", "Agent", {"name": "finder-p2", "description": "find issues"}), 200),
+            (1, _tool_result("u1", _SPAWN_RESULT_P2), 300),
+            (2, _user_content(_IDLE_NOTIFICATION_P2), 200),         # idle at line 2
+            (3, _tool_use("u3", "SendMessage", {"to": "finder-p2", "message": "one more task"}), 100),  # re-activate at line 3
+        ]
+        state = _extract(msgs)
+        mate = next((t for t in state.teammates
+                     if t.name == "finder-p2" or "finder-p2" in t.agent_id), None)
+        self.assertIsNotNone(mate, "finder-p2 must be in teammates")
+        s = (mate.status or "").strip().lower()
+        self.assertNotIn(s, _TEAMMATE_BENIGN,
+                         "SendMessage after idle_notification must re-activate teammate "
+                         f"(status must not be benign), got {s!r}")
+        safe, reason = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertFalse(safe,
+                         "Re-activated teammate (SendMessage after idle) must block reload")
+
+    def test_prose_teammate_message_does_not_transition(self):
+        """INVARIANT: prose-only <teammate-message> must NOT transition to idle.
+
+        Only the exact JSON idle_notification body triggers the transition.
+        This prevents false-idle transitions from progress-update prose blocks.
+        """
+        from cozempic.guard import _TEAMMATE_BENIGN
+        prose_msg = (
+            '<teammate-message teammate_id="finder-p2" summary="progress update">'
+            'I have completed the first 3 files and found no issues.'
+            '</teammate-message>'
+        )
+        msgs = [
+            (0, _tool_use("u1", "Agent", {"name": "finder-p2", "description": "find issues"}), 200),
+            (1, _tool_result("u1", _SPAWN_RESULT_P2), 300),
+            (2, _user_content(prose_msg), 200),
+        ]
+        state = _extract(msgs)
+        mate = next((t for t in state.teammates
+                     if t.name == "finder-p2" or "finder-p2" in t.agent_id), None)
+        if mate is not None:
+            s = (mate.status or "").strip().lower()
+            self.assertNotIn(s, _TEAMMATE_BENIGN,
+                             f"Prose teammate-message must NOT transition to benign, got {s!r}")
+
+
+# ─── TestSessionScopedAntiWedge (P0-E) ───────────────────────────────────────
+
+class TestSessionScopedAntiWedge(unittest.TestCase):
+    """P0-E: stale/cross-session config must NOT block safe_to_reload.
+
+    A stale team's config.json persisting on disk with non-benign teammates
+    must be silently bypassed when the team belongs to a different session.
+    """
+
+    def test_stale_cross_session_team_does_not_wedge_reload(self):
+        """REGRESSION GUARD — RED at base: no session-scope check; 'running' teammate wedges.
+
+        A TeamState with lead_session_id that does NOT match the session_path.stem
+        must NOT block safe_to_reload. Only the current session's team matters.
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="old-team",
+            lead_session_id="deadbeef-0000-0000-0000-000000000000",
+            teammates=[TeammateInfo("alice@old-team", "alice", status="running")],
+        )
+        # Current session has a DIFFERENT id in the path stem
+        session_path = Path("/tmp/aabbccdd1234abcd.jsonl")
+        safe, reason = safe_to_reload(state, [], session_path)
+        self.assertTrue(safe,
+                        "Stale/cross-session running teammate must NOT wedge reload; "
+                        f"got safe={safe}, reason={reason!r}")
+
+    def test_same_session_running_teammate_blocks_reload(self):
+        """INVARIANT (GREEN at base — blocks; correct reason after fix):
+        when lead_session_id matches the guarded session, a running teammate blocks.
+
+        This is an invariant-preservation test, not a regression guard.
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="live-team",
+            lead_session_id="aabbccdd1234abcd",
+            teammates=[TeammateInfo("alice@live-team", "alice", status="running")],
+        )
+        session_path = Path("/tmp/aabbccdd1234abcd.jsonl")
+        safe, reason = safe_to_reload(state, [], session_path)
+        self.assertFalse(safe,
+                         "Same-session running teammate must block reload")
+        self.assertIn("teammate", reason)
+
+    def test_no_session_id_in_state_is_conservative(self):
+        """INVARIANT (GREEN at base): empty lead_session_id → conservative → blocks.
+
+        Unknown session → assume it IS the current session → block if running.
+        Safe-fail mode.
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="unknown-team",
+            lead_session_id="",
+            teammates=[TeammateInfo("alice@unknown-team", "alice", status="running")],
+        )
+        session_path = Path("/tmp/aabbccdd1234abcd.jsonl")
+        safe, _ = safe_to_reload(state, [], session_path)
+        self.assertFalse(safe,
+                         "Unknown lead_session_id must be conservative → blocks reload")
+
+    def test_none_session_path_is_conservative(self):
+        """INVARIANT: session_path=None → cannot compare → conservative → blocks."""
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="t",
+            lead_session_id="some-session-id",
+            teammates=[TeammateInfo("a1", "alice", status="running")],
+        )
+        safe, _ = safe_to_reload(state, [], None)
+        self.assertFalse(safe,
+                         "session_path=None must be conservative → blocks reload")
+
+
+# ─── TestFullScenario (integration) ──────────────────────────────────────────
+
+class TestFullScenario(unittest.TestCase):
+    """End-to-end integration: the exact audit scenario.
+
+    The critical regression guard is test_pure_sendmessage_team_no_tasks_unsafe:
+    a team coordinated purely via Agent spawns + SendMessage, with no shared tasks,
+    must NOT be considered quiescent by safe_to_reload.
+
+    This test class proves the entire fix chain from P0-A through P0-E working
+    together on a realistic minimal message list.
+    """
+
+    def _pure_sendmessage_msgs(self, n_spawns=3):
+        """Build a message list with n Agent spawns + SendMessages, no TaskCreate."""
+        msgs = []
+        idx = 0
+        # TeamCreate with 'team_name' key (P0-A trigger)
+        msgs.append((idx, _tool_use("u0", "TeamCreate", {
+            "team_name": "myteam",
+            "description": "test team",
+        }), 100))
+        idx += 1
+        # n Agent spawns (P0-B trigger)
+        for i in range(1, n_spawns + 1):
+            spawn_result = (
+                f"Spawned successfully.\n"
+                f"agent_id: finder-p{i}@myteam\n"
+                f"name: finder-p{i}\n"
+                f"team_name: myteam\n"
+                "The agent is now running and will receive instructions via mailbox."
+            )
+            msgs.append((idx, _tool_use(f"us{i}", "Agent", {
+                "name": f"finder-p{i}",
+                "description": f"finder {i}",
+            }), 200))
+            idx += 1
+            msgs.append((idx, _tool_result(f"us{i}", spawn_result), 300))
+            idx += 1
+        # SendMessages to each (P0-C trigger: bare names)
+        for i in range(1, n_spawns + 1):
+            msgs.append((idx, _tool_use(f"um{i}", "SendMessage", {
+                "to": f"finder-p{i}",
+                "message": "start your task",
+            }), 100))
+            idx += 1
+        return msgs
+
+    def test_pure_sendmessage_team_no_tasks_unsafe(self):
+        """REGRESSION GUARD — RED at base: pure-SendMessage team → is_empty()=True → safe.
+
+        The exact audit scenario: finders spawned via Agent tool, coordinated
+        via SendMessage only (no TaskCreate/TaskUpdate at all).
+        Before fix: team_state.is_empty() → True (teammates=[], subagents=[], tasks=[])
+        → safe_to_reload returns (True, 'quiescent') → silent SIGKILL of working team.
+        After fix: teammates extracted with running status → blocks reload.
+
+        This is THE critical regression guard for F1.
+        """
+        from cozempic.guard import safe_to_reload
+        msgs = self._pure_sendmessage_msgs(n_spawns=3)
+        state = _extract(msgs)
+        # After fix, state must not be empty (teammates are visible)
+        self.assertFalse(state.is_empty(),
+                         "pure-SendMessage team state must not be empty after fix; "
+                         f"got team_name={state.team_name!r}, "
+                         f"teammates={len(state.teammates)}, "
+                         f"subagents={len(state.subagents)}, "
+                         f"tasks={len(state.tasks)}")
+        safe, reason = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertFalse(safe,
+                         "Pure-SendMessage active team must block safe_to_reload; "
+                         f"got safe={safe}, reason={reason!r}")
+
+    def test_pure_sendmessage_team_after_all_idle_is_safe(self):
+        """REGRESSION GUARD (partial — also GREEN at base for wrong reason):
+        after ALL teammates send idle_notification → safe_to_reload returns True.
+
+        Before fix: is_empty()=True → returns True (correct but for wrong reason;
+        no protection was active). After fix: teammates exist + all are idle → True.
+        This test validates the CORRECT path post-fix (all idle → benign → safe).
+        """
+        from cozempic.guard import safe_to_reload
+        n = 3
+        msgs = list(self._pure_sendmessage_msgs(n_spawns=n))
+        idx = len(msgs)
+        for i in range(1, n + 1):
+            idle = (
+                f'<teammate-message teammate_id="finder-p{i}" summary="idle">'
+                f'{{"type":"idle_notification","from":"finder-p{i}",'
+                f'"timestamp":"2026-06-08T10:00:00Z","idleReason":"available"}}'
+                f'</teammate-message>'
+            )
+            msgs.append((idx, _user_content(idle), 200))
+            idx += 1
+        state = _extract(msgs)
+        safe, _ = safe_to_reload(state, msgs, Path("/tmp/fake_session.jsonl"))
+        self.assertTrue(safe,
+                        "After ALL idle_notifications, safe_to_reload must return True")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -407,10 +407,10 @@ class TestIdleNotificationTransition(unittest.TestCase):
         state = _extract(msgs)
         mate = next((t for t in state.teammates
                      if t.name == "finder-p2" or "finder-p2" in t.agent_id), None)
-        if mate is not None:
-            s = (mate.status or "").strip().lower()
-            self.assertNotIn(s, _TEAMMATE_BENIGN,
-                             f"Prose teammate-message must NOT transition to benign, got {s!r}")
+        self.assertIsNotNone(mate, "finder-p2 must be in teammates after Agent spawn")
+        s = (mate.status or "").strip().lower()
+        self.assertNotIn(s, _TEAMMATE_BENIGN,
+                         f"Prose teammate-message must NOT transition to benign, got {s!r}")
 
 
 # ─── TestSessionScopedAntiWedge (P0-E) ───────────────────────────────────────
@@ -795,6 +795,162 @@ class TestFailedAgentSpawnNoWedge(unittest.TestCase):
             "Successful Agent spawn must block safe_to_reload; "
             f"got safe={safe}, reason={reason!r}"
         )
+
+
+# ─── TestGateRemoval (C-1 gate-removal regression guards) ────────────────────
+
+class TestGateRemoval(unittest.TestCase):
+    """C-1 (gate removal): _team_is_current_session was a redundant gate that
+    could MISFIRE: stale same-name config could inject a different leadSessionId,
+    causing the gate to skip the teammate block and return (True,'quiescent') for
+    a live team — SIGKILL.
+
+    The real safety invariant is simpler: a non-benign teammate status ("running")
+    can only come from THIS session's JSONL (Agent spawn / TeamCreate / SendMessage).
+    Config-only members always get status="config" (∈ _TEAMMATE_BENIGN) from
+    merge_config_into_state — they never block. So the teammate block must fire
+    UNCONDITIONALLY on any non-benign status, regardless of lead_session_id.
+
+    Regression guards below are RED at round-2 HEAD (where P0-E gate exists),
+    GREEN after gate removal.
+    """
+
+    def test_running_teammate_blocks_unconditionally_regardless_of_session_id(self):
+        """REGRESSION GUARD — RED at round-2 HEAD: P0-E gate skips block when
+        lead_session_id differs from session_path.stem.
+
+        A TeamState with a "running" teammate and ANY lead_session_id (including
+        one that doesn't match the session path) must block safe_to_reload.
+        After gate removal: the block is unconditional → returns (False, ...).
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        # Simulate a state where a stale config injected a wrong lead_session_id
+        # but the JSONL gave a "running" teammate (the real current-session signal).
+        state = TeamState(
+            team_name="myteam",
+            lead_session_id="STALE-SESSION-ID",   # does NOT match session_path.stem
+            teammates=[TeammateInfo("alice@myteam", "alice", status="running")],
+        )
+        session_path = Path("/tmp/LIVE-SESSION-2222.jsonl")
+        safe, reason = safe_to_reload(state, [], session_path)
+        self.assertFalse(
+            safe,
+            "A 'running' teammate must block safe_to_reload unconditionally, "
+            "regardless of lead_session_id vs session_path mismatch; "
+            f"got safe={safe}, reason={reason!r}"
+        )
+
+    def test_config_only_member_does_not_block_reload(self):
+        """INVARIANT (GREEN at both bases): config-only member (status='config')
+        must NOT block safe_to_reload.
+
+        merge_config_into_state hardcodes status='config' for members added from
+        config.json (not seen in JSONL). 'config' ∈ _TEAMMATE_BENIGN → never blocks.
+        This test documents the real safety mechanism.
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="myteam",
+            teammates=[TeammateInfo("alice@myteam", "alice", status="config")],
+        )
+        safe, _ = safe_to_reload(state, [], Path("/tmp/anysession.jsonl"))
+        self.assertTrue(safe,
+                        "config-only member (status='config') must not block reload")
+
+    def test_stale_same_name_config_with_live_jsonl_team_must_block(self):
+        """REGRESSION GUARD — RED at round-2 HEAD when C-1 name-only guard is absent
+        (or even with it present, this repro uses a STRONG join to inject stale id):
+        LIVE JSONL team + stale config injected leadSessionId → must still block.
+
+        This is the lead's C-1 repro. The state has:
+        - a "running" teammate from JSONL (finder-p1@myteam)
+        - stale config injected leadSessionId=OLD-SESSION-1111 via a strong join
+          on member-id intersection (bypasses the name-only guard if the stale
+          config lists the same member IDs).
+        After gate removal: block is unconditional on "running" status → safe=False.
+        """
+        from cozempic.guard import safe_to_reload
+        from cozempic.team import TeamState, TeammateInfo
+        # Construct the post-merge state directly: JSONL gave finder-p1 "running",
+        # but stale config successfully injected OLD-SESSION-1111 as lead_session_id.
+        state = TeamState(
+            team_name="myteam",
+            lead_session_id="OLD-SESSION-1111",   # injected by stale config
+            teammates=[TeammateInfo("finder-p1@myteam", "finder-p1", status="running")],
+        )
+        live_path = Path("/tmp/LIVE-SESSION-2222.jsonl")
+        safe, reason = safe_to_reload(state, [], live_path)
+        self.assertFalse(
+            safe,
+            "C-1 repro: JSONL 'running' teammate + stale lead_session_id must still "
+            f"block safe_to_reload; got safe={safe}, reason={reason!r}"
+        )
+
+
+# ─── TestNestedTeammateMessageRegex (M-1 regression guards) ──────────────────
+
+class TestNestedTeammateMessageRegex(unittest.TestCase):
+    """M-1: _TEAMMATE_MSG_RE with DOTALL can eat a nested <teammate-message> block
+    and mis-attribute its idle_notification to the outer teammate.
+
+    The fix: tighten the regex body group to exclude nested opening tags, e.g.
+    using a negative-lookahead: ((?:(?!<teammate-message).)*?)
+    so the match stops before any nested <teammate-message.
+    """
+
+    def test_nested_teammate_message_does_not_mis_attribute_idle(self):
+        """REGRESSION GUARD — RED at round-2 HEAD: DOTALL greedy body matches
+        nested <teammate-message>, mis-attributing the inner idle to the outer.
+
+        Scenario: outer block for 'lead' contains a nested block for 'alice'
+        (an idle_notification). The outer 'lead' must NOT be transitioned to idle.
+        After fix: only 'alice' is transitioned.
+        """
+        from cozempic.team import extract_team_state, TeammateInfo
+        # Build a message with a nested block: outer=lead (NOT idle), inner=alice (idle)
+        nested_content = (
+            '<teammate-message teammate_id="lead" summary="forwarded">'
+            'Forwarded for logging: '
+            '<teammate-message teammate_id="alice@myteam" summary="idle">'
+            '{"type":"idle_notification","from":"alice","idleReason":"available"}'
+            '</teammate-message>'
+            '</teammate-message>'
+        )
+        msgs = [
+            (0, _tool_use("u0", "TeamCreate", {
+                "team_name": "myteam",
+                "teammates": [
+                    {"agentId": "alice@myteam", "name": "alice"},
+                    {"agentId": "lead@myteam", "name": "lead"},
+                ],
+            }), 100),
+            (1, _user_content(nested_content), 200),
+        ]
+        with patch("cozempic.team.load_team_configs", return_value=[]):
+            state = extract_team_state(msgs)
+
+        lead_mate = next((t for t in state.teammates
+                          if t.name == "lead" or t.agent_id == "lead@myteam"), None)
+        alice_mate = next((t for t in state.teammates
+                           if t.name == "alice" or t.agent_id == "alice@myteam"), None)
+
+        from cozempic.guard import _TEAMMATE_BENIGN
+        if lead_mate is not None:
+            s = (lead_mate.status or "").strip().lower()
+            self.assertNotIn(
+                s, _TEAMMATE_BENIGN,
+                "Outer 'lead' must NOT be mis-attributed idle from nested block; "
+                f"got lead.status={s!r}"
+            )
+        if alice_mate is not None:
+            s = (alice_mate.status or "").strip().lower()
+            self.assertIn(
+                s, _TEAMMATE_BENIGN,
+                "Inner 'alice' idle_notification SHOULD transition alice to benign; "
+                f"got alice.status={s!r}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The 1.8.22 safe-point reload gate (`safe_to_reload`) is meant to never SIGKILL Claude through an active agent team — explicitly the guard's primary use case. But for a team spawned with the **`Agent` tool** (the current harness mechanism), the gate's teammate/subagent protection is **inert**, so a live team can be reloaded out from under itself:

- `extract_team_state` read `inp.get("name")` for `TeamCreate`, but the tool emits **`team_name`** → `state.team_name=""` → `merge_config_into_state` never matches the team's `config.json` → `teammates=[]`.
- `"Agent"` is not in `TEAM_TOOL_NAMES`, so `Agent`-tool teammate spawns create no teammate/subagent entry from the JSONL either.
- `detect_in_flight` does not match the `Agent`-spawn result text (`"Spawned successfully. agent_id: …"`), and that spawn already has a `tool_result`, so it is not an open call.

Net: a team coordinated via `SendMessage` with **no active shared-list task** + an idle lead → `safe_to_reload` returns `(True, "quiescent")` → the guard reloads (SIGKILL) the lead and orphans the live team. The only thing that protected such teams was an active task in the lead's transcript. Reproduced against real session transcripts.

## Fix

- **Read the real key**: `team_name` (fallback `name`), restoring config-merge so the team is visible (also fixes checkpoint accuracy).
- **Recognize `Agent`-tool teammate spawns** via an *extract-only* `_TEAM_EXTRACT_TOOL_NAMES = TEAM_TOOL_NAMES | {"Agent"}` — deliberately **not** added to `TEAM_TOOL_NAMES`, so `prune_with_team_protect` is unchanged and Agent calls are not over-preserved (no pruning regression). Placeholder `status="running"`, re-keyed to the real `agentId` parsed from the result.
- **Resolve bare-name `SendMessage(to:)`** (`"alice"`) against a `name→agentId` index (members are keyed `"alice@team"`).
- **Terminal transition**: a teammate goes benign `"idle"` on an `idle_notification` `<teammate-message>` (chronology-aware vs re-activating `SendMessage`s), and the idle-notification carrier is now prune-protected so the clear signal survives a prune (no permanent wedge).
- **Failed spawn**: an `Agent` result with no parseable `agent_id` marks the placeholder `"failed"` so a failed spawn cannot block reloads forever.
- **Teammate block fires unconditionally** on a non-benign status. A non-benign status can only originate from *this* session's JSONL; config-only members are `"config"` (benign) and never block. (An earlier session-id gate was prototyped and removed — it misfired on a reused-team-name stale `config.json`, injecting an old `leadSessionId` and skipping the block for a live team = the same catastrophe inverted.)

## Tests

- New `tests/test_guard_team_agent_spawn.py` (31 tests). Each regression guard proven RED at the PR base; characterization tests labeled as such.
- Covers: team_name extraction, Agent-spawn recognition, bare-name resolution, idle transition + chronology guard, idle-carrier prune-protection, failed-spawn cleanup, unconditional-block, stale same-name config (intersecting members) must still block, nested-`<teammate-message>` isolation.
- `docs/qa-fleet.md` L8 extended with the Agent-spawn team-visibility standing test.
- Full suite: **1225 passed, 5 skipped** (one pre-existing flaky `TestG4_PidfileWriteIsAtomic` pidfile race — untouched module, passes in isolation).
- Zero new dependencies (stdlib only — preserves the zero-dep design).

## Scope

- **Deferred** (separate follow-up, different subsystem): two LOW latent armed-sentinel items — `_write_armed_atomic` tmp-suffix uses `os.getpid()` only (narrow concurrent-teardown race), and `[:12]` session-slug collision (negligible for UUIDv4; shared module-wide convention).
- **Documented residual**: a teammate could stay `"running"` if its terminal signal is lost to asymmetric pruning → the reload defers (read-only checkpoint, autocompact fallback) rather than SIGKILLing — strictly better than the bug it replaces.
