### PR TITLE
test(isolation): deterministic fixes for two L11 test leaks (host PID + env clobber)

### DIFF
--- a/tests/test_active_session_detection.py
+++ b/tests/test_active_session_detection.py
@@ -92,10 +92,15 @@ class TestActiveTranscriptFix(_Base):
     def test_two_terminals_two_pids_resolve_independently(self):
         a = _write_session(self.projects / "-Users-ruya", "aaaaaaaa")
         b = _write_session(self.projects / "-Users-ruya-Documents-Advisor-Cozempic", "bbbbbbbb")
-        S.record_active_transcript(str(a), claude_pid=111)
-        S.record_active_transcript(str(b), claude_pid=222)
+        # `_pid_alive` must be patched around the record calls too — not only the
+        # lookups below. `record_active_transcript` prunes dead pids on write, so
+        # with the real `os.kill` the first entry (pid 111) is dropped during the
+        # second record on any host where 111 isn't a live process, leaving the
+        # lookup to return None (host-dependent flake). Patch it for the whole body.
         with mock.patch.object(S, "_session_id_from_process", lambda: None), \
              mock.patch.object(S, "_pid_alive", lambda pid: True):
+            S.record_active_transcript(str(a), claude_pid=111)
+            S.record_active_transcript(str(b), claude_pid=222)
             with mock.patch.object(S, "find_claude_pid", lambda: 111):
                 self.assertEqual(S.find_current_session("/tmp", strict=True)["session_id"], "aaaaaaaa")
             with mock.patch.object(S, "find_claude_pid", lambda: 222):

--- a/tests/test_protect_pattern.py
+++ b/tests/test_protect_pattern.py
@@ -12,6 +12,7 @@ from a strategy's removal actions.
 import io
 import unittest
 from contextlib import redirect_stderr
+from unittest import mock
 
 from cozempic.helpers import (
     compile_protect_patterns, tag_pattern_matches, strip_pattern_tags, is_protected,
@@ -115,8 +116,10 @@ class TestHardening1828(unittest.TestCase):
         # A catastrophic-backtracking pattern must NOT hang the prune/daemon — it
         # times out and fails open (no protection this cycle), not seconds/minutes.
         import os, time
-        os.environ["COZEMPIC_PROTECT_MATCH_SECONDS"] = "1.0"
-        try:
+        # patch.dict save/restores any pre-existing value instead of unconditionally
+        # popping it on teardown (which would clobber a real, externally-set
+        # COZEMPIC_PROTECT_MATCH_SECONDS the developer had in their environment).
+        with mock.patch.dict(os.environ, {"COZEMPIC_PROTECT_MATCH_SECONDS": "1.0"}):
             evil = compile_protect_patterns([r"(a+)+$"])
             msgs = [(0, _txt("a" * 40 + "!"), 50)]
             t0 = time.perf_counter()
@@ -128,8 +131,6 @@ class TestHardening1828(unittest.TestCase):
             self.assertEqual(n, 0, "must fail open (skip protection) on timeout")
             self.assertNotIn(_PATTERN_PROTECTED_KEY, msgs[0][1], "no half-protection left behind")
             self.assertIn("exceeded its time budget", buf.getvalue())
-        finally:
-            os.environ.pop("COZEMPIC_PROTECT_MATCH_SECONDS", None)
 
     def test_thinking_block_is_scanned(self):
         think = {"type": "assistant", "message": {"role": "assistant", "content": [


### PR DESCRIPTION
## Problem

Auditing the 1.8.30 suite surfaced two test-isolation (L11) issues:

1. **`test_two_terminals_two_pids_resolve_independently` is host-dependent — the only failing test on some machines.** It mocks `_pid_alive` only around the `find_current_session` lookups, but the two `record_active_transcript` calls run with the *real* `_pid_alive`. `record_active_transcript` prunes dead PIDs on write, so on any host where the fake PID `111` is not a live process, the first entry is pruned during the second record → `lookup_active_transcript(111)` returns `None` → `find_current_session(...)["session_id"]` raises `TypeError`. It passes only on hosts where PID 111 happens to be a live system process (`os.kill(111, 0)` → `PermissionError` → treated as alive).

2. **`test_redos_pattern_fails_open_within_budget` clobbers a developer's environment.** It sets `COZEMPIC_PROTECT_MATCH_SECONDS` with a raw `os.environ[...] =` and `pop`s it unconditionally on teardown, destroying any value already present instead of restoring it.

## Fix

1. Move the `_pid_alive → True` patch up to wrap the `record_active_transcript` calls too, so both PIDs read as alive and neither is pruned — matching the test's stated intent ("two pids resolve independently").
2. Use `mock.patch.dict(os.environ, {...})`, which save/restores the prior value.

Both changes are **test-only**; no production code is touched.

## Tests

- `tests/test_active_session_detection.py`: **8 passed** (was 1 failed on this host).
- `tests/test_protect_pattern.py`: **19 passed**.
- Full suite: **1322 passed, 5 skipped, 0 failed** (excluding the 3 pre-existing `test_model_detection` env-isolation failures), up from 1321/1.

## Scope

L11 test isolation only. A sibling L11 item found in the same audit — the reload-watcher test reads/appends the shared `/tmp/cozempic_guard.log`, which guard.py hardcodes rather than deriving from `_guard_tmp_root()` — is intentionally deferred to a guard.py change where the root path-consistency fix belongs (it also removes a latent Windows `/tmp` path that does not exist there).