### PR TITLE
fix(safety): enforce_floor must not fork the conversation DAG on a compacted session (L7)

### DIFF
--- a/src/cozempic/safety.py
+++ b/src/cozempic/safety.py
@@ -631,12 +631,18 @@ def enforce_floor(
                 if btype == "tool_use":
                     tid = block.get("id", "")
                     for p in tool_use_id_to_results.get(tid, set()):
-                        if p not in must_preserve:
+                        # M-1 (review): don't re-add a PRE-boundary pair partner past an
+                        # active compact_boundary — else step-3 pair-closure re-introduces a
+                        # pre-boundary root (the 2-root fork P0-A prevents elsewhere; C9 would
+                        # otherwise have to abort the prune).
+                        pe = before_by_uuid.get(p)
+                        if p not in must_preserve and not (pe and _is_pre_boundary(pe[0])):
                             new_additions.add(p)
                 elif btype == "tool_result":
                     tid = block.get("tool_use_id", "")
                     for owner in tool_use_id_to_owner.get(tid, set()):
-                        if owner not in must_preserve:
+                        oe = before_by_uuid.get(owner)
+                        if owner not in must_preserve and not (oe and _is_pre_boundary(oe[0])):
                             new_additions.add(owner)
         if not new_additions:
             break

--- a/src/cozempic/safety.py
+++ b/src/cozempic/safety.py
@@ -74,6 +74,27 @@ def _last_compact_boundary(
     return last
 
 
+def _last_active_compact_boundary_idx(
+    messages: list[tuple[int, dict, int]],
+) -> int | None:
+    """Return the line index of the last ACTIVE compact_boundary in messages.
+
+    An active boundary is one WITHOUT ``hasPreservedSegment=True``.
+    Returns None when no active boundary is found (normal non-compacted sessions).
+
+    Used by enforce_floor and validate_post_prune to determine which messages
+    are pre-boundary and therefore must not be re-added (P0-A) or required to
+    survive (C2 eligibility).
+    """
+    last_idx: int | None = None
+    for idx, msg, _ in messages:
+        if (msg.get("type") == "system"
+                and msg.get("subtype") == "compact_boundary"
+                and not msg.get("hasPreservedSegment")):
+            last_idx = idx
+    return last_idx
+
+
 def _build_orphan_shells(
     msgs_before: list[tuple[int, dict, int]],
 ) -> set[str]:
@@ -205,12 +226,7 @@ def validate_post_prune(
     # pre-boundary root; the compact_boundary itself becomes the new session root
     # (with parentUuid=None after _relink_parent_chain). Requiring the original
     # root to survive would contradict the collapse contract.
-    compact_boundary_before_line_idx: int | None = None
-    for idx, msg, _ in msgs_before:
-        if (msg.get("type") == "system"
-                and msg.get("subtype") == "compact_boundary"
-                and not msg.get("hasPreservedSegment")):
-            compact_boundary_before_line_idx = idx
+    compact_boundary_before_line_idx = _last_active_compact_boundary_idx(msgs_before)
     original_root_uuids: set[str] = set()
     for idx, msg, _ in msgs_before:
         if msg.get("parentUuid") is None and msg.get("uuid"):
@@ -483,13 +499,7 @@ def enforce_floor(
     # compact-summary-collapse legitimately dropped. Re-adding them would create a
     # 2-root DAG fork (root-0 and cb-1 both have parentUuid=None).
     # We compute the boundary line index here so step 2a/b/c can all skip pre-boundary.
-    compact_boundary_line_idx: int | None = None
-    for idx, msg, _ in msgs_before:
-        if (msg.get("type") == "system"
-                and msg.get("subtype") == "compact_boundary"
-                and not msg.get("hasPreservedSegment")):
-            compact_boundary_line_idx = idx
-            # keep scanning to find the LAST boundary (defensive; normally only one)
+    compact_boundary_line_idx = _last_active_compact_boundary_idx(msgs_before)
     # compact_boundary_line_idx is None when no active boundary exists (normal sessions).
 
     def _is_pre_boundary(candidate_idx: int) -> bool:

--- a/src/cozempic/safety.py
+++ b/src/cozempic/safety.py
@@ -133,8 +133,8 @@ def validate_post_prune(
 ) -> None:
     """Validate the pruned message list. Raise PruneValidationError on failure.
 
-    Checks run fail-fast in order C3 → C2 → C4 → C5 → C6 → C7 → C1 → C8 (semantic
-    checks before structural so the failure attribution is actionable):
+    Checks run fail-fast in order C3 → C2 → C9 → C4 → C5 → C6 → C7 → C1 → C8
+    (semantic checks before structural so the failure attribution is actionable):
 
       C1. parentUuid resolution — baseline-relative + orphan-shell-aware: only
           flag a parent that (a) WAS in msgs_before, (b) is absent from msgs_after,
@@ -142,9 +142,9 @@ def validate_post_prune(
           (parent ∉ before_uuids) and legitimately-dropped orphan-shell parents
           are both valid and skipped.
       C2. Root preserved — at least one ELIGIBLE original ``parentUuid=null`` uuid
-          from msgs_before must survive. Eligible = NOT a legit_removed_orphan_shell.
-          An orphan-shell root's removal is legitimate; it is excluded from the
-          required-root set (REVIEW-max B.11 + C-1 correctness fix).
+          from msgs_before must survive. Eligible = NOT a legit_removed_orphan_shell
+          AND NOT a pre-boundary root legitimately retired by compact-summary-collapse
+          (P0-A fix: compact_boundary becomes the new root in that case).
       C3. Conversation survival — ≥1 user AND ≥1 assistant survives.
       C4. compact_boundary — if msgs_before had a system/compact_boundary
           entry, the LAST such entry MUST survive.
@@ -158,6 +158,9 @@ def validate_post_prune(
           ``tool_result`` existed in msgs_before MUST keep that result in
           msgs_after (a dangling tool_use is structurally valid but
           unresumable; mirror of the orphaned-tool_result handling).
+      C9. Single-root invariant — baseline-relative: msgs_after must not have
+          MORE roots (parentUuid=None, non-orphan-shell) than msgs_before.
+          Catches 2-root DAG forks introduced by any strategy or floor bug.
 
     Each check is CONDITIONAL on its precondition existing in msgs_before —
     a session that never had a permission-mode entry passes C5 trivially.
@@ -197,9 +200,24 @@ def validate_post_prune(
     # ELIGIBLE = not a legit_removed_orphan_shell (C-1 fix): an orphan-shell
     # root is legitimately dropped by fix_orphaned_tool_results; its absence
     # must not trigger C2. (REVIEW-max B.11 + C-1 correctness fix.)
+    # ELIGIBLE also excludes pre-boundary roots when an active compact_boundary
+    # exists (P0-A fix): compact-summary-collapse legitimately retires the
+    # pre-boundary root; the compact_boundary itself becomes the new session root
+    # (with parentUuid=None after _relink_parent_chain). Requiring the original
+    # root to survive would contradict the collapse contract.
+    compact_boundary_before_line_idx: int | None = None
+    for idx, msg, _ in msgs_before:
+        if (msg.get("type") == "system"
+                and msg.get("subtype") == "compact_boundary"
+                and not msg.get("hasPreservedSegment")):
+            compact_boundary_before_line_idx = idx
     original_root_uuids: set[str] = set()
-    for _, msg, _ in msgs_before:
+    for idx, msg, _ in msgs_before:
         if msg.get("parentUuid") is None and msg.get("uuid"):
+            # Pre-boundary root legitimately dropped by compact-summary-collapse.
+            if (compact_boundary_before_line_idx is not None
+                    and idx < compact_boundary_before_line_idx):
+                continue
             original_root_uuids.add(msg["uuid"])
     eligible_roots = original_root_uuids - legit_removed_orphan_shells
     if eligible_roots and not (eligible_roots & surviving_uuids):
@@ -214,6 +232,39 @@ def validate_post_prune(
                 "expected_root_uuids": sorted(eligible_roots),
                 "before_count": len(msgs_before),
                 "after_count": len(msgs_after),
+            },
+        )
+
+    # ── C9: single-root invariant (no multi-root fork) ───────────────────────
+    # P0-A enforces this in enforce_floor; C9 is the defensive net that catches
+    # any future code path creating a second DAG root (e.g. a new strategy, a
+    # floor edge case, a hasPreservedSegment interaction).
+    # BASELINE-RELATIVE: only raise if msgs_after has MORE roots than msgs_before.
+    # This allows legitimate 2-chain team sessions (2 roots before → 2 after = OK;
+    # 1 root before → 2 after = C9).
+    before_roots_count = sum(
+        1 for _, msg, _ in msgs_before
+        if not msg.get("parentUuid") and msg.get("uuid")
+        and msg.get("uuid") not in legit_removed_orphan_shells
+    )
+    after_roots: list[str] = [
+        msg.get("uuid", "")
+        for _, msg, _ in msgs_after
+        if not msg.get("parentUuid")
+        and msg.get("uuid")
+        and msg.get("uuid") not in legit_removed_orphan_shells
+    ]
+    if len(after_roots) > before_roots_count:
+        raise PruneValidationError(
+            reason=(
+                f"prune introduced additional DAG roots: "
+                f"{len(after_roots)} roots after vs {before_roots_count} before"
+            ),
+            evidence={
+                "failed_check": "C9",
+                "root_uuids_after": sorted(after_roots),
+                "root_count_after": len(after_roots),
+                "root_count_before": before_roots_count,
             },
         )
 
@@ -427,6 +478,25 @@ def enforce_floor(
     # ── Step 2: must-preserve candidates ─────────────────────────────────────
     must_preserve: set[str] = set()
 
+    # P0-A: If there is an active compact_boundary (hasPreservedSegment not set),
+    # all messages at indices BEFORE the boundary are pre-boundary turns that
+    # compact-summary-collapse legitimately dropped. Re-adding them would create a
+    # 2-root DAG fork (root-0 and cb-1 both have parentUuid=None).
+    # We compute the boundary line index here so step 2a/b/c can all skip pre-boundary.
+    compact_boundary_line_idx: int | None = None
+    for idx, msg, _ in msgs_before:
+        if (msg.get("type") == "system"
+                and msg.get("subtype") == "compact_boundary"
+                and not msg.get("hasPreservedSegment")):
+            compact_boundary_line_idx = idx
+            # keep scanning to find the LAST boundary (defensive; normally only one)
+    # compact_boundary_line_idx is None when no active boundary exists (normal sessions).
+
+    def _is_pre_boundary(candidate_idx: int) -> bool:
+        """True iff the candidate is a pre-boundary turn that must not be re-added."""
+        return (compact_boundary_line_idx is not None
+                and candidate_idx < compact_boundary_line_idx)
+
     # preserve_first_message pins the first parentUuid=null root. NOTE: with the
     # default (True) this also satisfies validate_post_prune C2 (which requires an
     # original root to survive). Setting preserve_first_message=False together with
@@ -436,13 +506,17 @@ def enforce_floor(
     # re-adding the original root would undo compact-summary-collapse, which
     # legitimately drops the pre-boundary root in favor of the compact summary.
     if cfg.preserve_first_message:
-        for _, msg, _ in msgs_before:
+        for idx, msg, _ in msgs_before:
             if msg.get("parentUuid") is None and msg.get("uuid"):
-                must_preserve.add(msg["uuid"])
+                if not _is_pre_boundary(idx):
+                    must_preserve.add(msg["uuid"])
                 break
 
+    # Pre-boundary turns must not be re-added (P0-A). Exclude them from all
+    # must-preserve candidate lists so last_k and survival-cap never pin them.
     users_in_order = [
-        (idx, m) for idx, m, _ in msgs_before if m.get("type") == "user"
+        (idx, m) for idx, m, _ in msgs_before
+        if m.get("type") == "user" and not _is_pre_boundary(idx)
     ]
     # Real conversational user turns exclude tool_result-carrier user messages
     # (whose content is tool_result blocks, not a user utterance) — used for the
@@ -458,10 +532,11 @@ def enforce_floor(
 
     user_turns_in_order = [
         (idx, m) for idx, m, _ in msgs_before
-        if m.get("type") == "user" and _is_real_user_turn(m)
+        if m.get("type") == "user" and _is_real_user_turn(m) and not _is_pre_boundary(idx)
     ]
     asst_in_order = [
-        (idx, m) for idx, m, _ in msgs_before if m.get("type") == "assistant"
+        (idx, m) for idx, m, _ in msgs_before
+        if m.get("type") == "assistant" and not _is_pre_boundary(idx)
     ]
 
     last_k = max(0, int(cfg.preserve_last_k_turns))

--- a/tests/test_prune_safety.py
+++ b/tests/test_prune_safety.py
@@ -864,6 +864,87 @@ class TestFloorCompactedSession:
             f"root uuids: {[m.get('uuid') for m in roots]}"
         )
 
+    def test_floor_step3_does_not_re_add_pre_boundary_pair_partner(self):
+        """REGRESSION GUARD (review M-1) — RED without 8dce0b7: step-3 pair-closure re-adds
+        the pre-boundary tool_result partner when the post-boundary tool_use is preserved,
+        introducing a second DAG root (2-root fork).
+
+        Scenario (compacted session with tool pair straddling the boundary):
+          idx=0  pre-result  (user, parentUuid=None)  ← PRE-boundary root; tool_result(tid-1)
+          idx=1  cb-1        (compact_boundary, parentUuid=pre-result)
+          idx=2  cs-1        (compact_summary, parentUuid=cb-1)
+          idx=3  post-use    (asst, parentUuid=cs-1)  ← tool_use(tid-1), post-boundary
+          idx=4  pt-final    (user, parentUuid=post-use)  ← last user turn
+
+        After compact-summary-collapse removes pre-result (idx=0), cb-1 is relinked to
+        parentUuid=None (becomes the session root). preserve_last_k_turns=1 preserves
+        post-use (idx=3). Step-3 pair-closure then inspects post-use:
+          tool_use(id="tid-1") → tool_use_id_to_results["tid-1"] = {pre-result.uuid}
+
+        WITHOUT 8dce0b7 gate: pre-result added to must_preserve → re-added to result
+          → result has TWO roots: cb-1 (parentUuid=None) + pre-result (parentUuid=None).
+        WITH 8dce0b7 gate: pre-result is _is_pre_boundary(idx=0) → skipped.
+          → result has exactly ONE root: cb-1.
+
+        Asserts:
+          - exactly 1 root in enforce_floor result (cb-1)
+          - pre-result uuid is NOT in the result
+        """
+        import cozempic.strategies  # noqa: F401 — registers strategy names
+        from cozempic.executor import execute_actions
+        from cozempic.strategies.gentle import strategy_compact_summary_collapse
+        from cozempic.safety import enforce_floor
+        from cozempic.config import FloorConfig
+
+        # pre-result: parentUuid=None → it IS the pre-boundary root
+        pre_result_msg = (0, {
+            "type": "user",
+            "uuid": "pre-result",
+            "message": {
+                "content": [{"type": "tool_result", "tool_use_id": "tid-1", "content": "ok"}],
+                "role": "user",
+            },
+        }, 80)
+        cb1_msg = _cb(1, "cb-1", parent="pre-result")
+        cs1_msg = _cs(2, "cs-1", parent="cb-1")
+        # post-use: post-boundary asst with matching tool_use
+        post_use_msg = (3, {
+            "type": "assistant",
+            "uuid": "post-use",
+            "parentUuid": "cs-1",
+            "message": {
+                "content": [{"type": "tool_use", "id": "tid-1", "name": "Bash", "input": {}}],
+                "role": "assistant",
+            },
+        }, 100)
+        pt_final_msg = _user(4, "pt-final", parent="post-use")
+
+        msgs_before = [pre_result_msg, cb1_msg, cs1_msg, post_use_msg, pt_final_msg]
+
+        # Run compact-summary-collapse (removes pre-boundary turns, relinks cb-1 to root)
+        strategy_result = strategy_compact_summary_collapse(msgs_before, {})
+        msgs_after_collapse = execute_actions(msgs_before, strategy_result.actions)
+
+        # preserve_last_k_turns=1 puts post-use into must_preserve → step-3 fires
+        cfg = FloorConfig(preserve_first_message=False, preserve_last_k_turns=1,
+                          max_user_assistant_drop_pct=0.0)
+        result = enforce_floor(msgs_before, msgs_after_collapse, cfg=cfg)
+
+        result_uuids = {m.get("uuid") for _, m, _ in result}
+        roots = [m for _, m, _ in result if not m.get("parentUuid") and m.get("uuid")]
+
+        assert "pre-result" not in result_uuids, (
+            "pre-result (pre-boundary tool_result root) must NOT be re-added by step-3 "
+            "pair-closure — the _is_pre_boundary gate in 8dce0b7 should suppress it. "
+            f"result uuids: {sorted(result_uuids)}"
+        )
+        assert len(roots) == 1, (
+            f"enforce_floor produced {len(roots)} DAG roots — expected 1 (cb-1 only). "
+            f"root uuids: {[m.get('uuid') for m in roots]}. "
+            "Step-3 pair-closure re-introduced the pre-boundary tool_result as a second root "
+            "(2-root fork — M-1 regression guard missing until this test)"
+        )
+
 
 # ── Class 9: PruneValidationError in guard_prune_cycle abort path ─────────────
 # Rewritten (H-1): see test_prune_safety_r2.py::TestGuardAbortContractRewritten

--- a/tests/test_prune_safety.py
+++ b/tests/test_prune_safety.py
@@ -647,6 +647,224 @@ class TestTagLeakInvariant:
             assert "__cozempic_metadata_singleton__" not in msg
 
 
+# ── Class 10: enforce_floor 2-root DAG fork on compacted sessions (L7) ────────
+
+
+def _cs(idx: int, uuid: str, parent: str | None = "UNSET"):
+    """compact_summary user message (isCompactSummary=True)."""
+    d: dict = {"type": "user", "isCompactSummary": True, "uuid": uuid,
+               "message": {"content": "summary", "role": "user"}}
+    if parent != "UNSET":
+        d["parentUuid"] = parent
+    return (idx, d, len(json.dumps(d, separators=(",", ":"))))
+
+
+def _cb_preserved(idx: int, uuid: str, parent: str | None = "UNSET"):
+    """compact_boundary with hasPreservedSegment=True (collapse is a no-op)."""
+    d: dict = {"type": "system", "subtype": "compact_boundary",
+               "uuid": uuid, "hasPreservedSegment": True}
+    if parent != "UNSET":
+        d["parentUuid"] = parent
+    return (idx, d, len(json.dumps(d, separators=(",", ":"))))
+
+
+def _compacted_msgs():
+    """Standard compacted-session layout for TestFloorCompactedSession.
+
+    idx=0  root-0   (user, parentUuid=None)
+    idx=1  pre-1    (user, parentUuid=root-0)
+    idx=2  pre-2    (asst, parentUuid=pre-1)
+    idx=3  cb-1     (compact_boundary, parentUuid=pre-2)
+    idx=4  cs-1     (compact_summary user, isCompactSummary=True, parentUuid=cb-1)
+    idx=5  pt-1     (user, parentUuid=cs-1)
+    idx=6  pt-2     (asst, parentUuid=pt-1)
+    """
+    return [
+        _user(0, "root-0", parent=None),
+        _user(1, "pre-1",  parent="root-0"),
+        _asst(2, "pre-2",  parent="pre-1"),
+        _cb(3,  "cb-1",   parent="pre-2"),
+        _cs(4,  "cs-1",   parent="cb-1"),
+        _user(5, "pt-1",  parent="cs-1"),
+        _asst(6, "pt-2",  parent="pt-1"),
+    ]
+
+
+class TestFloorCompactedSession:
+    """L7 HIGH: enforce_floor must not re-add pre-boundary root on a compacted session.
+
+    Bug: compact-summary-collapse removes idx=0..2 and _relink_parent_chain re-roots
+    compact_boundary (cb-1) to parentUuid=None. Then enforce_floor(preserve_first_message=True)
+    re-adds the original root (root-0, parentUuid=None) creating TWO DAG roots:
+    root-0 and cb-1. The validate_post_prune C9 check (P0-B) catches this; the
+    enforce_floor fix (P0-A) prevents it from happening.
+
+    RED-at-base: tests 1, 2, and 6 fail before P0-A/P0-B because the bug is live.
+    Tests 3 and 4 are regression guards (GREEN at base and after fix).
+    Test 5 verifies the hasPreservedSegment edge case (GREEN at base too — edge case
+    does not exercise the buggy path since collapse is a no-op there).
+    """
+
+    def test_floor_does_not_re_add_pre_boundary_root_on_compacted_session(self):
+        """RED-at-base: floor re-adds root-0 alongside cb-1, creating 2 roots.
+
+        After fix (P0-A): only 1 root in result (cb-1); root-0 NOT re-added.
+        """
+        import cozempic.strategies  # noqa: F401 — registers strategy names
+        from cozempic.executor import execute_actions
+        from cozempic.strategies.gentle import strategy_compact_summary_collapse
+        from cozempic.safety import enforce_floor
+        from cozempic.config import FloorConfig
+
+        msgs_before = _compacted_msgs()
+
+        # Run compact-summary-collapse to get the post-collapse state
+        strategy_result = strategy_compact_summary_collapse(msgs_before, {})
+        msgs_after_collapse = execute_actions(msgs_before, strategy_result.actions)
+
+        # enforce_floor with default config (preserve_first_message=True)
+        cfg = FloorConfig(preserve_first_message=True, preserve_last_k_turns=0,
+                          max_user_assistant_drop_pct=0.0)
+        result = enforce_floor(msgs_before, msgs_after_collapse, cfg=cfg)
+
+        roots = [m for _, m, _ in result if not m.get("parentUuid") and m.get("uuid")]
+        # RED at base: 2 roots (root-0 and cb-1). After fix: 1 root (cb-1).
+        assert len(roots) == 1, (
+            f"floor produced {len(roots)} DAG roots — expected 1. "
+            f"root uuids: {[m.get('uuid') for m in roots]}. "
+            "enforce_floor re-added the pre-boundary root alongside compact_boundary "
+            "(confused-deputy 2-root DAG fork — P0-A guard missing)"
+        )
+
+    def test_c9_detects_two_root_fork_raises(self):
+        """RED-at-base: injecting a second root into msgs_after must raise C9.
+
+        Before P0-B, validate_post_prune does not detect the extra root.
+        After P0-B: raises PruneValidationError with failed_check='C9'.
+        """
+        from cozempic.safety import validate_post_prune, PruneValidationError
+
+        # Single-root before
+        msgs_before = [
+            _user(0, "root-a", parent=None),
+            _asst(1, "asst-1", parent="root-a"),
+            _user(2, "user-1", parent="asst-1"),
+        ]
+        # Two-root after (injected second root)
+        msgs_after = [
+            _user(0, "root-a", parent=None),
+            _user(3, "root-b", parent=None),  # spurious second root
+            _asst(1, "asst-1", parent="root-a"),
+            _user(2, "user-1", parent="asst-1"),
+        ]
+        with pytest.raises(PruneValidationError) as exc_info:
+            validate_post_prune(msgs_before, msgs_after)
+        assert exc_info.value.evidence.get("failed_check") == "C9", (
+            f"expected C9 but got {exc_info.value.evidence.get('failed_check')!r} — "
+            "C9 multi-root check is missing from validate_post_prune (P0-B)"
+        )
+
+    def test_c9_single_root_passes(self):
+        """Regression guard (GREEN at base and after fix): single-root session does not raise."""
+        from cozempic.safety import validate_post_prune
+
+        msgs = [
+            _user(0, "root-a", parent=None),
+            _asst(1, "asst-1", parent="root-a"),
+            _user(2, "user-1", parent="asst-1"),
+        ]
+        # identity prune: same before and after — must not raise
+        validate_post_prune(msgs, msgs)
+
+    def test_c9_multi_root_before_same_count_after_passes(self):
+        """Regression guard: a legitimately two-root session (team/resume) must not raise.
+
+        C9 is BASELINE-RELATIVE: if root count after == root count before, no raise.
+        Only raises if the prune INCREASED the root count.
+        """
+        from cozempic.safety import validate_post_prune
+
+        # Two-root session (team fork — both chains present in the same file)
+        msgs_before = [
+            _user(0, "root-a", parent=None),
+            _asst(1, "asst-a", parent="root-a"),
+            _user(2, "root-b", parent=None),   # second root from team session
+            _asst(3, "asst-b", parent="root-b"),
+        ]
+        # Prune keeps both roots and both assistants, same root count
+        msgs_after = [
+            _user(0, "root-a", parent=None),
+            _asst(1, "asst-a", parent="root-a"),
+            _user(2, "root-b", parent=None),
+            _asst(3, "asst-b", parent="root-b"),
+        ]
+        # Must not raise — root count (2) did not increase
+        validate_post_prune(msgs_before, msgs_after)
+
+    def test_floor_with_has_preserved_segment_still_re_adds(self):
+        """Edge case: compact_boundary(hasPreservedSegment=True) must NOT skip pre-boundary floor.
+
+        When hasPreservedSegment=True, compact-summary-collapse does NOT remove the
+        pre-boundary turns. The floor must still re-add them if needed (the P0-A skip
+        only fires when the boundary is ACTIVE — i.e., hasPreservedSegment=False/absent).
+        """
+        from cozempic.safety import enforce_floor
+        from cozempic.config import FloorConfig
+
+        msgs_before = [
+            _user(0, "root-0", parent=None),
+            _user(1, "pre-1",  parent="root-0"),
+            _asst(2, "pre-2",  parent="pre-1"),
+            _cb_preserved(3, "cb-1", parent="pre-2"),
+            _cs(4, "cs-1", parent="cb-1"),
+            _user(5, "pt-1", parent="cs-1"),
+            _asst(6, "pt-2", parent="pt-1"),
+        ]
+        # Simulate a partial removal that drops root-0 but NOT via a collapse
+        # (hasPreservedSegment=True → collapse did NOT run → root-0 is recoverable)
+        msgs_after = [
+            _user(1, "pre-1",  parent="root-0"),
+            _asst(2, "pre-2",  parent="pre-1"),
+            _cb_preserved(3, "cb-1", parent="pre-2"),
+            _cs(4, "cs-1", parent="cb-1"),
+            _user(5, "pt-1", parent="cs-1"),
+            _asst(6, "pt-2", parent="pt-1"),
+        ]
+        cfg = FloorConfig(preserve_first_message=True, preserve_last_k_turns=0,
+                          max_user_assistant_drop_pct=0.0)
+        result = enforce_floor(msgs_before, msgs_after, cfg=cfg)
+
+        result_uuids = {m.get("uuid") for _, m, _ in result}
+        assert "root-0" in result_uuids, (
+            "floor must re-add pre-boundary root when hasPreservedSegment=True "
+            "(the P0-A skip must NOT fire when the compact_boundary is not active)"
+        )
+
+    def test_run_prescription_compacted_session_single_root(self):
+        """END-TO-END acceptance: run_prescription on a compacted session yields exactly 1 root.
+
+        This is the EXACT acceptance check the lead will reproduce independently.
+        Before fix: result has 2 roots (root-0 and cb-1 both have parentUuid=None).
+        After fix: result has exactly 1 root (cb-1).
+        """
+        import cozempic.strategies  # noqa: F401
+        from cozempic.executor import run_prescription
+        from cozempic.config import FloorConfig
+
+        msgs_before = _compacted_msgs()
+        cfg = FloorConfig(preserve_first_message=True, preserve_last_k_turns=0,
+                          max_user_assistant_drop_pct=0.0)
+        result, _ = run_prescription(
+            msgs_before, ["compact-summary-collapse"], {}, floor_config=cfg
+        )
+
+        roots = [m for _, m, _ in result if not m.get("parentUuid") and m.get("uuid")]
+        assert len(roots) == 1, (
+            f"run_prescription produced {len(roots)} DAG roots — expected 1. "
+            f"root uuids: {[m.get('uuid') for m in roots]}"
+        )
+
+
 # ── Class 9: PruneValidationError in guard_prune_cycle abort path ─────────────
 # Rewritten (H-1): see test_prune_safety_r2.py::TestGuardAbortContractRewritten
 # for the correct abort-contract tests that patch cozempic.guard.prune_with_team_protect


### PR DESCRIPTION
## Problem

On a compacted session, compact-summary-collapse relinks the `compact_boundary` entry's `parentUuid` to `None` (it becomes the single root — the pre-boundary history has been replaced by the compact summary). Then `enforce_floor`'s `preserve_first_message` re-adds the original first message (`root-0`, also `parentUuid=None`) → the conversation DAG now has **two roots**. `validate_post_prune` misses it: C1 skips `None` parents; C2 only checks "≥1 original root survives" (which holds — root-0). A forked DAG can leave Claude Code unable to resume coherently. (Reproduced: 1 root → 2 roots `['root-0','cb-1']`.)

## Fix (defense-in-depth)

- **P0-A (prevention):** `enforce_floor` skips re-adding any pre-boundary message when an active `compact_boundary` exists — across ALL re-add paths: preserve-first-message, last-K, survival-cap, **and** step-3 tool_use/tool_result pair-closure (the last via the same `_is_pre_boundary` gate). This respects compact-summary-collapse: the summary IS the preserved pre-boundary representation.
- **C2 adjustment:** C2's "an original root must survive" eligible set now excludes pre-boundary roots when an active boundary exists — otherwise C2 false-positives on the *legitimate* collapse (which drops `root-0`). On a compacted session root-protection shifts to **C4** ("last compact_boundary must survive"); a genuine non-compacted root-drop is still caught by C2 (verified by construction in review).
- **P0-B (net):** new **C9** in `validate_post_prune` — baseline-relative multi-root guard (`raise if roots_after > roots_before`), so the prune fails-closed if any path ever introduces a new root. Placed after C2, before C4.

## Tests

`tests/test_prune_safety.py::TestFloorCompactedSession` — RED-at-base (the 2-root fork is live + C9 absent), the exact end-to-end acceptance `test_run_prescription_compacted_session_single_root`, a C9 false-positive guard (a legitimately-resumed 2→2-root session passes), and the `hasPreservedSegment` edge. **57** prune-safety + golden-corpus tests green. (A dedicated regression test for the step-3 pair-closure gate is being added.)

## Scope

L7 prune-safety / data-integrity. `safety.py` only.