### PR TITLE
fix(validation): bound env-int overrides, reject JSON bool in clamps, honor --system-overhead-tokens 0 (L1)

### DIFF
--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -174,13 +174,18 @@ def _env_warn(name: str, value: str, reason: str) -> None:
     )
 
 
-def parse_env_positive_int(name: str) -> int | None:
+def parse_env_positive_int(name: str, *, maximum: int | None = None) -> int | None:
     """Read env var `name`, parse as strictly-positive int, return None if
     absent or invalid (after emitting a warning on stderr).
 
     Used by `tokens.get_context_window_override` — a context window of 0 or
     negative is nonsensical and would propagate into `pct = total / cw`
     producing negative or divide-by-zero errors deep in diagnostics output.
+
+    `maximum`: if given, values above this bound are also rejected with a
+    warning and None is returned. A context-window value above e.g. 4_000_000
+    cannot reflect a real model and would silently disable the guard (every
+    ``pct = total / window`` rounds toward 0 when window is huge).
     """
     raw = os.environ.get(name)
     if raw is None or raw == "":
@@ -193,16 +198,23 @@ def parse_env_positive_int(name: str) -> int | None:
     if value <= 0:
         _env_warn(name, raw, "must be a positive integer")
         return None
+    if maximum is not None and value > maximum:
+        _env_warn(name, raw, f"must be <= {maximum}")
+        return None
     return value
 
 
-def parse_env_non_negative_int(name: str) -> int | None:
+def parse_env_non_negative_int(name: str, *, maximum: int | None = None) -> int | None:
     """Read env var, parse as non-negative int (0 OK), warn-and-fallback on
     failure.
 
     Used by `tokens.get_system_overhead_tokens` — `0` is a legitimate value
     meaning "no system overhead in this session" (e.g. a user with no CLAUDE.md
     and no MCP servers). Negatives and non-numerics are still rejected.
+
+    `maximum`: if given, values above this bound are also rejected with a
+    warning and None is returned. A system-overhead value at or above a full
+    context window would zero out usable context — cap at the default window.
     """
     raw = os.environ.get(name)
     if raw is None or raw == "":
@@ -214,6 +226,9 @@ def parse_env_non_negative_int(name: str) -> int | None:
         return None
     if value < 0:
         _env_warn(name, raw, "must be non-negative")
+        return None
+    if maximum is not None and value > maximum:
+        _env_warn(name, raw, f"must be <= {maximum}")
         return None
     return value
 

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1758,7 +1758,7 @@ def _prescan_argv(argv: list[str]) -> list[str]:
             if tok == "--system-overhead-tokens" and i + 1 < len(argv):
                 val = argv[i + 1]
                 try:
-                    if int(val) <= 0:
+                    if int(val) < 0:
                         raise ValueError
                     os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = val
                 except ValueError:
@@ -1768,7 +1768,7 @@ def _prescan_argv(argv: list[str]) -> list[str]:
             if tok.startswith("--system-overhead-tokens="):
                 val = tok.split("=", 1)[1]
                 try:
-                    if int(val) <= 0:
+                    if int(val) < 0:
                         raise ValueError
                     os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = val
                 except ValueError:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -66,6 +66,29 @@ def _positive_float(val: str) -> float:
         raise argparse.ArgumentTypeError(f"must be positive, got {f}")
     return f
 
+
+def _apply_token_env_overrides(args) -> None:
+    """Mirror --context-window / --system-overhead-tokens CLI flags into the env
+    vars the token layer reads.
+
+    Uses `is not None` rather than truthiness so an explicit
+    --system-overhead-tokens 0 (a legitimate "no overhead" value) is honored
+    rather than silently dropped to the 21_000 default. Zero is falsy in Python
+    but it is a valid override — e.g. a session with no CLAUDE.md, no MCP
+    servers, and no rules files really does have zero system overhead.
+
+    Replaces the duplicate truthiness-gated blocks that existed in both
+    cmd_guard() and main(), eliminating the DRY violation and the 0-drop bug
+    in a single fix.
+    """
+    cw = getattr(args, "context_window", None)
+    if cw is not None:
+        os.environ["COZEMPIC_CONTEXT_WINDOW"] = str(cw)
+    soh = getattr(args, "system_overhead_tokens", None)
+    if soh is not None:
+        os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = str(soh)
+
+
 # Fix Windows stdout/stderr encoding for Unicode characters (box-drawing, emoji)
 if sys.platform == "win32":
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -878,8 +901,7 @@ def cmd_guard(args):
     claude_pid = args.claude_pid or find_claude_pid()
     protect_patterns = _compile_protect_patterns_or_exit(args)  # #122
 
-    if getattr(args, "system_overhead_tokens", None):
-        os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = str(args.system_overhead_tokens)
+    _apply_token_env_overrides(args)
 
     if getattr(args, "reload_self", False):
         from .guard import reload_self_daemon
@@ -2109,11 +2131,9 @@ def main():
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # Also handle --context-window when placed before the subcommand (root parser)
-    if getattr(args, "context_window", None):
-        os.environ["COZEMPIC_CONTEXT_WINDOW"] = str(args.context_window)
-    if args.system_overhead_tokens:
-        os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"] = str(args.system_overhead_tokens)
+    # Mirror --context-window / --system-overhead-tokens into env vars using
+    # `is not None` (not truthiness) so --system-overhead-tokens 0 is honored.
+    _apply_token_env_overrides(args)
 
     if not args.command:
         parser.print_help()

--- a/src/cozempic/config.py
+++ b/src/cozempic/config.py
@@ -81,7 +81,14 @@ def _clamp_float(value: Any, lo: float, hi: float, default: float) -> float:
     REVIEW-max B.2: explicitly reject NaN and infinities BEFORE the range
     check — NaN compares False to every threshold so a naive ``v < lo or
     v > hi`` lets it through and downstream arithmetic silently propagates.
+
+    PR-2 P-B: reject bool before float() coercion — bool is a subclass of int,
+    so float(True)==1.0 and float(False)==0.0 both pass the range check for
+    [0.0, 1.0], silently coercing a JSON `true` into 1.0 and disabling the
+    max-drop-pct floor. Match the _is_strict_number guard from _validation.py.
     """
+    if isinstance(value, bool):
+        return default
     try:
         v = float(value)
     except (TypeError, ValueError):
@@ -101,6 +108,10 @@ def _clamp_int(value: Any, lo: int, hi: int, default: int) -> int:
     var would crash the daemon at config-load time. NaN / inf string tokens
     short-circuit before conversion so the fall-back path is uniform with
     ``_clamp_float``.
+
+    PR-2 P-B: class-of-bug fold from _clamp_float — bool is a subclass of int,
+    so int(True)==1 and int(False)==0 pass the range check. Reject before
+    conversion, consistent with _clamp_float and _is_strict_number.
     """
     # Short-circuit on string tokens that float() accepts but produce
     # non-finite values (inf, -inf, nan in any case).
@@ -109,6 +120,8 @@ def _clamp_int(value: Any, lo: int, hi: int, default: int) -> int:
         if tok in ("inf", "+inf", "-inf", "infinity", "+infinity", "-infinity",
                    "nan", "+nan", "-nan"):
             return default
+    if isinstance(value, bool):
+        return default
     if isinstance(value, float):
         if math.isnan(value) or math.isinf(value):
             return default

--- a/src/cozempic/tokens.py
+++ b/src/cozempic/tokens.py
@@ -25,8 +25,11 @@ SYSTEM_OVERHEAD_TOKENS = 21_000
 # 4M = 4x the current 1M max — generous headroom — above which we reject and
 # fall back to model-detected window so the guard keeps firing.
 MAX_CONTEXT_WINDOW = 4_000_000
-# A system-overhead override at or above a full default context window is
-# nonsensical (it would zero out usable context). Cap at the default window.
+# A system-overhead override above the default context window (1M) is a coarse
+# absurdity ceiling: it catches huge-int DoS / fat-finger overrides that would
+# zero out usable context, not a per-user-plan guarantee (a Pro user on a 200K
+# window can still set overhead=900K; the ceiling is intentionally loose).
+# The bound is strict-greater-than (> maximum), so exactly 1M is still accepted.
 MAX_SYSTEM_OVERHEAD_TOKENS = DEFAULT_CONTEXT_WINDOW
 
 # 4-tier pruning thresholds as fractions of context window

--- a/src/cozempic/tokens.py
+++ b/src/cozempic/tokens.py
@@ -19,6 +19,16 @@ from .types import Message
 DEFAULT_CONTEXT_WINDOW = 1_000_000  # All current Claude models are 1M. Pro plan users can override with COZEMPIC_CONTEXT_WINDOW=200000.
 SYSTEM_OVERHEAD_TOKENS = 21_000
 
+# Upper bounds for env-var overrides.
+# A context-window override above MAX_CONTEXT_WINDOW can't reflect a real model
+# and would silently disable the guard (every pct = total/window rounds toward 0).
+# 4M = 4x the current 1M max — generous headroom — above which we reject and
+# fall back to model-detected window so the guard keeps firing.
+MAX_CONTEXT_WINDOW = 4_000_000
+# A system-overhead override at or above a full default context window is
+# nonsensical (it would zero out usable context). Cap at the default window.
+MAX_SYSTEM_OVERHEAD_TOKENS = DEFAULT_CONTEXT_WINDOW
+
 # 4-tier pruning thresholds as fractions of context window
 DEFAULT_SOFT_TOKEN_PCT = 0.25   # 25% — gentle file maintenance, no reload
 DEFAULT_HARD1_TOKEN_PCT = 0.55  # 55% — standard prune + reload
@@ -35,7 +45,9 @@ def get_system_overhead_tokens() -> int:
     COZEMPIC_SYSTEM_OVERHEAD_TOKENS env var or --system-overhead-tokens flag.
     """
     from ._validation import parse_env_non_negative_int
-    override = parse_env_non_negative_int("COZEMPIC_SYSTEM_OVERHEAD_TOKENS")
+    override = parse_env_non_negative_int(
+        "COZEMPIC_SYSTEM_OVERHEAD_TOKENS", maximum=MAX_SYSTEM_OVERHEAD_TOKENS
+    )
     if override is not None:
         return override
     return SYSTEM_OVERHEAD_TOKENS
@@ -98,7 +110,7 @@ def get_context_window_override() -> int | None:
     (triggering model-based detection at detect_context_window).
     """
     from ._validation import parse_env_positive_int
-    return parse_env_positive_int("COZEMPIC_CONTEXT_WINDOW")
+    return parse_env_positive_int("COZEMPIC_CONTEXT_WINDOW", maximum=MAX_CONTEXT_WINDOW)
 
 # Chars-per-token defaults, calibrated against live Claude Code JSONL.
 # Measured 3.08–3.27 chars/token on real sessions: JSON keys, UUIDs, tool

--- a/tests/test_input_coercion_corpus.py
+++ b/tests/test_input_coercion_corpus.py
@@ -13,18 +13,32 @@ them. This corpus catches the whole class with an OUTPUT-shaped invariant:
 
 Adding a new COZEMPIC_* numeric knob? Add one row to _ENV_VALIDATORS and the corpus
 is applied automatically. Zero dependencies (cozempic is stdlib-only — no hypothesis).
+
+Extended in PR-2 (input-validation hardening) to cover:
+  P-A: parse_env_positive_int / parse_env_non_negative_int upper-bound (huge-int path)
+  P-B: _clamp_float / _clamp_int bool-rejection
+  P-C: cli._apply_token_env_overrides truthiness fix (0 is a valid system-overhead value)
 """
 
 import argparse
 import math
 import os
+import types
 import unittest
 from contextlib import contextmanager
+from unittest import mock
 
 import cozempic.cli as cli
+import cozempic.config as config
 import cozempic.guard as g
 import cozempic.tokens as t
-from cozempic._validation import ConfigError, coerce_positive_float, coerce_positive_int
+from cozempic._validation import (
+    ConfigError,
+    coerce_positive_float,
+    coerce_positive_int,
+    parse_env_non_negative_int,
+    parse_env_positive_int,
+)
 
 # env / CLI inputs are ALWAYS strings
 STR_CORPUS = ["nan", "NaN", "inf", "+inf", "-inf", "infinity", "1e999", "-1e999",
@@ -35,6 +49,12 @@ NATIVE_CORPUS = [float("nan"), float("inf"), float("-inf"), -0.0, 10 ** 400,
                  -1, 0, True, False, None, "x", [], {}]
 
 _UPPER = 10 ** 12  # any CLI/env validator output must be well under this
+
+# --- Huge-int boundary used by P-A tests ---
+_HUGE_INT = 10 ** 400
+_MAX_CONTEXT_WINDOW = 4_000_000   # matches tokens.MAX_CONTEXT_WINDOW (after P-A lands)
+_DEFAULT_CONTEXT_WINDOW = t.DEFAULT_CONTEXT_WINDOW  # 1_000_000
+_SYSTEM_OVERHEAD_DEFAULT = t.SYSTEM_OVERHEAD_TOKENS  # 21_000
 
 
 @contextmanager
@@ -104,6 +124,182 @@ class TestConfigDictCorpus(unittest.TestCase):
                     except (ConfigError, ValueError, TypeError):
                         continue  # a clean reject is acceptable
                     _assert_finite(self, r)  # a silent-accept of nan/inf fails here
+
+
+# ── P-A: env-parser upper-bound (huge-int) ────────────────────────────────────
+
+
+class TestParseEnvPositiveIntMaximum(unittest.TestCase):
+    """P-A: parse_env_positive_int must reject values above the maximum kwarg."""
+
+    def test_huge_int_rejected_with_maximum(self):
+        """10**400 > maximum=4_000_000 → must return None (not the huge int)."""
+        with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": str(_HUGE_INT)}):
+            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=_MAX_CONTEXT_WINDOW)
+        self.assertIsNone(result, f"huge int leaked through: {result!r}")
+
+    def test_above_maximum_rejected(self):
+        """5_000_000 > 4_000_000 → None."""
+        with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": "5000000"}):
+            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=_MAX_CONTEXT_WINDOW)
+        self.assertIsNone(result, f"above-max value leaked through: {result!r}")
+
+    def test_below_maximum_accepted(self):
+        """200_000 <= 4_000_000 → 200_000 (valid override)."""
+        with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": "200000"}):
+            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=_MAX_CONTEXT_WINDOW)
+        self.assertEqual(result, 200_000)
+
+    def test_no_maximum_still_works(self):
+        """Without maximum= kwarg the old behavior (no upper bound) is unchanged."""
+        with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": "200000"}):
+            result = parse_env_positive_int("COZEMPIC_TEST_CW")
+        self.assertEqual(result, 200_000)
+
+
+class TestParseEnvNonNegativeIntMaximum(unittest.TestCase):
+    """P-A: parse_env_non_negative_int must reject values above the maximum kwarg."""
+
+    def test_huge_int_rejected_with_maximum(self):
+        with mock.patch.dict(os.environ, {"COZEMPIC_TEST_SOH": str(_HUGE_INT)}):
+            result = parse_env_non_negative_int(
+                "COZEMPIC_TEST_SOH", maximum=_DEFAULT_CONTEXT_WINDOW
+            )
+        self.assertIsNone(result, f"huge int leaked through: {result!r}")
+
+    def test_zero_still_valid(self):
+        """0 is a legitimate 'no overhead' value and must not be rejected."""
+        with mock.patch.dict(os.environ, {"COZEMPIC_TEST_SOH": "0"}):
+            result = parse_env_non_negative_int(
+                "COZEMPIC_TEST_SOH", maximum=_DEFAULT_CONTEXT_WINDOW
+            )
+        self.assertEqual(result, 0)
+
+
+# ── P-A: tokens-layer integration (uses the constants once they exist) ────────
+
+
+class TestTokensUpperBound(unittest.TestCase):
+    """P-A: get_context_window_override and get_system_overhead_tokens must
+    apply the maximum= bound so a huge env var can never silently disable the guard."""
+
+    def test_context_window_huge_int_returns_none(self):
+        with mock.patch.dict(os.environ,
+                             {"COZEMPIC_CONTEXT_WINDOW": str(_HUGE_INT)}, clear=False):
+            result = t.get_context_window_override()
+        self.assertIsNone(result, f"huge int leaked from get_context_window_override: {result!r}")
+
+    def test_context_window_5m_returns_none(self):
+        """5_000_000 > MAX_CONTEXT_WINDOW (4_000_000) → None."""
+        with mock.patch.dict(os.environ,
+                             {"COZEMPIC_CONTEXT_WINDOW": "5000000"}, clear=False):
+            result = t.get_context_window_override()
+        self.assertIsNone(result, f"above-max value leaked: {result!r}")
+
+    def test_context_window_200k_accepted(self):
+        with mock.patch.dict(os.environ,
+                             {"COZEMPIC_CONTEXT_WINDOW": "200000"}, clear=False):
+            result = t.get_context_window_override()
+        self.assertEqual(result, 200_000)
+
+    def test_system_overhead_huge_int_falls_back_to_default(self):
+        """Huge COZEMPIC_SYSTEM_OVERHEAD_TOKENS → falls back to SYSTEM_OVERHEAD_TOKENS (21000)."""
+        with mock.patch.dict(os.environ,
+                             {"COZEMPIC_SYSTEM_OVERHEAD_TOKENS": str(_HUGE_INT)}, clear=False):
+            result = t.get_system_overhead_tokens()
+        self.assertEqual(result, _SYSTEM_OVERHEAD_DEFAULT,
+                         f"huge int leaked from get_system_overhead_tokens: {result!r}")
+
+    def test_system_overhead_zero_accepted(self):
+        """0 is a legitimate 'no overhead' value → must return 0, not the default."""
+        with mock.patch.dict(os.environ,
+                             {"COZEMPIC_SYSTEM_OVERHEAD_TOKENS": "0"}, clear=False):
+            result = t.get_system_overhead_tokens()
+        self.assertEqual(result, 0,
+                         "0 system-overhead was silently dropped (truthiness / upper-bound bug)")
+
+
+# ── P-B: config clamp helpers must reject bool ────────────────────────────────
+
+
+class TestClampBoolRejection(unittest.TestCase):
+    """P-B: _clamp_float and _clamp_int must treat bool as invalid (return default)."""
+
+    def test_clamp_float_true_returns_default(self):
+        """True coerces to 1.0 in Python, which is in-range — must return default instead."""
+        result = config._clamp_float(True, 0.0, 1.0, 0.5)
+        self.assertEqual(result, 0.5,
+                         f"bool True leaked through _clamp_float as {result!r} instead of default 0.5")
+
+    def test_clamp_float_false_returns_default(self):
+        result = config._clamp_float(False, 0.0, 1.0, 0.5)
+        self.assertEqual(result, 0.5)
+
+    def test_clamp_int_true_returns_default(self):
+        """True == 1 in Python, which passes range check — must return default instead."""
+        result = config._clamp_int(True, 0, 10, 5)
+        self.assertEqual(result, 5,
+                         f"bool True leaked through _clamp_int as {result!r} instead of default 5")
+
+    def test_clamp_int_false_returns_default(self):
+        result = config._clamp_int(False, 0, 10, 5)
+        self.assertEqual(result, 5)
+
+    def test_clamp_float_valid_value_still_works(self):
+        """Sanity: a valid float must not be broken by the bool guard."""
+        result = config._clamp_float(0.9, 0.0, 1.0, 0.5)
+        self.assertAlmostEqual(result, 0.9)
+
+    def test_clamp_int_valid_value_still_works(self):
+        result = config._clamp_int(7, 0, 10, 5)
+        self.assertEqual(result, 7)
+
+
+# ── P-C: cli._apply_token_env_overrides (DRY helper + truthiness fix) ─────────
+
+
+class TestApplyTokenEnvOverrides(unittest.TestCase):
+    """P-C: _apply_token_env_overrides must set env vars using `is not None`,
+    so --system-overhead-tokens 0 (legitimate 'no overhead') is honored."""
+
+    def _clean_env(self):
+        """Return a dict with both target keys removed so we start clean."""
+        return {k: v for k, v in os.environ.items()
+                if k not in ("COZEMPIC_CONTEXT_WINDOW", "COZEMPIC_SYSTEM_OVERHEAD_TOKENS")}
+
+    def test_zero_system_overhead_sets_env(self):
+        """0 is a valid 'no overhead' value — must NOT be silently dropped."""
+        args = types.SimpleNamespace(system_overhead_tokens=0, context_window=None)
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cli._apply_token_env_overrides(args)
+            self.assertEqual(os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"), "0",
+                             "system_overhead_tokens=0 was silently dropped (truthiness bug)")
+            self.assertNotIn("COZEMPIC_CONTEXT_WINDOW", os.environ)
+
+    def test_zero_context_window_sets_env(self):
+        """context_window=0: also set (downstream parse_env_positive_int will reject it,
+        but the CLI layer must not silently drop it first)."""
+        args = types.SimpleNamespace(system_overhead_tokens=None, context_window=0)
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cli._apply_token_env_overrides(args)
+            self.assertEqual(os.environ.get("COZEMPIC_CONTEXT_WINDOW"), "0")
+            self.assertNotIn("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", os.environ)
+
+    def test_both_none_sets_neither(self):
+        """When both attrs are None, neither env var is touched."""
+        args = types.SimpleNamespace(system_overhead_tokens=None, context_window=None)
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cli._apply_token_env_overrides(args)
+            self.assertNotIn("COZEMPIC_CONTEXT_WINDOW", os.environ)
+            self.assertNotIn("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", os.environ)
+
+    def test_positive_values_set_env(self):
+        """Normal positive values are set as expected."""
+        args = types.SimpleNamespace(system_overhead_tokens=30000, context_window=200000)
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cli._apply_token_env_overrides(args)
+            self.assertEqual(os.environ["COZEMPIC_CONTEXT_WINDOW"], "200000")
+            self.assertEqual(os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"], "30000")
 
 
 if __name__ == "__main__":

--- a/tests/test_input_coercion_corpus.py
+++ b/tests/test_input_coercion_corpus.py
@@ -54,11 +54,11 @@ NATIVE_CORPUS = [float("nan"), float("inf"), float("-inf"), -0.0, _HUGE_INT,
 
 _UPPER = 10 ** 12  # any CLI/env validator output must be well under this
 
-# P-A test boundaries — reference production constants so a change to tokens.py
-# is automatically reflected here without a separate test-file update.
-_MAX_CONTEXT_WINDOW = t.MAX_CONTEXT_WINDOW        # 4_000_000
+# Pre-existing constants safe to reference at module scope (present on origin/main).
 _DEFAULT_CONTEXT_WINDOW = t.DEFAULT_CONTEXT_WINDOW  # 1_000_000
 _SYSTEM_OVERHEAD_DEFAULT = t.SYSTEM_OVERHEAD_TOKENS  # 21_000
+# NOTE: t.MAX_CONTEXT_WINDOW is NEW (not on origin/main), so it must be
+# accessed inside test methods to avoid an AttributeError at collection against base.
 
 
 @contextmanager
@@ -139,19 +139,19 @@ class TestParseEnvPositiveIntMaximum(unittest.TestCase):
     def test_huge_int_rejected_with_maximum(self):
         """10**400 > maximum=4_000_000 → must return None (not the huge int)."""
         with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": str(_HUGE_INT)}):
-            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=_MAX_CONTEXT_WINDOW)
+            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=t.MAX_CONTEXT_WINDOW)
         self.assertIsNone(result, f"huge int leaked through: {result!r}")
 
     def test_above_maximum_rejected(self):
         """5_000_000 > 4_000_000 → None."""
         with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": "5000000"}):
-            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=_MAX_CONTEXT_WINDOW)
+            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=t.MAX_CONTEXT_WINDOW)
         self.assertIsNone(result, f"above-max value leaked through: {result!r}")
 
     def test_below_maximum_accepted(self):
         """200_000 <= 4_000_000 → 200_000 (valid override)."""
         with mock.patch.dict(os.environ, {"COZEMPIC_TEST_CW": "200000"}):
-            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=_MAX_CONTEXT_WINDOW)
+            result = parse_env_positive_int("COZEMPIC_TEST_CW", maximum=t.MAX_CONTEXT_WINDOW)
         self.assertEqual(result, 200_000)
 
     def test_no_maximum_still_works(self):
@@ -304,6 +304,65 @@ class TestApplyTokenEnvOverrides(unittest.TestCase):
             cli._apply_token_env_overrides(args)
             self.assertEqual(os.environ["COZEMPIC_CONTEXT_WINDOW"], "200000")
             self.assertEqual(os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"], "30000")
+
+
+# ── H-1: _prescan_argv must allow --system-overhead-tokens 0 through to the env ──
+
+
+class TestPrescanArgvZeroOverhead(unittest.TestCase):
+    """H-1: _prescan_argv uses `< 0` (not `<= 0`) for --system-overhead-tokens,
+    so the legitimate 'no overhead' value 0 reaches the env var and is not silently
+    dropped with a spurious warning."""
+
+    def _clean_env(self):
+        return {k: v for k, v in os.environ.items()
+                if k != "COZEMPIC_SYSTEM_OVERHEAD_TOKENS"}
+
+    def test_zero_overhead_reaches_env_via_prescan(self):
+        """E2E: drive argv through _prescan_argv; assert env var is set to '0'.
+
+        This test is RED at base (prescan rejects 0 with `<= 0` gate) and GREEN
+        after the fix (gate changed to `< 0`).
+        """
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cleaned = cli._prescan_argv(["guard", "--system-overhead-tokens", "0"])
+            self.assertEqual(
+                os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"), "0",
+                "--system-overhead-tokens 0 was silently dropped by _prescan_argv "
+                "(gate was `<= 0`; must be `< 0` so 0 is passed through)"
+            )
+        # The flag must be consumed by prescan (not left for argparse to see)
+        self.assertNotIn("--system-overhead-tokens", cleaned)
+        self.assertNotIn("0", cleaned)
+
+    def test_zero_overhead_eq_form_reaches_env(self):
+        """E2E: --system-overhead-tokens=0 (= form) also goes through prescan correctly."""
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cli._prescan_argv(["guard", "--system-overhead-tokens=0"])
+            self.assertEqual(
+                os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"), "0",
+                "--system-overhead-tokens=0 (= form) was silently dropped by _prescan_argv"
+            )
+
+    def test_negative_overhead_still_rejected(self):
+        """Negatives must still be rejected; only 0 was wrongly excluded before."""
+        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+            cli._prescan_argv(["guard", "--system-overhead-tokens", "-1"])
+            self.assertIsNone(
+                os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"),
+                "negative --system-overhead-tokens must still be rejected by prescan"
+            )
+
+    def test_context_window_zero_still_rejected(self):
+        """--context-window 0 must still be rejected (0 IS invalid for context window)."""
+        env_key = "COZEMPIC_CONTEXT_WINDOW"
+        clean = {k: v for k, v in os.environ.items() if k != env_key}
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cli._prescan_argv(["guard", "--context-window", "0"])
+            self.assertIsNone(
+                os.environ.get(env_key),
+                "--context-window 0 must be rejected (0 is not a valid context window)"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_input_coercion_corpus.py
+++ b/tests/test_input_coercion_corpus.py
@@ -44,15 +44,19 @@ from cozempic._validation import (
 STR_CORPUS = ["nan", "NaN", "inf", "+inf", "-inf", "infinity", "1e999", "-1e999",
               "-0", "", "   ", "0", "-1", "-0.5", "abc", "١٢٣",
               "1" + "0" * 400, "1.5", "50"]
+# Shared huge-int sentinel — used in both the native corpus and the P-A upper-bound tests.
+# A single definition avoids the 10**400 expression being evaluated twice at module load.
+_HUGE_INT = 10 ** 400
+
 # native-typed corpus for the config-DICT helpers (built in-process, not from a string)
-NATIVE_CORPUS = [float("nan"), float("inf"), float("-inf"), -0.0, 10 ** 400,
+NATIVE_CORPUS = [float("nan"), float("inf"), float("-inf"), -0.0, _HUGE_INT,
                  -1, 0, True, False, None, "x", [], {}]
 
 _UPPER = 10 ** 12  # any CLI/env validator output must be well under this
 
-# --- Huge-int boundary used by P-A tests ---
-_HUGE_INT = 10 ** 400
-_MAX_CONTEXT_WINDOW = 4_000_000   # matches tokens.MAX_CONTEXT_WINDOW (after P-A lands)
+# P-A test boundaries — reference production constants so a change to tokens.py
+# is automatically reflected here without a separate test-file update.
+_MAX_CONTEXT_WINDOW = t.MAX_CONTEXT_WINDOW        # 4_000_000
 _DEFAULT_CONTEXT_WINDOW = t.DEFAULT_CONTEXT_WINDOW  # 1_000_000
 _SYSTEM_OVERHEAD_DEFAULT = t.SYSTEM_OVERHEAD_TOKENS  # 21_000
 

--- a/tests/test_input_coercion_corpus.py
+++ b/tests/test_input_coercion_corpus.py
@@ -74,6 +74,20 @@ def _env(name, value):
             os.environ[name] = old
 
 
+_TOKEN_ENV_KEYS = ("COZEMPIC_CONTEXT_WINDOW", "COZEMPIC_SYSTEM_OVERHEAD_TOKENS")
+
+
+def _token_env_clean() -> dict:
+    """Return current environ with both token override keys removed.
+
+    Used with ``mock.patch.dict(..., clear=True)`` to give each test a known-clean
+    token env without affecting unrelated env vars.  Shared by tests that exercise
+    either _apply_token_env_overrides (both keys) or _prescan_argv (one key), so
+    both classes exclude the full pair and test isolation is consistent.
+    """
+    return {k: v for k, v in os.environ.items() if k not in _TOKEN_ENV_KEYS}
+
+
 def _assert_finite(tc, r):
     tc.assertIsInstance(r, (int, float))
     if isinstance(r, float):
@@ -266,15 +280,10 @@ class TestApplyTokenEnvOverrides(unittest.TestCase):
     """P-C: _apply_token_env_overrides must set env vars using `is not None`,
     so --system-overhead-tokens 0 (legitimate 'no overhead') is honored."""
 
-    def _clean_env(self):
-        """Return a dict with both target keys removed so we start clean."""
-        return {k: v for k, v in os.environ.items()
-                if k not in ("COZEMPIC_CONTEXT_WINDOW", "COZEMPIC_SYSTEM_OVERHEAD_TOKENS")}
-
     def test_zero_system_overhead_sets_env(self):
         """0 is a valid 'no overhead' value — must NOT be silently dropped."""
         args = types.SimpleNamespace(system_overhead_tokens=0, context_window=None)
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._apply_token_env_overrides(args)
             self.assertEqual(os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"), "0",
                              "system_overhead_tokens=0 was silently dropped (truthiness bug)")
@@ -284,7 +293,7 @@ class TestApplyTokenEnvOverrides(unittest.TestCase):
         """context_window=0: also set (downstream parse_env_positive_int will reject it,
         but the CLI layer must not silently drop it first)."""
         args = types.SimpleNamespace(system_overhead_tokens=None, context_window=0)
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._apply_token_env_overrides(args)
             self.assertEqual(os.environ.get("COZEMPIC_CONTEXT_WINDOW"), "0")
             self.assertNotIn("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", os.environ)
@@ -292,7 +301,7 @@ class TestApplyTokenEnvOverrides(unittest.TestCase):
     def test_both_none_sets_neither(self):
         """When both attrs are None, neither env var is touched."""
         args = types.SimpleNamespace(system_overhead_tokens=None, context_window=None)
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._apply_token_env_overrides(args)
             self.assertNotIn("COZEMPIC_CONTEXT_WINDOW", os.environ)
             self.assertNotIn("COZEMPIC_SYSTEM_OVERHEAD_TOKENS", os.environ)
@@ -300,7 +309,7 @@ class TestApplyTokenEnvOverrides(unittest.TestCase):
     def test_positive_values_set_env(self):
         """Normal positive values are set as expected."""
         args = types.SimpleNamespace(system_overhead_tokens=30000, context_window=200000)
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._apply_token_env_overrides(args)
             self.assertEqual(os.environ["COZEMPIC_CONTEXT_WINDOW"], "200000")
             self.assertEqual(os.environ["COZEMPIC_SYSTEM_OVERHEAD_TOKENS"], "30000")
@@ -314,17 +323,13 @@ class TestPrescanArgvZeroOverhead(unittest.TestCase):
     so the legitimate 'no overhead' value 0 reaches the env var and is not silently
     dropped with a spurious warning."""
 
-    def _clean_env(self):
-        return {k: v for k, v in os.environ.items()
-                if k != "COZEMPIC_SYSTEM_OVERHEAD_TOKENS"}
-
     def test_zero_overhead_reaches_env_via_prescan(self):
         """E2E: drive argv through _prescan_argv; assert env var is set to '0'.
 
         This test is RED at base (prescan rejects 0 with `<= 0` gate) and GREEN
         after the fix (gate changed to `< 0`).
         """
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cleaned = cli._prescan_argv(["guard", "--system-overhead-tokens", "0"])
             self.assertEqual(
                 os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"), "0",
@@ -337,7 +342,7 @@ class TestPrescanArgvZeroOverhead(unittest.TestCase):
 
     def test_zero_overhead_eq_form_reaches_env(self):
         """E2E: --system-overhead-tokens=0 (= form) also goes through prescan correctly."""
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._prescan_argv(["guard", "--system-overhead-tokens=0"])
             self.assertEqual(
                 os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"), "0",
@@ -346,7 +351,7 @@ class TestPrescanArgvZeroOverhead(unittest.TestCase):
 
     def test_negative_overhead_still_rejected(self):
         """Negatives must still be rejected; only 0 was wrongly excluded before."""
-        with mock.patch.dict(os.environ, self._clean_env(), clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._prescan_argv(["guard", "--system-overhead-tokens", "-1"])
             self.assertIsNone(
                 os.environ.get("COZEMPIC_SYSTEM_OVERHEAD_TOKENS"),
@@ -355,12 +360,10 @@ class TestPrescanArgvZeroOverhead(unittest.TestCase):
 
     def test_context_window_zero_still_rejected(self):
         """--context-window 0 must still be rejected (0 IS invalid for context window)."""
-        env_key = "COZEMPIC_CONTEXT_WINDOW"
-        clean = {k: v for k, v in os.environ.items() if k != env_key}
-        with mock.patch.dict(os.environ, clean, clear=True):
+        with mock.patch.dict(os.environ, _token_env_clean(), clear=True):
             cli._prescan_argv(["guard", "--context-window", "0"])
             self.assertIsNone(
-                os.environ.get(env_key),
+                os.environ.get("COZEMPIC_CONTEXT_WINDOW"),
                 "--context-window 0 must be rejected (0 is not a valid context window)"
             )
 


### PR DESCRIPTION
## Problem

Three input-validation (L1) gaps found by an adversarial audit of 1.8.30:

1. **An unbounded env int silently disables the guard.** `parse_env_positive_int` / `parse_env_non_negative_int` validate sign but have no upper bound. `int("1"+"0"*400)` is a valid huge Python int, so `COZEMPIC_CONTEXT_WINDOW=<400-digit>` is returned verbatim → `get_context_window_override` yields a giant window → every `pct = total/window` rounds toward 0 → the guard never fires.
2. **A JSON `true` disables the prune floor.** `config._clamp_float` / `_clamp_int` coerce `bool` (a subclass of `int`): `float(True)==1.0` passes the `[0,1]` range check, so a `true` for the floor max-drop-pct silently becomes 1.0 (100% drop).
3. **`--system-overhead-tokens 0` is silently dropped.** `0` is a legitimate value ("no overhead", per the parser's own docstring), but `cli.py` gated the env passthrough on truthiness, so `0` fell back to the 21000 default.

## Fix

1. `maximum=` keyword-only bound on both env parsers; `tokens.py` passes `MAX_CONTEXT_WINDOW = 4_000_000` (4× the current 1M max — generous headroom; above this an override can no longer keep the guard meaningful for a real ≤1M session) and `MAX_SYSTEM_OVERHEAD_TOKENS = DEFAULT_CONTEXT_WINDOW`. Above the bound → warn + fall back to model-detected default.
2. Reject `bool` at the top of `_clamp_float` and `_clamp_int` (class-of-bug fold), matching `_validation._is_strict_number`.
3. Extract `cli._apply_token_env_overrides(args)` using `is not None` — DRY: replaces the duplicated truthiness-gated blocks in `cmd_guard` and `main`.

## Tests

Extended the standing L1 corpus `tests/test_input_coercion_corpus.py` (each new test proven RED at base): huge-int rejection on both parsers + both `tokens` getters, legit 200k / 0 preserved, `_clamp_*(True)` → default, `_apply_token_env_overrides(soh=0)` → env `"0"`.

Full suite: **1342 passed, 5 skipped**. The single remaining failure — `test_active_session_detection.py::...test_two_terminals_two_pids_resolve_independently` — is **pre-existing and host-dependent** (it relies on host PID liveness) and is fixed independently in #124; it is unrelated to this diff.

## Scope

L1 input validation only. No behavior change for valid inputs — the env bounds reject only implausible values and fall back to the existing default.