### PR TITLE
fix(watchdog): verify guard identity before guard-watchdog --fix SIGTERM (L2)

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -979,17 +979,16 @@ def cmd_guard_watchdog(args):
         print(f"      {h.report.reason}")
         print(f"      futile={h.report.futile_cycles} total={h.report.total_prune_cycles} "
               f"backoff_max={h.report.max_backoff_s}s exit_seen={h.report.has_exit}")
-        if getattr(args, "fix", False) and h.pid_alive and h.pid:
-            if not h.guard_confirmed:
-                print(f"      → pid {h.pid} is alive but is NOT a cozempic guard "
-                      f"(recycled?) — refusing to kill")
-            else:
-                try:
-                    os.kill(int(h.pid), signal.SIGTERM)
-                    print(f"      → SIGTERM sent to looping daemon pid {h.pid}")
-                    arrested += 1
-                except (ProcessLookupError, PermissionError, OSError) as e:
-                    print(f"      ! could not signal pid {h.pid}: {e}")
+        if getattr(args, "fix", False) and h.guard_confirmed:
+            try:
+                os.kill(int(h.pid), signal.SIGTERM)
+                print(f"      → SIGTERM sent to looping daemon pid {h.pid}")
+                arrested += 1
+            except (ProcessLookupError, PermissionError, OSError) as e:
+                print(f"      ! could not signal pid {h.pid}: {e}")
+        elif getattr(args, "fix", False) and h.pid_alive and h.pid:
+            print(f"      → pid {h.pid} is alive but is NOT a cozempic guard "
+                  f"(recycled?) — refusing to kill")
         elif h.pid_alive:
             print(f"      → re-run with --fix to terminate this looping daemon "
                   f"(or: kill {h.pid})")

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -952,8 +952,9 @@ def cmd_guard_watchdog(args):
     A process safeguard outside the daemon: an OLD or broken guard that fails to
     self-arrest (the f641174c / PilotCC reload-loop) keeps spinning until killed.
     This reads the guard logs and flags the loop signature. ``--fix`` SIGTERMs a
-    LIVE looping daemon (our own process — stopping a harmful loop is safe); the
-    default is report-only.
+    LIVE looping daemon that has been IDENTITY-VERIFIED as a cozempic guard
+    process; without that check, a recycled PID (kernel reuse after hard exit)
+    could be an innocent unrelated process. The default mode is report-only.
     """
     import signal
     from .watchdog import scan_guard_logs
@@ -979,12 +980,16 @@ def cmd_guard_watchdog(args):
         print(f"      futile={h.report.futile_cycles} total={h.report.total_prune_cycles} "
               f"backoff_max={h.report.max_backoff_s}s exit_seen={h.report.has_exit}")
         if getattr(args, "fix", False) and h.pid_alive and h.pid:
-            try:
-                os.kill(int(h.pid), signal.SIGTERM)
-                print(f"      → SIGTERM sent to looping daemon pid {h.pid}")
-                arrested += 1
-            except (ProcessLookupError, PermissionError, OSError) as e:
-                print(f"      ! could not signal pid {h.pid}: {e}")
+            if not h.guard_confirmed:
+                print(f"      → pid {h.pid} is alive but is NOT a cozempic guard "
+                      f"(recycled?) — refusing to kill")
+            else:
+                try:
+                    os.kill(int(h.pid), signal.SIGTERM)
+                    print(f"      → SIGTERM sent to looping daemon pid {h.pid}")
+                    arrested += 1
+                except (ProcessLookupError, PermissionError, OSError) as e:
+                    print(f"      ! could not signal pid {h.pid}: {e}")
         elif h.pid_alive:
             print(f"      → re-run with --fix to terminate this looping daemon "
                   f"(or: kill {h.pid})")

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -142,6 +142,7 @@ class GuardLoopHit:
     pid: int | None
     pid_alive: bool
     report: LoopReport
+    guard_confirmed: bool = False  # True iff pid_alive AND process is a cozempic guard
 
 
 def _read_pid(pid_file: Path) -> int | None:
@@ -194,11 +195,21 @@ def scan_guard_logs(
             continue
         pid_file = log_file.with_suffix(".pid")
         pid = _read_pid(pid_file) if pid_file.exists() else None
+        alive = _pid_alive(pid)
+        if alive and pid is not None:
+            # Lazy import to avoid a heavy module-level import of guard.py (large,
+            # side-effecty) and to prevent a circular import (guard imports watchdog
+            # indirectly through its own helpers).
+            from .guard import _is_cozempic_guard_process
+            confirmed = _is_cozempic_guard_process(pid)
+        else:
+            confirmed = False
         hits.append(GuardLoopHit(
             log_file=log_file,
             pid_file=pid_file if pid_file.exists() else None,
             pid=pid,
-            pid_alive=_pid_alive(pid),
+            pid_alive=alive,
             report=rep,
+            guard_confirmed=confirmed,
         ))
     return hits

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -196,10 +196,11 @@ def scan_guard_logs(
         pid_file = log_file.with_suffix(".pid")
         pid = _read_pid(pid_file) if pid_file.exists() else None
         alive = _pid_alive(pid)
-        if alive and pid is not None:
-            # Lazy import to avoid a heavy module-level import of guard.py (large,
-            # side-effecty) and to prevent a circular import (guard imports watchdog
-            # indirectly through its own helpers).
+        if alive:
+            # Lazy import: avoids the heavy module-level guard.py load (large,
+            # side-effecty) and prevents a circular import (guard imports watchdog
+            # indirectly through its own helpers). alive=True implies pid is not
+            # None (since _pid_alive(None) returns False).
             from .guard import _is_cozempic_guard_process
             confirmed = _is_cozempic_guard_process(pid)
         else:

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -209,10 +209,12 @@ class TestCliCommand(unittest.TestCase):
         self.assertEqual(cm.exception.code, 3)
 
     def test_fix_sends_sigterm(self):
+        """--fix SIGTERMs a pid confirmed as a cozempic guard (guard_confirmed=True)."""
         killed = {}
         def fake_kill(pid, sig):
             killed["pid"], killed["sig"] = pid, sig
         with mock.patch("cozempic.watchdog._pid_alive", lambda pid: True), \
+             mock.patch("cozempic.guard._is_cozempic_guard_process", return_value=True), \
              mock.patch("os.kill", fake_kill):
             self._run(fix=True)
         self.assertEqual(killed.get("pid"), 4242)
@@ -254,7 +256,11 @@ class TestFixIdentityGate(unittest.TestCase):
              mock.patch("cozempic.guard._is_cozempic_guard_process", return_value=is_guard), \
              mock.patch("os.kill", fake_kill):
             args = SimpleNamespace(fix=True, log_dir=str(self.dir), loop_trip=20)
-            cmd_guard_watchdog(args)
+            try:
+                cmd_guard_watchdog(args)
+            except SystemExit:
+                # sys.exit(3) when live loop not arrested (non-guard case) — expected
+                pass
         return killed
 
     def test_fix_refuses_to_kill_non_guard(self):

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -219,5 +219,61 @@ class TestCliCommand(unittest.TestCase):
         self.assertEqual(killed.get("sig"), signal.SIGTERM)
 
 
+class TestFixIdentityGate(unittest.TestCase):
+    """L2 HIGH: --fix must verify guard identity before sending SIGTERM.
+
+    Confused-deputy scenario: guard exits hard (SIGKILL / OOM), pidfile is
+    never unlinked, OS recycles the PID to an unrelated same-user process,
+    operator runs `cozempic guard-watchdog --fix`.  Without an identity gate,
+    the innocent process is SIGTERMed.
+
+    RED-at-base proof: before the fix, ``test_fix_refuses_to_kill_non_guard``
+    fails because os.kill IS called on the recycled pid (SIGTERM to innocent).
+    After the fix, the gate blocks the kill and the test passes.
+    """
+
+    def setUp(self):
+        self._td = TemporaryDirectory()
+        self.dir = Path(self._td.name)
+        (self.dir / "cozempic_guard_zzz.log").write_text(_respawn_storm(), encoding="utf-8")
+        (self.dir / "cozempic_guard_zzz.pid").write_text("7777", encoding="utf-8")
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def _run_fix(self, is_guard: bool) -> dict:
+        """Drive cmd_guard_watchdog(fix=True) with identity mock; return kill calls."""
+        from types import SimpleNamespace
+        from cozempic.cli import cmd_guard_watchdog
+        killed: dict = {}
+
+        def fake_kill(pid, sig):
+            killed["pid"], killed["sig"] = pid, sig
+
+        with mock.patch("cozempic.watchdog._pid_alive", return_value=True), \
+             mock.patch("cozempic.guard._is_cozempic_guard_process", return_value=is_guard), \
+             mock.patch("os.kill", fake_kill):
+            args = SimpleNamespace(fix=True, log_dir=str(self.dir), loop_trip=20)
+            cmd_guard_watchdog(args)
+        return killed
+
+    def test_fix_refuses_to_kill_non_guard(self):
+        """RED-at-base: a recycled (non-guard) pid must NOT receive SIGTERM.
+
+        Without guard_confirmed gate, os.kill IS called — this test FAILS at
+        base and PASSES after the fix adds the identity check.
+        """
+        killed = self._run_fix(is_guard=False)
+        self.assertNotIn("pid", killed,
+                         "os.kill was called on a recycled non-guard pid — "
+                         "confused-deputy bug: the identity gate is missing")
+
+    def test_fix_kills_confirmed_guard(self):
+        """A pid confirmed as a cozempic guard MUST receive SIGTERM under --fix."""
+        killed = self._run_fix(is_guard=True)
+        self.assertEqual(killed.get("pid"), 7777)
+        self.assertEqual(killed.get("sig"), signal.SIGTERM)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The v1.8.30 `guard-watchdog --fix` (`cmd_guard_watchdog`) SIGTERMs a PID read straight from a `cozempic_guard_*.pid` file, gated only on liveness (`h.pid_alive` — a bare `os.kill(pid,0)` that even treats `PermissionError` as alive), with **no identity check**. `watchdog.py` never imports `guard._is_cozempic_guard_process` — the argv-based check every other kill site in guard.py uses (guard.py:2915/3789/3799).

Confused-deputy: a guard loop-churns its log, then dies HARD (SIGKILL/OOM/power-loss) so its pidfile is never CAS-unlinked; the OS recycles that PID to an unrelated same-user process; an operator — or a cron/CI wrapper, which the cli's own comment explicitly invites — runs `cozempic guard-watchdog --fix` → it SIGTERMs the **innocent** process. The cli docstring even claimed `--fix` "SIGTERMs ... our own process — stopping a harmful loop is safe", which was unverified.

## Fix

- Add `GuardLoopHit.guard_confirmed: bool`, computed in `scan_guard_logs` for a live pid via a lazy `from .guard import _is_cozempic_guard_process` (argv check — **ps-only, no psutil**, so it delivers full value on the zero-dependency default install; avoids the PR #98 optional-dep trap). A dead/absent pid → `False` without a check.
- `--fix` now SIGTERMs **only** when `guard_confirmed`; a live-but-unconfirmed pid prints `refusing to kill` and leaves `arrested=0`, so the `sys.exit(3)` cron-alert path still fires on an un-arrested live loop. Docstring corrected to state the identity check.

## Tests

`tests/test_guard_watchdog.py::TestFixIdentityGate` — RED-at-base proven (against base source the captured stdout literally shows `→ SIGTERM sent to looping daemon pid 7777`, i.e. base KILLS the innocent pid) → GREEN after the gate; plus the positive `test_fix_kills_confirmed_guard`. **19/19** watchdog tests green.

## Scope

L2 daemon-kill safety only. The 2 `_pid_alive` liveness copies (this PR adds none, so the class-of-bug fold doesn't trigger), the SIGTERM-startup-window pidfile leak, and the hardcoded watcher-log path → `_guard_tmp_root` are tracked for a separate guard-cleanup PR.