### PR TITLE
fix(digest): skip sub-agent (sidechain) turns in extract_corrections (L6)

### DIFF
--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -21,6 +21,7 @@ from typing import Literal
 
 from ._validation import parse_env_bool
 from .helpers import get_content_blocks, get_msg_type, text_of
+from .tokens import _is_sidechain
 from .types import Message
 
 # ---------------------------------------------------------------------------
@@ -426,6 +427,14 @@ def extract_corrections(
 
     prev_assistant_text = ""
     for pos, (idx, msg, _) in enumerate(messages):
+        # Skip sub-agent (sidechain) turns entirely — they are scaffolding/tool
+        # prompts, not the human correcting Claude. Mining them is an L6
+        # injection: untrusted sub-agent content becomes a learned behavioral rule.
+        # Also skip their assistant text from prev_assistant_text so sidechain
+        # context never bleeds into the `before` field of a following main turn.
+        if _is_sidechain(msg):
+            continue
+
         if pos < since_turn:
             # Track assistant text even before our window
             if get_msg_type(msg) == "assistant":

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -3068,3 +3068,97 @@ class TestDigestInjectMessage(unittest.TestCase):
     def test_synced_count(self):
         out = self._run(Path("/x/memory"), 3, ["rule"])
         self.assertIn("Synced 3", out)
+
+
+# ---------------------------------------------------------------------------
+# L6 — sidechain turns must not be mined as corrections
+# ---------------------------------------------------------------------------
+
+class TestSidechainInjectionGuard(unittest.TestCase):
+    """L6 injection: sub-agent (sidechain) user-turns must NEVER produce a DigestRule.
+
+    Confused-deputy scenario: a sub-agent conversation has isSidechain=True on every
+    message. Its user-side turns (scaffolding prompts) can carry EXPLICIT_CORRECTION
+    phrases. Without an isSidechain guard, extract_corrections mines those as if they
+    were the human's own corrections → untrusted sub-agent scaffolding becomes a
+    learned behavioral rule injected into the main session.
+
+    RED-at-base proof: before the guard, a sidechain user-turn with
+    "don't add Co-Authored-By" yields 1 DigestRule. After the guard: 0 rules.
+
+    Paired positive test: the IDENTICAL turn WITHOUT isSidechain DOES produce a rule
+    (proves the flag is the discriminant, not the phrase).
+    """
+
+    CORRECTION_PHRASE = "don't add Co-Authored-By to commits"
+
+    def _make_sidechain_user(self, line_idx: int, text: str) -> tuple:
+        """A user-role turn with isSidechain=True at the top level."""
+        return make_message(line_idx, {
+            "type": "user",
+            "isSidechain": True,
+            "message": {"role": "user", "content": text},
+        })
+
+    def _make_sidechain_assistant(self, line_idx: int, text: str) -> tuple:
+        """An assistant-role turn with isSidechain=True at the top level."""
+        return make_message(line_idx, {
+            "type": "assistant",
+            "isSidechain": True,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        })
+
+    def test_sidechain_user_turn_produces_no_rule(self):
+        """RED-at-base: a sidechain user-turn carrying an EXPLICIT_CORRECTION phrase
+        must yield 0 rules. Without the guard, extract_corrections mines it and yields
+        1 rule — the confused-deputy injection.
+        """
+        messages = [
+            self._make_sidechain_user(0, self.CORRECTION_PHRASE),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(
+            len(rules), 0,
+            "sidechain (sub-agent) user-turn must NOT produce a DigestRule — "
+            "isSidechain guard is missing (L6 confused-deputy injection)"
+        )
+
+    def test_main_turn_same_phrase_produces_rule(self):
+        """Positive control: the SAME phrase in a main-session (non-sidechain) turn
+        MUST produce exactly 1 rule. This proves the isSidechain flag is the
+        discriminant, not the phrase itself.
+        """
+        messages = [
+            make_user(0, self.CORRECTION_PHRASE),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(
+            len(rules), 1,
+            "a main-session user-turn with EXPLICIT_CORRECTION must produce a rule"
+        )
+
+    def test_sidechain_assistant_does_not_pollute_prev_assistant_text(self):
+        """A sidechain assistant-turn in the pre-window must NOT set prev_assistant_text.
+
+        Without the guard, a sidechain assistant turn sets prev_assistant_text, so the
+        next main-session user-turn sees a non-empty prev_assistant_text and may be
+        classified differently (e.g. APOLOGY_FOLLOW_UP instead of EXPLICIT_CORRECTION).
+        This is a pollution of context between sidechain and main turns.
+        """
+        # Sidechain assistant turn (pre-window), then main user correction.
+        # The sidechain assistant text is irrelevant scaffolding; the main rule
+        # should have an empty `before` field (prev_assistant_text not polluted).
+        messages = [
+            self._make_sidechain_assistant(0, "Sub-agent said something here."),
+            make_user(1, self.CORRECTION_PHRASE),
+        ]
+        rules = extract_corrections(messages)
+        self.assertEqual(len(rules), 1, "main-session correction after sidechain assistant must be captured")
+        self.assertEqual(
+            rules[0].before, "",
+            "prev_assistant_text must NOT be set from a sidechain assistant turn — "
+            "sidechain context must not bleed into main-session rule evidence"
+        )

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -70,6 +70,24 @@ def make_assistant(line_idx: int, text: str) -> tuple[int, dict, int]:
     })
 
 
+def make_sidechain_user(line_idx: int, text: str) -> tuple[int, dict, int]:
+    """A user-role turn with isSidechain=True at the top level (sub-agent scaffolding)."""
+    return make_message(line_idx, {
+        "type": "user",
+        "isSidechain": True,
+        "message": {"role": "user", "content": text},
+    })
+
+
+def make_sidechain_assistant(line_idx: int, text: str) -> tuple[int, dict, int]:
+    """An assistant-role turn with isSidechain=True at the top level (sub-agent response)."""
+    return make_message(line_idx, {
+        "type": "assistant",
+        "isSidechain": True,
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    })
+
+
 # ---------------------------------------------------------------------------
 # classify_turn
 # ---------------------------------------------------------------------------
@@ -3092,32 +3110,13 @@ class TestSidechainInjectionGuard(unittest.TestCase):
 
     CORRECTION_PHRASE = "don't add Co-Authored-By to commits"
 
-    def _make_sidechain_user(self, line_idx: int, text: str) -> tuple:
-        """A user-role turn with isSidechain=True at the top level."""
-        return make_message(line_idx, {
-            "type": "user",
-            "isSidechain": True,
-            "message": {"role": "user", "content": text},
-        })
-
-    def _make_sidechain_assistant(self, line_idx: int, text: str) -> tuple:
-        """An assistant-role turn with isSidechain=True at the top level."""
-        return make_message(line_idx, {
-            "type": "assistant",
-            "isSidechain": True,
-            "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": text}],
-            },
-        })
-
     def test_sidechain_user_turn_produces_no_rule(self):
         """RED-at-base: a sidechain user-turn carrying an EXPLICIT_CORRECTION phrase
         must yield 0 rules. Without the guard, extract_corrections mines it and yields
         1 rule — the confused-deputy injection.
         """
         messages = [
-            self._make_sidechain_user(0, self.CORRECTION_PHRASE),
+            make_sidechain_user(0, self.CORRECTION_PHRASE),
         ]
         rules = extract_corrections(messages)
         self.assertEqual(
@@ -3141,18 +3140,16 @@ class TestSidechainInjectionGuard(unittest.TestCase):
         )
 
     def test_sidechain_assistant_does_not_pollute_prev_assistant_text(self):
-        """A sidechain assistant-turn in the pre-window must NOT set prev_assistant_text.
+        """A sidechain assistant-turn must NOT set prev_assistant_text.
 
         Without the guard, a sidechain assistant turn sets prev_assistant_text, so the
         next main-session user-turn sees a non-empty prev_assistant_text and may be
         classified differently (e.g. APOLOGY_FOLLOW_UP instead of EXPLICIT_CORRECTION).
-        This is a pollution of context between sidechain and main turns.
         """
-        # Sidechain assistant turn (pre-window), then main user correction.
-        # The sidechain assistant text is irrelevant scaffolding; the main rule
+        # Sidechain assistant turn, then main user correction. The main rule
         # should have an empty `before` field (prev_assistant_text not polluted).
         messages = [
-            self._make_sidechain_assistant(0, "Sub-agent said something here."),
+            make_sidechain_assistant(0, "Sub-agent said something here."),
             make_user(1, self.CORRECTION_PHRASE),
         ]
         rules = extract_corrections(messages)


### PR DESCRIPTION
## Problem

`digest.extract_corrections` scans `user` turns for correction signals and builds a `DigestRule` — which is injected as a `hard` behavioral rule into the MAIN session. It filters `_is_system_noise` but has **no `isSidechain` guard**. So a SUB-AGENT conversation's user-turn (role:user, type:text, inside a sidechain) carrying an explicit-correction phrase is mined as if it were the human's direct correction → **untrusted sub-agent content becomes a learned behavioral rule**. Sidechain turns are sub-agent scaffolding/prompts, not the user correcting Claude.

## Fix

One `if _is_sidechain(msg): continue` at the TOP of the loop (reusing the canonical `tokens._is_sidechain`), placed BEFORE the pre-window split — so neither a sidechain user-turn is mined NOR a sidechain assistant-turn pollutes `prev_assistant_text` (the `before` evidence) for a following main rule. `extract_corrections` is the sole turn-mining chokepoint (`update_digest` / `flush_digest` / `recover_digest` all funnel through it), so the one guard closes the class.

## Tests

`tests/test_digest.py::TestSidechainInjectionGuard` — RED-at-base proven (a sidechain correction turn yields a rule at base: `1 != 0`), GREEN after. Plus a **positive control** (the IDENTICAL phrase WITHOUT `isSidechain` DOES yield a rule — proving the flag, not the phrasing, is the discriminant) and a **bleed control** (a sidechain assistant turn no longer populates the next main rule's `before`). `test_digest.py` = 216/216.

## Scope

L6 untrusted-input / digest pollution. `digest.py` only, stdlib.