### PR TITLE
fix(guard): agents_active counts active teammates, not just subagents (L8)

### DIFF
--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -770,20 +770,32 @@ def start_guard(
                 ):
                     # Defer: stay alive, keep cycling at backoff cap.
                     if not deferred_exit_announced:
-                        running_count = sum(
-                            1 for s in state.subagents
+                        running_subagents = sum(
+                            1 for s in (state.subagents or [])
                             if s.status in ("running", "unknown")
                         )
+                        running_teammates = sum(
+                            1 for t in (state.teammates or [])
+                            if (t.status or "").strip().lower()
+                            not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+                        )
+                        running_count = running_subagents + running_teammates
                         worst_case_min = (
                             HARD_LOOP_HARD_EXIT_THRESHOLD
                             * HARD_LOOP_BACKOFF_CAP_SECONDS
                             // 60
                         )
+                        parts = []
+                        if running_subagents:
+                            parts.append(f"{running_subagents} subagent(s)")
+                        if running_teammates:
+                            parts.append(f"{running_teammates} teammate(s)")
+                        active_desc = " + ".join(parts) if parts else f"{running_count} agent(s)"
                         print(
                             f"  [{_now()}] K={consecutive_empty_hard_prunes} "
                             f"reached normal exit threshold "
                             f"({HARD_LOOP_EXIT_THRESHOLD}) but "
-                            f"{running_count} subagent(s) still active. "
+                            f"{active_desc} still active. "
                             f"Deferring daemon exit until agents quiesce "
                             f"or K reaches hard cap "
                             f"({HARD_LOOP_HARD_EXIT_THRESHOLD}, "
@@ -970,13 +982,10 @@ def start_guard(
             if threshold_tokens is not None or soft_threshold_tokens is not None:
                 current_tokens = quick_token_estimate(session_path)
 
-            # Detect if agents are actively running (reload would kill them)
-            agents_active = False
-            if state and not state.is_empty():
-                agents_active = any(
-                    s.status in ("running", "unknown")
-                    for s in state.subagents
-                )
+            # Detect if agents are actively running (reload would kill them).
+            # Covers both subagents (Agent-tool spawns) and teammates (Agent-tool
+            # spawned team members tracked in state.teammates).
+            agents_active = _compute_agents_active(state)
 
             # ── E: interactive reload gating ──────────────────────────
             # Interactive sessions never reload mid-turn — they wait for an idle
@@ -2425,6 +2434,35 @@ _STATUS_TERMINAL = {"completed", "complete", "done", "failed", "cancelled",
 # wedge the gate (a teammate legitimately sits in these between tasks). Kept
 # minimal/conservative — anything not here AND not terminal blocks.
 _TEAMMATE_BENIGN = {"", "config", "idle", "unknown"}
+
+
+def _compute_agents_active(state) -> bool:
+    """Return True when any subagent OR teammate is actively running.
+
+    Mirrors the canonical predicate used in safe_to_reload for teammate visibility
+    (guard.py:2725-2728) and extends it to subagents so both populations are covered
+    by a single, testable function.
+
+    A subagent is active when its status is "running" or "unknown".
+    A teammate is active when its (stripped, lower-cased) status is NOT in
+    _STATUS_TERMINAL and NOT in _TEAMMATE_BENIGN — the same fail-safe DENYLIST
+    logic used by safe_to_reload.
+
+    Called from the daemon loop (guard.py:973-979) and from tests.
+    """
+    if state is None or state.is_empty():
+        return False
+    subagent_active = any(
+        s.status in ("running", "unknown")
+        for s in (state.subagents or [])
+    )
+    if subagent_active:
+        return True
+    teammate_active = any(
+        (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+        for t in (state.teammates or [])
+    )
+    return teammate_active
 
 
 def _msg_dict(item) -> dict:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -771,8 +771,8 @@ def start_guard(
                     # Defer: stay alive, keep cycling at backoff cap.
                     if not deferred_exit_announced:
                         running_subagents = sum(
-                            1 for s in (state.subagents or [])
-                            if s.status in ("running", "unknown")
+                            1 for s in state.subagents
+                            if _is_active_subagent(s)
                         )
                         running_teammates = sum(
                             1 for t in (getattr(state, "teammates", None) or [])
@@ -825,13 +825,14 @@ def start_guard(
                         # different diagnostic. Do NOT tell the
                         # operator to `/clear` (that destroys
                         # subagent state too).
+                        _hc_desc = _hard_cap_exit_desc(state)
                         print(
                             f"  [{_now()}] Guard hard-cap exit "
                             f"(K={consecutive_empty_hard_prunes} >= "
                             f"{HARD_LOOP_HARD_EXIT_THRESHOLD}). "
-                            f"Subagents are still active; their state "
+                            f"{_hc_desc} still active; their state "
                             f"may be lost on the next compaction. "
-                            f"Consider letting current subagents "
+                            f"Consider letting current agents "
                             f"finish then starting a fresh session.",
                             flush=True,
                         )
@@ -2436,23 +2437,54 @@ _STATUS_TERMINAL = {"completed", "complete", "done", "failed", "cancelled",
 _TEAMMATE_BENIGN = {"", "config", "idle", "unknown"}
 
 
+def _is_active_subagent(s) -> bool:
+    """Return True if a subagent entry represents an actively-executing task.
+
+    Uses the DENYLIST predicate (not in _STATUS_TERMINAL) rather than an
+    ALLOWLIST so any non-terminal status — including None, empty, or an
+    off-vocabulary working word like "busy" / "in-progress" — is treated as
+    active.  This matches safe_to_reload's subagent check and ensures
+    _compute_agents_active fails safe in the same direction.
+    """
+    return (s.status or "").strip().lower() not in _STATUS_TERMINAL
+
+
+def _hard_cap_exit_desc(state) -> str:
+    """Return a concise description of what is still active at hard-cap exit.
+
+    Mirrors the soft-K block active_desc logic (guard.py:788-793) so the
+    hard-cap message accurately names the active population (subagent(s),
+    teammate(s), or both) rather than unconditionally saying 'Subagents'.
+    Extracted for testability — Q-B (lead decision).
+    """
+    hc_subagents = sum(1 for s in (state.subagents or []) if _is_active_subagent(s))
+    hc_teammates = sum(
+        1 for t in (getattr(state, "teammates", None) or [])
+        if (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+    )
+    parts = []
+    if hc_subagents:
+        parts.append(f"{hc_subagents} subagent(s)")
+    if hc_teammates:
+        parts.append(f"{hc_teammates} teammate(s)")
+    return " + ".join(parts) if parts else "active agent(s)"
+
+
 def _compute_agents_active(state) -> bool:
     """Return True when any subagent OR teammate is actively running.
 
-    Mirrors the canonical predicate used in safe_to_reload for teammate visibility
-    (guard.py:2725-2728) and extends it to subagents so both populations are covered
-    by a single, testable function.
+    Both populations use DENYLIST predicates (not-in-terminal-set) that
+    mirror safe_to_reload (guard.py:2739-2760) and fail safe on unrecognized
+    or off-vocabulary working statuses (e.g. None, '', 'busy', 'in-progress').
 
-    A subagent is active when its status is "running" or "unknown".
-    A teammate is active when its (stripped, lower-cased) status is NOT in
-    _STATUS_TERMINAL and NOT in _TEAMMATE_BENIGN — the same fail-safe DENYLIST
-    logic used by safe_to_reload.
+    Subagents: active when NOT in _STATUS_TERMINAL (via _is_active_subagent).
+    Teammates: active when NOT in (_STATUS_TERMINAL | _TEAMMATE_BENIGN).
 
-    Called from the daemon loop (guard.py:973-979) and from tests.
+    Called from the daemon loop (guard.py:988) and from tests.
     """
     if state is None or state.is_empty():
         return False
-    if any(s.status in ("running", "unknown") for s in (state.subagents or [])):
+    if any(_is_active_subagent(s) for s in state.subagents):  # always a list
         return True
     return any(
         (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -776,8 +776,7 @@ def start_guard(
                         )
                         running_teammates = sum(
                             1 for t in (getattr(state, "teammates", None) or [])
-                            if (t.status or "").strip().lower()
-                            not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+                            if _is_active_teammate(t)
                         )
                         running_count = running_subagents + running_teammates
                         worst_case_min = (
@@ -2449,18 +2448,26 @@ def _is_active_subagent(s) -> bool:
     return (s.status or "").strip().lower() not in _STATUS_TERMINAL
 
 
+def _is_active_teammate(t) -> bool:
+    """Return True if a teammate entry is actively working.
+
+    Uses the DENYLIST predicate: NOT in (_STATUS_TERMINAL | _TEAMMATE_BENIGN).
+    Mirrors the safe_to_reload teammate check and _compute_agents_active.
+    """
+    return (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+
+
 def _hard_cap_exit_desc(state) -> str:
     """Return a concise description of what is still active at hard-cap exit.
 
-    Mirrors the soft-K block active_desc logic (guard.py:788-793) so the
-    hard-cap message accurately names the active population (subagent(s),
-    teammate(s), or both) rather than unconditionally saying 'Subagents'.
-    Extracted for testability — Q-B (lead decision).
+    Mirrors the soft-K block active_desc logic so the hard-cap message accurately
+    names the active population (subagent(s), teammate(s), or both) rather than
+    unconditionally saying 'Subagents'.  Extracted for testability — Q-B.
     """
-    hc_subagents = sum(1 for s in (state.subagents or []) if _is_active_subagent(s))
+    hc_subagents = sum(1 for s in state.subagents if _is_active_subagent(s))
     hc_teammates = sum(
         1 for t in (getattr(state, "teammates", None) or [])
-        if (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+        if _is_active_teammate(t)
     )
     parts = []
     if hc_subagents:
@@ -2478,7 +2485,7 @@ def _compute_agents_active(state) -> bool:
     or off-vocabulary working statuses (e.g. None, '', 'busy', 'in-progress').
 
     Subagents: active when NOT in _STATUS_TERMINAL (via _is_active_subagent).
-    Teammates: active when NOT in (_STATUS_TERMINAL | _TEAMMATE_BENIGN).
+    Teammates: active when NOT in (_STATUS_TERMINAL | _TEAMMATE_BENIGN) (via _is_active_teammate).
 
     Called from the daemon loop (guard.py:988) and from tests.
     """
@@ -2487,7 +2494,7 @@ def _compute_agents_active(state) -> bool:
     if any(_is_active_subagent(s) for s in state.subagents):  # always a list
         return True
     return any(
-        (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
+        _is_active_teammate(t)
         for t in (getattr(state, "teammates", None) or [])
     )
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2452,17 +2452,12 @@ def _compute_agents_active(state) -> bool:
     """
     if state is None or state.is_empty():
         return False
-    subagent_active = any(
-        s.status in ("running", "unknown")
-        for s in (state.subagents or [])
-    )
-    if subagent_active:
+    if any(s.status in ("running", "unknown") for s in (state.subagents or [])):
         return True
-    teammate_active = any(
+    return any(
         (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
         for t in (getattr(state, "teammates", None) or [])
     )
-    return teammate_active
 
 
 def _msg_dict(item) -> dict:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -775,7 +775,7 @@ def start_guard(
                             if s.status in ("running", "unknown")
                         )
                         running_teammates = sum(
-                            1 for t in (state.teammates or [])
+                            1 for t in (getattr(state, "teammates", None) or [])
                             if (t.status or "").strip().lower()
                             not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
                         )
@@ -2460,7 +2460,7 @@ def _compute_agents_active(state) -> bool:
         return True
     teammate_active = any(
         (t.status or "").strip().lower() not in (_STATUS_TERMINAL | _TEAMMATE_BENIGN)
-        for t in (state.teammates or [])
+        for t in (getattr(state, "teammates", None) or [])
     )
     return teammate_active
 

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -22,6 +22,17 @@ from pathlib import Path
 
 from .types import Message
 
+# Terminal (finished) statuses for teammate classification in build_team_recovery_receipt.
+# Duplicated from guard._STATUS_TERMINAL to avoid a circular import (guard imports team).
+# A future PR consolidating _constants.py can remove this copy.
+# ADD a comment here if guard._STATUS_TERMINAL changes so the two stay in sync.
+_TEAMMATE_QUIESCENT: frozenset[str] = frozenset({
+    "completed", "complete", "done", "failed", "cancelled",
+    "canceled", "stopped", "killed", "aborted", "error",
+    "success", "succeeded", "finished", "timeout", "timed_out",
+    "ok",
+})  # duplicated until a future PR consolidates this + guard._STATUS_TERMINAL + #132's cap into _constants.py.
+
 
 @dataclass
 class SubagentInfo:
@@ -268,7 +279,10 @@ def build_team_recovery_receipt(state: TeamState) -> dict:
     subagents = state.subagents or []
     teammates = state.teammates or []
     running_subagents = [s for s in subagents if (s.status or "").lower() == "running"]
-    active_teammates = [t for t in teammates if (t.status or "").lower() not in {"done", "completed"}]
+    active_teammates = [
+        t for t in teammates
+        if (t.status or "").strip().lower() not in _TEAMMATE_QUIESCENT
+    ]
 
     gaps: list[str] = []
     if state.is_empty():

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -330,7 +330,7 @@ class TestPolishPR93_K10DeferWhenAgentsActive(unittest.TestCase):
                 self.subagents = [sub] if has_agents else []
                 # Inline teammate stub — matches the subset of TeammateInfo that
                 # _compute_agents_active reads (only .status).
-                tm = type("T", (), {"status": tm_status})() if tm_status else None
+                tm = type("T", (), {"status": tm_status})() if tm_status is not None else None
                 self.teammates = [tm] if tm else []
                 self.tasks = []
                 self.message_count = 0

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -313,23 +313,32 @@ class TestPolishPR93_K10DeferWhenAgentsActive(unittest.TestCase):
         # Default is 50 per architect spec.
         self.assertEqual(guard.HARD_LOOP_HARD_EXIT_THRESHOLD, 50)
 
-    def _run_loop(self, agents_active=True, max_cycles=80):
+    def _run_loop(self, agents_active=True, max_cycles=80, teammate_status=None):
         """Run start_guard with prune=0 forever and the given agents_active
-        state. Returns (exited, cycle_count)."""
+        state. Returns (exited, cycle_count).
+
+        teammate_status: if not None, adds a single teammate with that status
+        string and EMPTY subagents list, so the test exercises the teammate
+        path exclusively.
+        """
         from cozempic import guard as guard_mod
 
         class _FakeState:
-            def __init__(self, has_agents):
+            def __init__(self, has_agents, tm_status):
                 self.has_agents = has_agents
                 sub = type("S", (), {"status": "running"})()
                 self.subagents = [sub] if has_agents else []
+                # Inline teammate stub — matches the subset of TeammateInfo that
+                # _compute_agents_active reads (only .status).
+                tm = type("T", (), {"status": tm_status})() if tm_status else None
+                self.teammates = [tm] if tm else []
                 self.tasks = []
                 self.message_count = 0
 
             def is_empty(self):
-                return not self.has_agents
+                return not self.has_agents and not self.teammates
 
-        fake_state = _FakeState(agents_active)
+        fake_state = _FakeState(agents_active, teammate_status)
 
         def fake_prune_cycle(**kwargs):
             return {
@@ -406,6 +415,33 @@ class TestPolishPR93_K10DeferWhenAgentsActive(unittest.TestCase):
             exited,
             f"K=10 must NOT exit when agents_active=True (deferred). "
             f"Got exited=True after {n} cycles.",
+        )
+
+    def test_k10_defers_when_teammate_running(self):
+        """REGRESSION GUARD (PR-8 Sub-PR A) — K-exit wiring: a running teammate
+        must cause the daemon to DEFER at K=10, exactly like a running subagent.
+
+        This test exercises the FULL wiring path:
+          state.teammates[0].status="running"
+          → _compute_agents_active(state) → True
+          → guard main loop defers sys.exit at K=10
+
+        Behavioural RED at base: reverting guard.py:988 to inline
+        `agents_active = any(s.status in ("running","unknown") for s in state.subagents)`
+        causes the daemon to EXIT at K=10 (subagents=[], teammate ignored) —
+        verified by commenting the teammate branch in _compute_agents_active.
+        The existing subagent tests remain GREEN because they don't set teammates.
+        """
+        # agents_active=False disables the _FakeState subagent; teammate_status
+        # "running" adds one running teammate so ONLY the teammate path is exercised.
+        exited, n = self._run_loop(
+            agents_active=False, teammate_status="running", max_cycles=40
+        )
+        self.assertFalse(
+            exited,
+            f"K=10 must NOT exit when a teammate is running (status='running'). "
+            f"Got exited=True after {n} cycles — daemon ignored the teammate. "
+            f"Check _compute_agents_active covers state.teammates.",
         )
 
     def test_hard_cap_exits_with_agents_active(self):

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -997,8 +997,8 @@ class TestAgentsActiveTeammateBlind(unittest.TestCase):
     """
 
     def _compute_agents_active(self, state):
-        """Mirror the exact guard.py:974-979 computation so tests target the real logic."""
-        from cozempic.guard import _compute_agents_active  # doesn't exist yet → ImportError at base
+        """Delegate to the guard helper so tests exercise the real production logic."""
+        from cozempic.guard import _compute_agents_active
         return _compute_agents_active(state)
 
     def test_running_teammate_empty_subagents_agents_active_false_at_base(self):

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -979,5 +979,159 @@ class TestNestedTeammateMessageRegex(unittest.TestCase):
             )
 
 
+class TestAgentsActiveTeammateBlind(unittest.TestCase):
+    """L8 CRITICAL: agents_active is blind to Agent-tool teammates in state.teammates.
+
+    guard.py:974-979 computes agents_active as:
+        any(s.status in ("running", "unknown") for s in state.subagents)
+    — it iterates ONLY state.subagents and never touches state.teammates.
+
+    An Agent-tool-spawned teammate has status="running" in state.teammates (after
+    extract_team_state parses the spawn result).  When subagents is empty, agents_active
+    is False even though a live teammate is running, so the K-exit deferral at
+    guard.py:766-793 does NOT fire → the daemon exits at K=10 → the teammate loses guard
+    protection → native autocompact can destroy team state.
+
+    REGRESSION GUARD tests are proven RED at base (origin/main 4f15d6d) before any fix.
+    Positive-control / invariant tests that pass at base are labelled accordingly.
+    """
+
+    def _compute_agents_active(self, state):
+        """Mirror the exact guard.py:974-979 computation so tests target the real logic."""
+        from cozempic.guard import _compute_agents_active  # doesn't exist yet → ImportError at base
+        return _compute_agents_active(state)
+
+    def test_running_teammate_empty_subagents_agents_active_false_at_base(self):
+        """REGRESSION GUARD — RED at base: agents_active is False for running teammate,
+        empty subagents.  After the fix it must be True.
+
+        Scenario: a session has one Agent-tool teammate with status="running" and NO
+        subagents.  _compute_agents_active must return True so the K-exit deferral fires.
+        At base (guard.py:974-979 unchanged) it returns False → daemon K-exits and
+        orphans the teammate.
+        """
+        from cozempic.team import TeamState, TeammateInfo, SubagentInfo
+        state = TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            teammates=[TeammateInfo(agent_id="finder-p1@myteam", name="finder-p1", status="running")],
+            subagents=[],
+        )
+        result = self._compute_agents_active(state)
+        self.assertTrue(
+            result,
+            "agents_active must be True when a teammate has status='running' and subagents is empty; "
+            f"got {result!r} — K-exit deferral would silently fire and orphan the running teammate",
+        )
+
+    def test_completed_teammate_empty_subagents_agents_active_false(self):
+        """Positive control (invariant) — GREEN at base: a completed teammate with no
+        subagents is NOT considered active.  The K-exit should fire normally.
+
+        This test documents the quiescent-session invariant: once all agents finish, the
+        daemon is allowed to exit without deferral.
+        """
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            teammates=[TeammateInfo(agent_id="finder-p1@myteam", name="finder-p1", status="completed")],
+            subagents=[],
+        )
+        result = self._compute_agents_active(state)
+        self.assertFalse(
+            result,
+            "agents_active must be False when the only teammate is 'completed' and subagents is empty; "
+            f"got {result!r}",
+        )
+
+    def test_idle_teammate_empty_subagents_agents_active_false(self):
+        """Positive control — GREEN at base: an idle teammate (benign status) with no
+        subagents should NOT count as active.
+        """
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            teammates=[TeammateInfo(agent_id="finder-p1@myteam", name="finder-p1", status="idle")],
+            subagents=[],
+        )
+        result = self._compute_agents_active(state)
+        self.assertFalse(
+            result,
+            "agents_active must be False when the only teammate is 'idle' (benign status); "
+            f"got {result!r}",
+        )
+
+    def test_running_subagent_no_teammates_still_active(self):
+        """Invariant (GREEN at base): a running subagent with no teammates → agents_active True.
+
+        This verifies the EXISTING subagent coverage is NOT broken by the fix.
+        """
+        from cozempic.team import TeamState, SubagentInfo
+        state = TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            teammates=[],
+            subagents=[SubagentInfo(agent_id="sub-1", status="running")],
+        )
+        result = self._compute_agents_active(state)
+        self.assertTrue(
+            result,
+            "agents_active must remain True when a subagent is 'running' (pre-existing coverage); "
+            f"got {result!r}",
+        )
+
+    def test_running_teammate_and_running_subagent_both_active(self):
+        """REGRESSION GUARD — RED at base: mixed session with a running teammate AND a
+        running subagent.  Both must contribute to agents_active=True.
+
+        At base the subagent already makes it True, so this test is not strictly needed
+        to catch the regression — but it documents that the combined case works after the
+        fix and the teammate side is verified independently.
+        """
+        from cozempic.team import TeamState, TeammateInfo, SubagentInfo
+        state = TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            teammates=[TeammateInfo(agent_id="finder-p1@myteam", name="finder-p1", status="running")],
+            subagents=[SubagentInfo(agent_id="sub-1", status="running")],
+        )
+        result = self._compute_agents_active(state)
+        self.assertTrue(
+            result,
+            "agents_active must be True when both teammate and subagent are running; "
+            f"got {result!r}",
+        )
+
+    def test_empty_state_not_active(self):
+        """Invariant (GREEN at base): empty TeamState → agents_active False."""
+        from cozempic.team import TeamState
+        state = TeamState(
+            team_name="",
+            lead_agent_id="",
+            lead_session_id="",
+            config_source="jsonl",
+            teammates=[],
+            subagents=[],
+        )
+        result = self._compute_agents_active(state)
+        self.assertFalse(
+            result,
+            "agents_active must be False when state has no teammates and no subagents; "
+            f"got {result!r}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -992,7 +992,9 @@ class TestAgentsActiveTeammateBlind(unittest.TestCase):
     guard.py:766-793 does NOT fire → the daemon exits at K=10 → the teammate loses guard
     protection → native autocompact can destroy team state.
 
-    REGRESSION GUARD tests are proven RED at base (origin/main 4f15d6d) before any fix.
+    REGRESSION GUARD tests are proven ERROR at base (origin/main 4f15d6d: ImportError on
+    _compute_agents_active which didn't exist yet) before any fix.  Both ERROR and FAIL
+    achieve the regression-guard intent; "ERROR" is the accurate label.
     Positive-control / invariant tests that pass at base are labelled accordingly.
     """
 
@@ -1130,6 +1132,35 @@ class TestAgentsActiveTeammateBlind(unittest.TestCase):
             result,
             "agents_active must be False when state has no teammates and no subagents; "
             f"got {result!r}",
+        )
+
+    def test_default_teammate_status_unknown_is_benign(self):
+        """INVARIANT (GREEN at base and after fix): a TeammateInfo with default status
+        'unknown' must NOT count as active.
+
+        Documents the intentional SubagentInfo/TeammateInfo 'unknown' asymmetry:
+        - TeammateInfo.status defaults to 'unknown' (in _TEAMMATE_BENIGN → benign).
+        - SubagentInfo.status defaults to 'running' (not in _TEAMMATE_BENIGN → active).
+
+        A newly-created team member sitting at 'unknown' before any task-status
+        notification arrives must not block K-exit deferral.
+        """
+        from cozempic.guard import _compute_agents_active
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            teammates=[TeammateInfo(agent_id="w@myteam", name="w")],  # status defaults to 'unknown'
+            subagents=[],
+        )
+        self.assertFalse(
+            _compute_agents_active(state),
+            "A TeammateInfo with default status='unknown' (in _TEAMMATE_BENIGN) must be "
+            "non-active — 'unknown' means the teammate has not yet received a working-status "
+            "notification, not that it is mid-execution. This documents the intentional "
+            "SubagentInfo-vs-TeammateInfo 'unknown' asymmetry.",
         )
 
 

--- a/tests/test_guard_team_agent_spawn.py
+++ b/tests/test_guard_team_agent_spawn.py
@@ -1164,5 +1164,163 @@ class TestAgentsActiveTeammateBlind(unittest.TestCase):
         )
 
 
+class TestComputeAgentsActiveAllowlistFix(unittest.TestCase):
+    """_compute_agents_active must use DENYLIST (not ALLOWLIST) for subagents.
+
+    Current (ALLOWLIST): `s.status in ("running", "unknown")` — misses null and any
+    off-vocabulary working status like "busy", "in-progress", or "executing".
+
+    Fixed (DENYLIST): `(s.status or "").strip().lower() not in _STATUS_TERMINAL` —
+    mirrors safe_to_reload and fails safe on any non-terminal status.
+
+    REGRESSION GUARD tests are proven at base (e65636e before P0-A fix):
+    - test_subagent_null_status / test_subagent_busy_status: False at base (bug) →
+      True after fix (correct).
+    - test_is_active_subagent_helper_exists: ERROR at base (ImportError, helper
+      doesn't exist) → GREEN after fix.
+    """
+
+    def test_subagent_null_status_counts_as_active(self):
+        """REGRESSION GUARD: subagent with status=None must block K-exit deferral.
+
+        At base (ALLOWLIST): None not in ('running','unknown') -> False -> K-exit proceeds.
+        After fix (DENYLIST): '' not in _STATUS_TERMINAL -> True -> K-exit deferred.
+        """
+        from cozempic.guard import _compute_agents_active
+        from cozempic.team import TeamState, SubagentInfo
+        state = TeamState(
+            team_name="t", lead_agent_id="l@t", lead_session_id="s",
+            config_source="jsonl",
+            subagents=[SubagentInfo(agent_id="a1", status=None)],
+            teammates=[],
+        )
+        self.assertTrue(
+            _compute_agents_active(state),
+            "subagent with status=None must be treated as active (DENYLIST fail-safe); "
+            "at base (ALLOWLIST), None is not in ('running','unknown') -> False (bug).",
+        )
+
+    def test_subagent_busy_status_counts_as_active(self):
+        """REGRESSION GUARD: off-vocabulary working status 'busy' must block K-exit.
+
+        At base (ALLOWLIST): 'busy' not in ('running','unknown') -> False -> K-exit proceeds.
+        After fix (DENYLIST): 'busy' not in _STATUS_TERMINAL -> True -> K-exit deferred.
+        """
+        from cozempic.guard import _compute_agents_active
+        from cozempic.team import TeamState, SubagentInfo
+        state = TeamState(
+            team_name="t", lead_agent_id="l@t", lead_session_id="s",
+            config_source="jsonl",
+            subagents=[SubagentInfo(agent_id="a1", status="busy")],
+            teammates=[],
+        )
+        self.assertTrue(
+            _compute_agents_active(state),
+            "subagent with off-vocabulary status='busy' must be treated as active "
+            "(DENYLIST: 'busy' not in _STATUS_TERMINAL); got False at base (ALLOWLIST).",
+        )
+
+    def test_subagent_empty_string_status_counts_as_active(self):
+        """REGRESSION GUARD: subagent with status='' must block K-exit (not in _STATUS_TERMINAL).
+
+        At base (ALLOWLIST): '' not in ('running','unknown') -> False -> K-exit proceeds.
+        After fix (DENYLIST): '' not in _STATUS_TERMINAL -> True -> K-exit deferred.
+        """
+        from cozempic.guard import _compute_agents_active
+        from cozempic.team import TeamState, SubagentInfo
+        state = TeamState(
+            team_name="t", lead_agent_id="l@t", lead_session_id="s",
+            config_source="jsonl",
+            subagents=[SubagentInfo(agent_id="a1", status="")],
+            teammates=[],
+        )
+        self.assertTrue(
+            _compute_agents_active(state),
+            "subagent with status='' must be treated as active (DENYLIST fail-safe). "
+            "At base (ALLOWLIST): '' not in ('running','unknown') -> False (bug).",
+        )
+
+    def test_is_active_subagent_helper_exists(self):
+        """After fix: _is_active_subagent must be importable from cozempic.guard.
+
+        ERROR at base (function doesn't exist yet).
+        GREEN after fix.
+        """
+        from cozempic.guard import _is_active_subagent
+        self.assertTrue(callable(_is_active_subagent))
+
+    def test_running_subagent_still_active_after_denylist_fix(self):
+        """Positive control (GREEN at base and after fix): 'running' subagent is active.
+
+        The DENYLIST must not regress the existing behavior for 'running' status.
+        """
+        from cozempic.guard import _compute_agents_active
+        from cozempic.team import TeamState, SubagentInfo
+        state = TeamState(
+            team_name="t", lead_agent_id="l@t", lead_session_id="s",
+            config_source="jsonl",
+            subagents=[SubagentInfo(agent_id="a1", status="running")],
+            teammates=[],
+        )
+        self.assertTrue(
+            _compute_agents_active(state),
+            "subagent with status='running' must still be active after DENYLIST fix.",
+        )
+
+    def test_completed_subagent_not_active(self):
+        """Positive control (GREEN at base and after fix): 'completed' subagent is not active.
+
+        At base (ALLOWLIST): 'completed' not in ('running','unknown') -> False (correct).
+        After fix (DENYLIST): 'completed' in _STATUS_TERMINAL -> False (correct).
+        """
+        from cozempic.guard import _compute_agents_active
+        from cozempic.team import TeamState, SubagentInfo
+        state = TeamState(
+            team_name="t", lead_agent_id="l@t", lead_session_id="s",
+            config_source="jsonl",
+            subagents=[SubagentInfo(agent_id="a1", status="completed")],
+            teammates=[],
+        )
+        self.assertFalse(
+            _compute_agents_active(state),
+            "subagent with status='completed' must not be active (in _STATUS_TERMINAL).",
+        )
+
+    def test_hard_cap_exit_desc_helper_exists(self):
+        """After fix: _hard_cap_exit_desc must be importable from cozempic.guard.
+
+        ERROR at base (function doesn't exist yet per Q-B answer: extract helper).
+        """
+        from cozempic.guard import _hard_cap_exit_desc
+        self.assertTrue(callable(_hard_cap_exit_desc))
+
+    def test_hard_cap_exit_desc_teammate_only_no_subagents_label(self):
+        """_hard_cap_exit_desc must not say 'subagent(s)' for a teammate-only session.
+
+        The old hard-cap message said 'Subagents are still active' unconditionally.
+        After fix, for state with a running teammate and no subagents, the description
+        must contain 'teammate(s)' and must NOT contain 'subagent(s)'.
+        """
+        from cozempic.guard import _hard_cap_exit_desc
+        from cozempic.team import TeamState, TeammateInfo
+        state = TeamState(
+            team_name="t", lead_agent_id="l@t", lead_session_id="s",
+            config_source="jsonl",
+            teammates=[TeammateInfo(agent_id="w@t", name="w", status="running")],
+            subagents=[],
+        )
+        desc = _hard_cap_exit_desc(state)
+        self.assertIn(
+            "teammate(s)",
+            desc,
+            f"hard-cap desc for teammate-only session must contain 'teammate(s)'; got {desc!r}",
+        )
+        self.assertNotIn(
+            "subagent(s)",
+            desc,
+            f"hard-cap desc for teammate-only session must NOT contain 'subagent(s)'; got {desc!r}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_team_recovery_receipt.py
+++ b/tests/test_team_recovery_receipt.py
@@ -1,0 +1,147 @@
+"""Regression guards for build_team_recovery_receipt terminal-status predicate.
+
+P0-C: team.py:271 used `not in {"done", "completed"}` to classify active teammates,
+missing all _STATUS_TERMINAL members except those two. A "failed" or "cancelled"
+teammate counted as active → verdict='partial' when the session was actually quiescent.
+
+REGRESSION GUARD tests are proven RED at base (HEAD e65636e before P0-C fix):
+  with only a terminal teammate and no other active work, verdict='partial'
+  (bug: has_active_work=True adds "per_teammate_event_cursors_not_recorded" gap).
+  After fix: terminal teammate → has_active_work=False → verdict='complete'.
+
+Also includes the _TEAMMATE_QUIESCENT == guard._STATUS_TERMINAL equality test per
+lead Q-A: the local frozen set in team.py must mirror guard._STATUS_TERMINAL members.
+"""
+import unittest
+
+
+class TestBuildTeamRecoveryReceiptTerminalStatuses(unittest.TestCase):
+    """build_team_recovery_receipt must treat all _STATUS_TERMINAL statuses as
+    non-active, not just 'done'/'completed'.
+
+    Test state: single terminal teammate + one completed task + full cursors.
+    No running subagents, no active tasks → has_active_work must be False → no
+    "per_teammate_event_cursors_not_recorded" gap → verdict='complete'.
+
+    At base (L271 uses {"done","completed"}), 'failed'/'cancelled'/'aborted' count
+    as active teammates → has_active_work=True → verdict='partial'.
+    """
+
+    def _make_quiescent_state(self, tm_status: str):
+        from cozempic.team import TeamState, TeammateInfo, TaskInfo
+        return TeamState(
+            team_name="myteam",
+            lead_agent_id="lead@myteam",
+            lead_session_id="sess-1",
+            config_source="jsonl",
+            last_coordination_index=10,  # cursor present
+            tasks=[TaskInfo(task_id="1", subject="clean up", status="completed")],
+            teammates=[TeammateInfo(agent_id="w@myteam", name="w", status=tm_status)],
+            subagents=[],
+        )
+
+    def test_failed_teammate_not_active(self):
+        """REGRESSION GUARD: a 'failed' teammate with all other work quiescent must
+        yield verdict='complete', not 'partial'.
+
+        RED at base (e65636e): 'failed' not in {"done","completed"} → has_active_work=True
+        → gaps=['per_teammate_event_cursors_not_recorded'] → verdict='partial'.
+        GREEN after fix: 'failed' in _TEAMMATE_QUIESCENT → has_active_work=False
+        → gaps=[] → verdict='complete'.
+        """
+        from cozempic.team import build_team_recovery_receipt
+        receipt = build_team_recovery_receipt(self._make_quiescent_state("failed"))
+        self.assertEqual(
+            "complete",
+            receipt["recovery_verdict"],
+            f"A 'failed' teammate with no other active work must yield verdict='complete'; "
+            f"got {receipt['recovery_verdict']!r}. Audit gaps: {receipt['audit_gaps']}. "
+            f"team.py:271 predicate uses {{\"done\",\"completed\"}} which misses 'failed'.",
+        )
+
+    def test_cancelled_teammate_not_active(self):
+        """REGRESSION GUARD: a 'cancelled' teammate with all other work quiescent must
+        yield verdict='complete'.
+
+        RED at base: 'cancelled' not in {"done","completed"} → partial.
+        GREEN after fix: 'cancelled' in _TEAMMATE_QUIESCENT → complete.
+        """
+        from cozempic.team import build_team_recovery_receipt
+        receipt = build_team_recovery_receipt(self._make_quiescent_state("cancelled"))
+        self.assertEqual(
+            "complete",
+            receipt["recovery_verdict"],
+            f"A 'cancelled' teammate with no other active work must yield verdict='complete'; "
+            f"got {receipt['recovery_verdict']!r}. Audit gaps: {receipt['audit_gaps']}.",
+        )
+
+    def test_aborted_teammate_not_active(self):
+        """REGRESSION GUARD: 'aborted' is in _STATUS_TERMINAL but not {"done","completed"}.
+
+        RED at base: 'aborted' not in {"done","completed"} → partial.
+        GREEN after fix: 'aborted' in _TEAMMATE_QUIESCENT → complete.
+        """
+        from cozempic.team import build_team_recovery_receipt
+        receipt = build_team_recovery_receipt(self._make_quiescent_state("aborted"))
+        self.assertEqual(
+            "complete",
+            receipt["recovery_verdict"],
+            f"'aborted' teammate must yield verdict='complete'; got {receipt!r}",
+        )
+
+    def test_done_teammate_was_already_not_active(self):
+        """Positive control (GREEN at base): 'done' was already in the old set.
+
+        Verifies the fix doesn't regress the existing behavior for 'done'.
+        """
+        from cozempic.team import build_team_recovery_receipt
+        receipt = build_team_recovery_receipt(self._make_quiescent_state("done"))
+        self.assertEqual(
+            "complete",
+            receipt["recovery_verdict"],
+            f"'done' teammate (already covered at base) must yield verdict='complete'; "
+            f"got {receipt['recovery_verdict']!r}. Audit gaps: {receipt['audit_gaps']}.",
+        )
+
+    def test_completed_teammate_not_active(self):
+        """Positive control (GREEN at base): 'completed' was already in the old set."""
+        from cozempic.team import build_team_recovery_receipt
+        receipt = build_team_recovery_receipt(self._make_quiescent_state("completed"))
+        self.assertEqual(
+            "complete",
+            receipt["recovery_verdict"],
+            f"'completed' teammate must yield verdict='complete'; "
+            f"got {receipt['recovery_verdict']!r}.",
+        )
+
+
+class TestTeammateQuiescentSetParity(unittest.TestCase):
+    """_TEAMMATE_QUIESCENT in team.py must mirror guard._STATUS_TERMINAL members.
+
+    Lead Q-A answer: use a local frozenset named _TEAMMATE_QUIESCENT (duplicated
+    until a future PR consolidates into _constants.py). Guard parity with a test
+    that imports both modules — no runtime cycle (test can import both).
+    """
+
+    def test_teammate_quiescent_equals_status_terminal(self):
+        """_TEAMMATE_QUIESCENT (team.py) must equal guard._STATUS_TERMINAL in membership.
+
+        If this fails after adding _TEAMMATE_QUIESCENT, the two sets have diverged
+        and the P0-C fix is incomplete.  ERROR at base (_TEAMMATE_QUIESCENT doesn't
+        exist yet → ImportError). GREEN after fix.
+        """
+        from cozempic.team import _TEAMMATE_QUIESCENT
+        from cozempic.guard import _STATUS_TERMINAL
+        self.assertEqual(
+            _TEAMMATE_QUIESCENT,
+            _STATUS_TERMINAL,
+            f"team._TEAMMATE_QUIESCENT must equal guard._STATUS_TERMINAL.\n"
+            f"  _TEAMMATE_QUIESCENT: {sorted(_TEAMMATE_QUIESCENT)}\n"
+            f"  _STATUS_TERMINAL:    {sorted(_STATUS_TERMINAL)}\n"
+            f"  In _QUIESCENT not _TERMINAL: {_TEAMMATE_QUIESCENT - _STATUS_TERMINAL}\n"
+            f"  In _TERMINAL not _QUIESCENT: {_STATUS_TERMINAL - _TEAMMATE_QUIESCENT}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`agents_active` (guard.py) was `any(s.status in ("running","unknown") for s in state.subagents)` — it iterated ONLY `state.subagents`, never `state.teammates`. An `Agent`-tool-spawned teammate lives in `state.teammates`, so a running teammate + empty subagents → `agents_active=False`. That feeds the futile-loop **K-exit deferral** (guard.py:766-794): with `agents_active=False` the deferral doesn't fire → the daemon `sys.exit`s on K consecutive empty prunes → the live teammates lose their guard daemon → context bloats → native autocompact destroys the team state (the exact failure the guard exists to prevent). `safe_to_reload` got teammate-awareness in the F1/#117 work; this K-exit path never did.

## Fix

Factored `_compute_agents_active(state)` that ORs the subagent check with a teammate check using the **same predicate** as `safe_to_reload` — byte-identical, so the K-exit and the reload gate can never disagree about "active." Widened the deferral diagnostic log to report active teammates, and `getattr(state, "teammates", None) or []` for legacy-mock back-compat.

## Tests

`tests/test_guard_team_agent_spawn.py::TestAgentsActiveTeammateBlind` (helper, 6 cases) + a **behavioural** integration test `test_guard_polish_pr93.py::...test_k10_defers_when_teammate_running`: a running teammate with empty subagents DEFERS the K=10 exit — behaviourally RED at base, GREEN after. Benign/idle/terminal/unknown teammate → agents_active stays False so a genuinely-quiescent team still K-exits.

## Scope

L8 reload-safety, guard.py + team.py, stdlib only.

---

## Follow-up — `/code-review max` hardening

An independent max-recall review upgraded a PLAUSIBLE finding to a real safety bug, fixed here; an adversarial review (no CRITICAL/HIGH) confirmed the direction-safety:

- **Allowlist/denylist asymmetry closed (the headline).** Even after the teammate fix above, `_compute_agents_active` still used an **ALLOWLIST** for *subagents* (`s.status in ("running","unknown")`) while `safe_to_reload` uses a **DENYLIST** (`not in _STATUS_TERMINAL`). They diverge for off-vocabulary / null statuses — empirically `None`, `''`, `'busy'`, `'in-progress'`, `'executing'` → `_compute_agents_active` returned False (K-exit NOT deferred) while `safe_to_reload` would block. A subagent mid-execution with such a status could lose its guard. Unified behind a single `_is_active_subagent` (DENYLIST) so the two gates can never disagree; the change only ever makes MORE things count active (over-defer = safe), never fewer.
- **Recovery-receipt predicate.** `build_team_recovery_receipt` used `not in {"done","completed"}` (2 elements), missing the other 14 terminal statuses (`failed`/`cancelled`/`aborted`/…) → a *failed* teammate counted active → a misleading `"partial"` verdict. Now uses the full quiescent set.
- **Predicate consolidation (this replaces the "deferred to a future sub-PR" note).** Extracted `_is_active_subagent` + `_is_active_teammate`, used consistently across the soft-K block, the hard-cap diagnostic, and `_compute_agents_active`. The hard-cap message now names the actual active population (subagents *and/or* teammates) instead of unconditionally saying "Subagents". The teammate terminal set lives in a **self-contained** `_TEAMMATE_QUIESCENT` frozenset in team.py (guarded by a parity test against `guard._STATUS_TERMINAL`; a future PR consolidates both + #132's cap into `_constants.py`).

Each behavioral gap has a RED-at-base test. guard.py + team.py, stdlib only.
