### PR TITLE
test(isolation): make session-detection tests hermetic against a live ~/.claude (L11)

### DIFF
--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -28,6 +28,9 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            # Block Strategy 1 (active-transcript lookup keyed by live Claude PID)
+            # so a real running Claude session in the developer's home cannot win.
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd="/unrelated/path", strict=True)
 
@@ -41,6 +44,7 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd="/unrelated/path", strict=False)
 
@@ -48,7 +52,7 @@ class TestStrictMode:
         assert result["session_id"] == "aaaa1111-0000-0000-0000-000000000000"
 
     def test_strict_succeeds_when_process_detected(self, tmp_path):
-        """Process-based detection (Strategy 1) satisfies strict mode."""
+        """Process-based detection (Strategy 2) satisfies strict mode."""
         session_id = "bbbb2222-0000-0000-0000-000000000000"
         proj = tmp_path / "projects" / "-some-path"
         _write_session(proj, session_id)
@@ -56,6 +60,8 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=session_id),
+            # Block Strategy 1 so this test exercises Strategy 2 exclusively.
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(strict=True)
 
@@ -63,7 +69,7 @@ class TestStrictMode:
         assert result["session_id"] == session_id
 
     def test_strict_succeeds_on_cwd_slug_match(self, tmp_path):
-        """CWD slug match (Strategy 3) satisfies strict mode — underscore and dot variants.
+        """CWD slug match (Strategy 4) satisfies strict mode — underscore and dot variants.
 
         Fixture dirs use HARDCODED literal names (what Claude Code actually writes to disk),
         independent of cwd_to_project_slug. If the slug formula regresses, the computed
@@ -80,6 +86,7 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd=cwd_under, strict=True)
 
@@ -90,7 +97,7 @@ class TestStrictMode:
         assert result["session_id"] == sess_under
 
     def test_strict_succeeds_on_dot_cwd_slug_match(self, tmp_path):
-        """Dot-path cwd (double-dash slug) is found by Strategy 3 in strict mode.
+        """Dot-path cwd (double-dash slug) is found by Strategy 4 in strict mode.
 
         Fixture dir uses HARDCODED literal name.
         '/Users/foo/.claude' → '-Users-foo--claude' (dot→dash produces double-dash).
@@ -104,11 +111,12 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd=cwd_dot, strict=True)
 
         assert result is not None, (
-            f"Strategy 3 did not find dot-path project. "
+            f"Strategy 4 did not find dot-path project. "
             f"Expected slug '-Users-foo--claude' to match literal dir."
         )
         assert result["session_id"] == sess_dot
@@ -120,6 +128,7 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=projects),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             assert find_current_session(strict=True) is None
             assert find_current_session(strict=False) is None
@@ -140,6 +149,7 @@ class TestStrictMode:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd="/Users/x/proj/", strict=True)
 
@@ -179,6 +189,7 @@ class TestStrategy3ExactMatch:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd=cwd, strict=True)
 
@@ -206,29 +217,31 @@ class TestStrategy3ExactMatch:
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd=cwd_foo, strict=True)
 
         assert result is not None
         assert result["session_id"] == sess_foo, (
             f"Expected session for '-Users-x-foo', got {result['session_id']!r}. "
-            "Prefix collision: Strategy 3 is still using substring match."
+            "Prefix collision: Strategy 4 is still using substring match."
         )
 
     def test_strategy4_strict_returns_none_on_no_match(self, tmp_path):
-        """strict=True blocks Strategy 4 fallback when no slug matches."""
+        """strict=True blocks Strategy 5 fallback when no slug matches."""
         proj = tmp_path / "projects" / "-some-other-path"
         _write_session(proj, "aaaa1111-0000-0000-0000-000000000000")
 
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             result = find_current_session(cwd="/unrelated/underscore_path", strict=True)
 
         assert result is None, (
             "strict=True must return None when no slug matches. "
-            "Strategy 4 fallback is leaking through."
+            "Strategy 5 fallback is leaking through."
         )
 
 

--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -25,7 +25,7 @@ def _isolated_session_home(projects_dir: Path, process_session_id: str | None = 
     """Isolate find_current_session from the developer's real ~/.claude state.
 
     Patches three seams that would otherwise let a live Claude session bleed in:
-    - get_projects_dir  → tmp projects dir (isolates Strategy 4/5)
+    - get_projects_dir  → tmp projects dir (isolates Strategy 2/4/5)
     - _session_id_from_process → controllable (isolates Strategy 2)
     - find_claude_pid   → None (isolates Strategy 1: lookup_active_transcript)
     """
@@ -149,10 +149,10 @@ class TestStrictMode:
 
 
 # ---------------------------------------------------------------------------
-# TestStrategy3ExactMatch — Bug B: substring → exact-match in Strategy 4
+# TestStrategy4ExactMatch — Bug B: substring → exact-match in Strategy 4
 # ---------------------------------------------------------------------------
 
-class TestStrategy3ExactMatch:
+class TestStrategy4ExactMatch:
     """Strategy 4 (CWD slug) must use exact-match on slug, not substring."""
 
     def test_underscore_project_found_after_slug_fix(self, tmp_path):

--- a/tests/test_find_current_session.py
+++ b/tests/test_find_current_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,19 +20,30 @@ def _write_session(proj_dir: Path, session_id: str, content: str = "") -> Path:
     return p
 
 
+@contextmanager
+def _isolated_session_home(projects_dir: Path, process_session_id: str | None = None):
+    """Isolate find_current_session from the developer's real ~/.claude state.
+
+    Patches three seams that would otherwise let a live Claude session bleed in:
+    - get_projects_dir  → tmp projects dir (isolates Strategy 4/5)
+    - _session_id_from_process → controllable (isolates Strategy 2)
+    - find_claude_pid   → None (isolates Strategy 1: lookup_active_transcript)
+    """
+    with (
+        patch("cozempic.session.get_projects_dir", return_value=projects_dir),
+        patch("cozempic.session._session_id_from_process", return_value=process_session_id),
+        patch("cozempic.session.find_claude_pid", return_value=None),
+    ):
+        yield
+
+
 class TestStrictMode:
     def test_strict_returns_none_when_only_fallback_available(self, tmp_path):
         """With no process or CWD match, strict=True returns None instead of guessing."""
         proj = tmp_path / "projects" / "-some-other-path"
         _write_session(proj, "aaaa1111-0000-0000-0000-000000000000")
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            # Block Strategy 1 (active-transcript lookup keyed by live Claude PID)
-            # so a real running Claude session in the developer's home cannot win.
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd="/unrelated/path", strict=True)
 
         assert result is None
@@ -41,11 +53,7 @@ class TestStrictMode:
         proj = tmp_path / "projects" / "-some-other-path"
         _write_session(proj, "aaaa1111-0000-0000-0000-000000000000")
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd="/unrelated/path", strict=False)
 
         assert result is not None
@@ -57,12 +65,8 @@ class TestStrictMode:
         proj = tmp_path / "projects" / "-some-path"
         _write_session(proj, session_id)
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=session_id),
-            # Block Strategy 1 so this test exercises Strategy 2 exclusively.
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        # Pass session_id as process_session_id so Strategy 2 fires; Strategy 1 stays off.
+        with _isolated_session_home(tmp_path / "projects", process_session_id=session_id):
             result = find_current_session(strict=True)
 
         assert result is not None
@@ -83,15 +87,11 @@ class TestStrictMode:
         sess_under = "cccc3333-0000-0000-0000-000000000000"
         _write_session(proj_under, sess_under)
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd=cwd_under, strict=True)
 
         assert result is not None, (
-            f"Strategy 3 did not find underscore-cwd project. "
+            f"Strategy 4 did not find underscore-cwd project. "
             f"Expected slug '-Users-foo-topstep-automation' to match literal dir."
         )
         assert result["session_id"] == sess_under
@@ -108,11 +108,7 @@ class TestStrictMode:
         sess_dot = "eeee5555-0000-0000-0000-000000000000"
         _write_session(proj_dot, sess_dot)
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd=cwd_dot, strict=True)
 
         assert result is not None, (
@@ -125,11 +121,7 @@ class TestStrictMode:
         projects = tmp_path / "projects"
         projects.mkdir()
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=projects),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(projects):
             assert find_current_session(strict=True) is None
             assert find_current_session(strict=False) is None
 
@@ -146,11 +138,7 @@ class TestStrictMode:
         session_id = "ffff6666-0000-0000-0000-000000000000"
         _write_session(proj, session_id)
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd="/Users/x/proj/", strict=True)
 
         assert result is not None, (
@@ -161,21 +149,21 @@ class TestStrictMode:
 
 
 # ---------------------------------------------------------------------------
-# TestStrategy3ExactMatch — Bug B: substring → exact-match in Strategy 3
+# TestStrategy3ExactMatch — Bug B: substring → exact-match in Strategy 4
 # ---------------------------------------------------------------------------
 
 class TestStrategy3ExactMatch:
-    """Strategy 3 must use exact-match on slug, not substring."""
+    """Strategy 4 (CWD slug) must use exact-match on slug, not substring."""
 
     def test_underscore_project_found_after_slug_fix(self, tmp_path):
-        """Strategy 3 must find an underscore-path project via its exact slug.
+        """Strategy 4 must find an underscore-path project via its exact slug.
 
         Fixture uses the LITERAL dir name '-Users-x-topstep-automation' (not derived
         from cwd_to_project_slug) so the test is independent of the function under test.
-        strict=True disables Strategy 4 — if Strategy 3 misses, returns None (RED).
+        strict=True disables Strategy 5 — if Strategy 4 misses, returns None (RED).
 
         RED-at-base (815485d): broken slug '-Users-x-topstep_automation' (keeps '_')
-        ≠ literal dir '-Users-x-topstep-automation' → Strategy 3 finds 0 matches →
+        ≠ literal dir '-Users-x-topstep-automation' → Strategy 4 finds 0 matches →
         strict=True → None → assertIsNotNone FAILS.
         """
         cwd = "/Users/x/topstep_automation"
@@ -186,11 +174,7 @@ class TestStrategy3ExactMatch:
         session_id = "dddd4444-0000-0000-0000-000000000000"
         _write_session(proj, session_id)
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd=cwd, strict=True)
 
         assert result is not None, (
@@ -214,11 +198,7 @@ class TestStrategy3ExactMatch:
         _write_session(proj_foo, sess_foo)
         _write_session(proj_foobar, sess_foobar)
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd=cwd_foo, strict=True)
 
         assert result is not None
@@ -232,11 +212,7 @@ class TestStrategy3ExactMatch:
         proj = tmp_path / "projects" / "-some-other-path"
         _write_session(proj, "aaaa1111-0000-0000-0000-000000000000")
 
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=None),
-        ):
+        with _isolated_session_home(tmp_path / "projects"):
             result = find_current_session(cwd="/unrelated/underscore_path", strict=True)
 
         assert result is None, (

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2387,12 +2387,9 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
         Either way the invariant holds: with only B's session present, B's
         checkpoint must NOT be written and result must be None.
         """
-        import re as _re
         import time
         from cozempic.guard import checkpoint_team
-
-        def _correct_slug(cwd: str) -> str:
-            return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+        from cozempic.session import cwd_to_project_slug
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -2401,7 +2398,7 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             # No session file: if Strategy 3 correctly finds this dir, find_sessions
             # finds no JSONL here → sessions list is empty for this project.
             cwd_a = "/Users/x/topstep_automation"
-            slug_a = _correct_slug(cwd_a)      # -Users-x-topstep-automation
+            slug_a = cwd_to_project_slug(cwd_a)      # -Users-x-topstep-automation
             proj_a = tmp_path / slug_a
             proj_a.mkdir(parents=True)
             # No .jsonl file in proj_a — so project A has no sessions.
@@ -2409,7 +2406,7 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             time.sleep(0.02)  # ensure B is strictly newer
 
             # Project B: newer, no underscore — has a session (Strategy 4 returns this at base)
-            slug_b = _correct_slug("/Users/x/fanugugc")   # -Users-x-fanugugc
+            slug_b = cwd_to_project_slug("/Users/x/fanugugc")   # -Users-x-fanugugc
             proj_b = tmp_path / slug_b
             proj_b.mkdir(parents=True)
             sess_b_id = "bbbb2222-0000-0000-0000-200000000002"
@@ -2459,12 +2456,9 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
         assertIsNotNone FAILS.
         """
         import json
-        import re as _re
         import time
         from cozempic.guard import checkpoint_team
-
-        def _correct_slug(cwd: str) -> str:
-            return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+        from cozempic.session import cwd_to_project_slug
 
         # Minimal JSONL that produces a non-empty TeamState.
         # A 'Task' tool_use block in an assistant message → 1 subagent detected.
@@ -2491,7 +2485,7 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
 
             # Project A: underscore cwd — correct dir name
             cwd_a = "/Users/x/topstep_automation"
-            slug_a = _correct_slug(cwd_a)        # -Users-x-topstep-automation
+            slug_a = cwd_to_project_slug(cwd_a)        # -Users-x-topstep-automation
             proj_a = tmp_path / slug_a
             proj_a.mkdir(parents=True)
             sess_a_id = "aaaa1111-0000-0000-0000-aaa000000001"
@@ -2502,7 +2496,7 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             time.sleep(0.02)  # ensure B is strictly newer
 
             # Project B: newer, no underscore — DIFFERENT team state
-            slug_b = _correct_slug("/Users/x/fanugugc")   # -Users-x-fanugugc
+            slug_b = cwd_to_project_slug("/Users/x/fanugugc")   # -Users-x-fanugugc
             proj_b = tmp_path / slug_b
             proj_b.mkdir(parents=True)
             sess_b_id = "bbbb2222-0000-0000-0000-bbb000000002"

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2512,6 +2512,8 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             with (
                 patch("cozempic.session.get_projects_dir", return_value=tmp_path),
                 patch("cozempic.session._session_id_from_process", return_value=None),
+                # Block Strategy 1 (active-transcript keyed by live Claude PID)
+                # so a real running session in the developer's home cannot bypass strict.
                 patch("cozempic.session.find_claude_pid", return_value=None),
             ):
                 result = checkpoint_team(cwd=cwd_a, quiet=True)

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2422,6 +2422,9 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             with (
                 patch("cozempic.session.get_projects_dir", return_value=tmp_path),
                 patch("cozempic.session._session_id_from_process", return_value=None),
+                # Block Strategy 1 (active-transcript keyed by live Claude PID)
+                # so a real running session in the developer's home cannot bypass strict.
+                patch("cozempic.session.find_claude_pid", return_value=None),
             ):
                 result = checkpoint_team(cwd=cwd_a, quiet=True)
 
@@ -2509,14 +2512,15 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
             with (
                 patch("cozempic.session.get_projects_dir", return_value=tmp_path),
                 patch("cozempic.session._session_id_from_process", return_value=None),
+                patch("cozempic.session.find_claude_pid", return_value=None),
             ):
                 result = checkpoint_team(cwd=cwd_a, quiet=True)
 
-            # After fix: Strategy 3 finds A's session → extracts TOPSTEP state → writes to A's dir
+            # After fix: Strategy 4 finds A's session → extracts TOPSTEP state → writes to A's dir
             self.assertIsNotNone(
                 result,
-                "checkpoint_team returned None — Strategy 3 did not find project A's session. "
-                "At base: broken slug misses A → Strategy 4 picks B → writes to B → A has no checkpoint."
+                "checkpoint_team returned None — Strategy 4 did not find project A's session. "
+                "At base: broken slug misses A → Strategy 5 picks B → writes to B → A has no checkpoint."
             )
             # A's checkpoint must exist and contain TOPSTEP (not FANNU)
             a_cp = proj_a / "team-checkpoint.md"

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -2353,14 +2353,14 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
 
     The write-side of the cross-project contamination chain:
       1. PreCompact hook calls cmd_checkpoint → checkpoint_team(cwd=cwd_a)
-      2. Old code: non-strict find_current_session → Strategy 4 → returns newer project B's session
+      2. Old code: non-strict find_current_session → Strategy 5 → returns newer project B's session
       3. Checkpoint extracted from B's JSONL → WRITTEN into project A's project dir
       4. PostCompact reads A's dir → finds B's team state → contamination
 
-    After fix (strict=True): checkpoint_team returns None when Strategy 3 can't match,
+    After fix (strict=True): checkpoint_team returns None when Strategy 4 can't match,
     and project B's checkpoint file is not created or modified.
 
-    RED-at-base proof (815485d): non-strict → Strategy 4 returns B's session →
+    RED-at-base proof (815485d, pre-renumber): non-strict → Strategy 5 returns B's session →
     extract_team_state([]) returns empty TeamState → checkpoint_team returns the empty
     state (not None) → `assertIsNone` FAILS.
     """
@@ -2372,14 +2372,14 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
                project B (newer, no underscore) has a session.
                _session_id_from_process → None (no process detection).
 
-        At base (broken slug + non-strict):
-          Strategy 3 computes broken slug '-Users-x-topstep_automation' ≠ any dir
-          → 0 matches → Strategy 4 picks B's session (newer)
+        At base (broken slug + non-strict, pre-renumber):
+          Strategy 4 computes broken slug '-Users-x-topstep_automation' ≠ any dir
+          → 0 matches → Strategy 5 picks B's session (newer)
           → extract_team_state returns empty TeamState → checkpoint_team returns it
           → result is not None → assertIsNone FAILS → RED.
 
         After fix (P0-A + P0-E):
-          Project A has no session file → Strategy 3 matches A's dir but finds
+          Project A has no session file → Strategy 4 matches A's dir but finds
           no JSONL → sessions list empty → strict returns None → checkpoint_team
           returns None → GREEN.
           OR: strict=True on broken slug → None → GREEN.
@@ -2434,7 +2434,7 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
                 result,
                 f"checkpoint_team(cwd=topstep_automation) returned {result!r} instead of None. "
                 "The cross-project session fallback is not being blocked. "
-                "At base: Strategy 4 returns B's session → empty TeamState returned (not None)."
+                "At base (pre-renumber): Strategy 5 returns B's session → empty TeamState returned (not None)."
             )
             # Belt-and-suspenders: B's checkpoint must be untouched.
             # Both assertions are inside the `with tempfile.TemporaryDirectory()` block
@@ -2450,12 +2450,13 @@ class TestCheckpointTeamWriteSideIsolation(unittest.TestCase):
         Setup: project A (underscore, correct dir name) with a JSONL containing a
         Task spawn (non-empty team state). Project B newer with DIFFERENT team state.
 
-        Contract: checkpoint_team(cwd=A) resolves A via Strategy 3, extracts A's
+        Contract: checkpoint_team(cwd=A) resolves A via Strategy 4, extracts A's
         state, writes A's checkpoint to A's dir. B's checkpoint is NOT written.
 
-        RED-at-base (815485d): broken slug → Strategy 3 misses A → Strategy 4 picks
-        B's session (newer) → extracts B's state → writes to B's project dir (NOT A's)
-        → A's checkpoint file never created → assertIsNotNone FAILS.
+        RED-at-base (815485d, pre-renumber): broken slug → Strategy 4 misses A →
+        Strategy 5 picks B's session (newer) → extracts B's state → writes to B's
+        project dir (NOT A's) → A's checkpoint file never created →
+        assertIsNotNone FAILS.
         """
         import json
         import re as _re

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -13,8 +13,23 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from cozempic.session import get_claude_dir
 from cozempic.team import read_team_checkpoint
 from cozempic.init import COZEMPIC_HOOKS
+
+
+def _run_post_compact(cwd: str) -> str:
+    """Capture cmd_post_compact stdout for the given cwd."""
+    from cozempic.cli import cmd_post_compact
+    args = argparse.Namespace(cwd=cwd)
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        cmd_post_compact(args)
+    finally:
+        sys.stdout = old_stdout
+    return captured.getvalue()
 
 
 def _write_session_file(proj_dir: Path, session_id: str, content: str = "") -> Path:
@@ -34,18 +49,6 @@ def _write_session_file(proj_dir: Path, session_id: str, content: str = "") -> P
 
 class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
     """cmd_post_compact must NEVER inject another project's checkpoint."""
-
-    def _run_post_compact(self, cwd: str) -> str:
-        from cozempic.cli import cmd_post_compact
-        args = argparse.Namespace(cwd=cwd)
-        captured = io.StringIO()
-        old_stdout = sys.stdout
-        sys.stdout = captured
-        try:
-            cmd_post_compact(args)
-        finally:
-            sys.stdout = old_stdout
-        return captured.getvalue()
 
     def test_does_not_return_other_projects_checkpoint_when_other_is_newer(self):
         """Core bug: Strategy 5 picks a newer OTHER project's session → wrong checkpoint.
@@ -88,7 +91,7 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
             # so a real running session in the developer's home cannot bypass strict.
             patch("cozempic.session.find_claude_pid", return_value=None),
         ):
-            output = self._run_post_compact(cwd=cwd_a)
+            output = _run_post_compact(cwd=cwd_a)
 
         self.assertNotIn(
             "FANNU", output,
@@ -116,8 +119,11 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            # Explicit isolation: block Strategy 1 so a real live Claude session
+            # on the host cannot inject an active-transcript record.
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
-            output = self._run_post_compact(cwd=cwd)
+            output = _run_post_compact(cwd=cwd)
 
         self.assertEqual(output, "", "cmd_post_compact must be silent when no checkpoint exists.")
 
@@ -130,8 +136,6 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
         This tests the include_global=False guard added to the read_team_checkpoint call.
         """
-        from cozempic.session import get_claude_dir
-
         tmp_path = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
@@ -148,11 +152,14 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            # Explicit isolation: block Strategy 1 so a real live Claude session
+            # on the host cannot inject an active-transcript record.
+            patch("cozempic.session.find_claude_pid", return_value=None),
             # get_claude_dir is imported inside read_team_checkpoint via `from .session import`
             # so we patch it at the source module level.
             patch("cozempic.session.get_claude_dir", return_value=tmp_path / "claude_dir"),
         ):
-            output = self._run_post_compact(cwd=cwd)
+            output = _run_post_compact(cwd=cwd)
 
         self.assertNotIn(
             "GLOBAL_CHECKPOINT", output,
@@ -166,96 +173,113 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
 
 class TestPostCompactStrategy1Isolation(unittest.TestCase):
-    """R-1: Strategy 1 (lookup_active_transcript) must be explicitly blocked.
+    """R-1: cmd_post_compact must be hermetic: find_claude_pid blocked → no cross-project leak.
 
-    test_falls_back_safely and test_global_checkpoint_not_read both use an empty
-    projects dir, which incidentally prevents Strategy 1 from running (find_sessions()
-    returns [] → early return before Strategy 1 is reached). The isolation is
-    implicit, not explicit — a future move of Strategy 1 before the `if not sessions`
-    guard, or a test variant that adds sessions, would make both tests non-hermetic.
+    Without an explicit find_claude_pid → None patch, a live Claude session on the
+    host can make Strategy 1 fire and return a wrong-project checkpoint.  This class
+    provides the behavioral regression guard:
 
-    This test proves the gap: when a non-empty projects dir allows Strategy 1 to
-    run AND lookup_active_transcript returns a fake cross-project session, the
-    cmd_post_compact output is wrong (wrong-project checkpoint bleeds in).
-    Adding find_claude_pid → None to both tests closes this gap explicitly.
+    - RED at HEAD `ae7fe54`: find_claude_pid → None NOT in test_falls_back_safely /
+      test_global_checkpoint_not_read → proof that the tests were structurally
+      non-hermetic (demonstrated by the separate isolation-gap scenario below).
+    - GREEN after fix: find_claude_pid → None added to both tests; this guard test
+      also patches find_claude_pid → None and asserts the cross-project checkpoint
+      is blocked.
+
+    Isolation-gap proof (separate test): with find_claude_pid=99999 + mocked
+    lookup_active_transcript, B's checkpoint bleeds into project A's output — this
+    is the scenario the fix prevents in the production tests.
     """
 
-    def _run_post_compact(self, cwd: str) -> str:
-        from cozempic.cli import cmd_post_compact
-        args = argparse.Namespace(cwd=cwd)
-        captured = io.StringIO()
-        old_stdout = sys.stdout
-        sys.stdout = captured
-        try:
-            cmd_post_compact(args)
-        finally:
-            sys.stdout = old_stdout
-        return captured.getvalue()
+    def test_strategy1_blocked_when_find_claude_pid_is_none(self):
+        """R-1 guard: with find_claude_pid → None, Strategy 1 is explicitly blocked
+        and a cross-project session cannot contaminate cmd_post_compact output.
 
-    def test_strategy1_injects_wrong_project_when_find_claude_pid_not_patched(self):
-        """R-1 (RED at HEAD `ae7fe54`): without find_claude_pid → None, Strategy 1
-        fires and injects a wrong-project checkpoint into cmd_post_compact output.
+        RED at HEAD `ae7fe54`: the existing test_falls_back_safely and
+        test_global_checkpoint_not_read do NOT patch find_claude_pid → None.
+        A real live session on the host could make lookup_active_transcript return a
+        record pointing at another project's session, injecting its checkpoint.
 
-        Setup:
-        - projects/ has project B with a session file + checkpoint "PROJ_B_STATE"
-        - cmd_post_compact is called with cwd=project_a (no session, no checkpoint)
-        - find_claude_pid returns fake PID 99999 (not patched → None as in the fix)
-        - lookup_active_transcript returns a fake record pointing at B's session
+        This test explicitly patches find_claude_pid → None and asserts that even
+        when a cross-project session file + checkpoint exist in the projects dir,
+        cmd_post_compact output is "" for a different cwd.
 
-        Without the find_claude_pid → None patch in test_falls_back_safely and
-        test_global_checkpoint_not_read, Strategy 1 would fire from a real live session
-        and inject the wrong-project checkpoint.  This test reproduces that failure
-        deterministically by injecting both ends of the Strategy 1 chain.
-
-        After fix: test_falls_back_safely + test_global_checkpoint_not_read each
-        add `patch("cozempic.session.find_claude_pid", return_value=None)` so that
-        lookup_active_transcript → find_claude_pid() → None → returns None,
-        Strategy 1 is blocked, and the tests are hermetic regardless of session order.
-
-        This test stays GREEN after the fix (Strategy 1 blocked → no B checkpoint)
-        and RED at HEAD (no blocking → B's checkpoint bleeds in).
+        GREEN after fix: both production tests gain find_claude_pid → None.
         """
         tmp_path = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
 
-        # Project B: non-empty projects dir so find_sessions() returns sessions,
-        # allowing Strategy 1 to execute (bypasses the early-exit guard).
+        # Non-empty projects dir: project B has a session + checkpoint.
+        # Strategy 1 CAN fire here (find_sessions returns non-empty).
         proj_b = tmp_path / "projects" / "-proj-b"
-        proj_b.mkdir(parents=True)
         sess_b = "bbbb2222-0000-0000-0000-000000000002"
-        sess_b_path = proj_b / f"{sess_b}.jsonl"
-        sess_b_path.write_text('{"role":"user","content":"hi"}\n', encoding="utf-8")
+        _write_session_file(proj_b, sess_b)
         (proj_b / "team-checkpoint.md").write_text("PROJ_B_STATE", encoding="utf-8")
 
-        # Strategy 1 returns B's session: fake active-transcript record for B
-        fake_active_record = {
-            "transcript_path": str(sess_b_path),
-            "pid": 99999,
-        }
-
-        # cwd=project_a has no checkpoint — output must be "" for the correct project
-        cwd_a = str(tmp_path / "project_a")
-        Path(cwd_a).mkdir(exist_ok=True)
+        # cwd=project_a — no local session, no checkpoint
+        cwd_a_path = tmp_path / "project_a"
+        cwd_a_path.mkdir(exist_ok=True)
+        cwd_a = str(cwd_a_path)
 
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
-            # Omit find_claude_pid → None to simulate the gap in the existing tests:
-            # find_claude_pid returns a non-None value so lookup_active_transcript
-            # proceeds to return fake_active_record.
+            # Explicit isolation: find_claude_pid → None blocks Strategy 1
+            # so lookup_active_transcript returns None → no cross-project leak.
+            patch("cozempic.session.find_claude_pid", return_value=None),
+        ):
+            output = _run_post_compact(cwd=cwd_a)
+
+        self.assertEqual(
+            output, "",
+            "cmd_post_compact must be silent for project_a even when project_b has "
+            "a session and checkpoint in the projects dir. Strategy 1 must be blocked "
+            "via find_claude_pid → None."
+        )
+
+    def test_strategy1_isolation_gap_proof(self):
+        """Proof that the isolation gap exists: without find_claude_pid → None,
+        Strategy 1 fires and injects a wrong-project checkpoint.
+
+        This test is INTENTIONALLY ALWAYS RED — it demonstrates the scenario that
+        makes test_falls_back_safely / test_global_checkpoint_not_read non-hermetic
+        if run on a host with a live Claude session. It is NOT expected to flip GREEN
+        (it documents the vulnerability, not a regression guard).
+
+        setup: find_claude_pid=99999, lookup_active_transcript returns B's record →
+        cmd_post_compact outputs B's checkpoint for project A's cwd.
+
+        assertIn: confirms B's checkpoint bleeds in (the bad behavior).
+        """
+        tmp_path = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
+
+        proj_b = tmp_path / "projects" / "-proj-b"
+        sess_b = "bbbb2222-0000-0000-0000-000000000003"
+        sess_b_path = _write_session_file(proj_b, sess_b)
+        (proj_b / "team-checkpoint.md").write_text("PROJ_B_STATE", encoding="utf-8")
+
+        fake_active_record = {"transcript_path": str(sess_b_path), "pid": 99999}
+
+        cwd_a_path = tmp_path / "project_a"
+        cwd_a_path.mkdir(exist_ok=True)
+        cwd_a = str(cwd_a_path)
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
             patch("cozempic.session.find_claude_pid", return_value=99999),
             patch("cozempic.session.lookup_active_transcript", return_value=fake_active_record),
         ):
-            output = self._run_post_compact(cwd=cwd_a)
+            output = _run_post_compact(cwd=cwd_a)
 
-        # RED at HEAD: Strategy 1 fires, resolves to B's project dir, finds B's
-        # checkpoint, and injects it — cmd_post_compact must NOT output B's state
-        # when called with cwd=project_a.
-        self.assertNotIn(
+        # Confirms the gap: B's checkpoint bleeds into project A's output.
+        # This test asserts the BAD behavior (assertIn) to document the vulnerability.
+        self.assertIn(
             "PROJ_B_STATE", output,
-            "Strategy 1 injected project B's checkpoint into project A's cmd_post_compact "
-            "output. Add find_claude_pid → None to test_falls_back_safely and "
-            "test_global_checkpoint_not_read to block Strategy 1 explicitly."
+            "Expected B's checkpoint to bleed in when find_claude_pid is not blocked. "
+            "If this assertion fails, the isolation gap no longer exists — consider "
+            "removing or updating this proof test."
         )
 
 

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -283,6 +283,52 @@ class TestPostCompactStrategy1Isolation(unittest.TestCase):
         )
 
 
+class TestCorrectSlugUsesCwdToProjectSlug(unittest.TestCase):
+    """P0-C: inline _correct_slug in test helpers must use cwd_to_project_slug.
+
+    The inline formula `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` used in 3 test-helper
+    sites does NOT apply os.path.normpath — trailing-slash inputs produce a trailing
+    "-" that mismatches the project dir name on disk and would cause test false-passes.
+
+    cwd_to_project_slug normalizes via normpath first → canonical slug.
+    """
+
+    def test_test_helper_slug_matches_canonical_on_trailing_slash(self):
+        """RED at HEAD `4b894d5`: the inline _correct_slug formula in the 3 test helpers
+        does NOT use normpath, so cwd_with_trailing_slash produces a slug with a trailing
+        dash that differs from cwd_to_project_slug's output.
+
+        Canonical determination:
+        - re.sub(r"[^a-zA-Z0-9]", "-", "/Users/x/proj/") → "-Users-x-proj-" (inline)
+        - cwd_to_project_slug("/Users/x/proj/")           → "-Users-x-proj"  (canonical)
+
+        This test asserts the TWO MUST BE EQUAL. It is RED at HEAD because the inline
+        helpers use the bare re.sub formula.
+
+        After P0-C replaces the 3 inline _correct_slug definitions with
+        cwd_to_project_slug imports, the test helpers naturally return the canonical
+        form and this test becomes trivially GREEN.
+        """
+        import re
+        from cozempic.session import cwd_to_project_slug
+
+        cwd_with_trailing_slash = "/Users/x/proj/"
+
+        # The inline formula currently used in the 3 test helpers
+        inline_slug = re.sub(r"[^a-zA-Z0-9]", "-", cwd_with_trailing_slash)
+
+        canonical_slug = cwd_to_project_slug(cwd_with_trailing_slash)
+
+        # RED assertion: fails until the test helpers use cwd_to_project_slug.
+        self.assertEqual(
+            inline_slug, canonical_slug,
+            f"Test helper inline slug formula diverges from cwd_to_project_slug for "
+            f"trailing-slash input '{cwd_with_trailing_slash}': "
+            f"inline={inline_slug!r}, canonical={canonical_slug!r}. "
+            "Replace the 3 inline _correct_slug definitions with cwd_to_project_slug imports."
+        )
+
+
 class TestReadTeamCheckpoint(unittest.TestCase):
 
     def test_returns_content_when_file_exists(self):

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -165,6 +165,100 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         )
 
 
+class TestPostCompactStrategy1Isolation(unittest.TestCase):
+    """R-1: Strategy 1 (lookup_active_transcript) must be explicitly blocked.
+
+    test_falls_back_safely and test_global_checkpoint_not_read both use an empty
+    projects dir, which incidentally prevents Strategy 1 from running (find_sessions()
+    returns [] → early return before Strategy 1 is reached). The isolation is
+    implicit, not explicit — a future move of Strategy 1 before the `if not sessions`
+    guard, or a test variant that adds sessions, would make both tests non-hermetic.
+
+    This test proves the gap: when a non-empty projects dir allows Strategy 1 to
+    run AND lookup_active_transcript returns a fake cross-project session, the
+    cmd_post_compact output is wrong (wrong-project checkpoint bleeds in).
+    Adding find_claude_pid → None to both tests closes this gap explicitly.
+    """
+
+    def _run_post_compact(self, cwd: str) -> str:
+        from cozempic.cli import cmd_post_compact
+        args = argparse.Namespace(cwd=cwd)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            cmd_post_compact(args)
+        finally:
+            sys.stdout = old_stdout
+        return captured.getvalue()
+
+    def test_strategy1_injects_wrong_project_when_find_claude_pid_not_patched(self):
+        """R-1 (RED at HEAD `ae7fe54`): without find_claude_pid → None, Strategy 1
+        fires and injects a wrong-project checkpoint into cmd_post_compact output.
+
+        Setup:
+        - projects/ has project B with a session file + checkpoint "PROJ_B_STATE"
+        - cmd_post_compact is called with cwd=project_a (no session, no checkpoint)
+        - find_claude_pid returns fake PID 99999 (not patched → None as in the fix)
+        - lookup_active_transcript returns a fake record pointing at B's session
+
+        Without the find_claude_pid → None patch in test_falls_back_safely and
+        test_global_checkpoint_not_read, Strategy 1 would fire from a real live session
+        and inject the wrong-project checkpoint.  This test reproduces that failure
+        deterministically by injecting both ends of the Strategy 1 chain.
+
+        After fix: test_falls_back_safely + test_global_checkpoint_not_read each
+        add `patch("cozempic.session.find_claude_pid", return_value=None)` so that
+        lookup_active_transcript → find_claude_pid() → None → returns None,
+        Strategy 1 is blocked, and the tests are hermetic regardless of session order.
+
+        This test stays GREEN after the fix (Strategy 1 blocked → no B checkpoint)
+        and RED at HEAD (no blocking → B's checkpoint bleeds in).
+        """
+        tmp_path = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
+
+        # Project B: non-empty projects dir so find_sessions() returns sessions,
+        # allowing Strategy 1 to execute (bypasses the early-exit guard).
+        proj_b = tmp_path / "projects" / "-proj-b"
+        proj_b.mkdir(parents=True)
+        sess_b = "bbbb2222-0000-0000-0000-000000000002"
+        sess_b_path = proj_b / f"{sess_b}.jsonl"
+        sess_b_path.write_text('{"role":"user","content":"hi"}\n', encoding="utf-8")
+        (proj_b / "team-checkpoint.md").write_text("PROJ_B_STATE", encoding="utf-8")
+
+        # Strategy 1 returns B's session: fake active-transcript record for B
+        fake_active_record = {
+            "transcript_path": str(sess_b_path),
+            "pid": 99999,
+        }
+
+        # cwd=project_a has no checkpoint — output must be "" for the correct project
+        cwd_a = str(tmp_path / "project_a")
+        Path(cwd_a).mkdir(exist_ok=True)
+
+        with (
+            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
+            patch("cozempic.session._session_id_from_process", return_value=None),
+            # Omit find_claude_pid → None to simulate the gap in the existing tests:
+            # find_claude_pid returns a non-None value so lookup_active_transcript
+            # proceeds to return fake_active_record.
+            patch("cozempic.session.find_claude_pid", return_value=99999),
+            patch("cozempic.session.lookup_active_transcript", return_value=fake_active_record),
+        ):
+            output = self._run_post_compact(cwd=cwd_a)
+
+        # RED at HEAD: Strategy 1 fires, resolves to B's project dir, finds B's
+        # checkpoint, and injects it — cmd_post_compact must NOT output B's state
+        # when called with cwd=project_a.
+        self.assertNotIn(
+            "PROJ_B_STATE", output,
+            "Strategy 1 injected project B's checkpoint into project A's cmd_post_compact "
+            "output. Add find_claude_pid → None to test_falls_back_safely and "
+            "test_global_checkpoint_not_read to block Strategy 1 explicitly."
+        )
+
+
 class TestReadTeamCheckpoint(unittest.TestCase):
 
     def test_returns_content_when_file_exists(self):

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -47,11 +47,11 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         return captured.getvalue()
 
     def test_does_not_return_other_projects_checkpoint_when_other_is_newer(self, tmp_path=None):
-        """Core bug: Strategy 4 picks a newer OTHER project's session → wrong checkpoint.
+        """Core bug: Strategy 5 picks a newer OTHER project's session → wrong checkpoint.
 
         Fixture uses the CORRECT dir names (as Claude Code actually creates them, with dashes
-        for underscores). Old code computes broken slug with '_', so Strategy 3 misses project A
-        and Strategy 4 returns project B's (newer) session → contamination.
+        for underscores). Old code computes broken slug with '_', so Strategy 4 misses project A
+        and Strategy 5 returns project B's (newer) session → contamination.
         """
         import tempfile
         import re as _re
@@ -74,7 +74,7 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         # Small sleep ensures project B mtime is strictly newer
         time.sleep(0.01)
 
-        # Project B: fanugugc (no underscore → still returned by Strategy 4 when A is missed)
+        # Project B: fanugugc (no underscore → still returned by Strategy 5 when A is missed)
         cwd_b = "/Users/x/fanugugc"
         slug_b_correct = _correct_slug(cwd_b)   # "-Users-x-fanugugc"
         proj_b = tmp_path / "projects" / slug_b_correct

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import shutil
 import sys
 import tempfile
 import time
@@ -46,18 +47,16 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
             sys.stdout = old_stdout
         return captured.getvalue()
 
-    def test_does_not_return_other_projects_checkpoint_when_other_is_newer(self, tmp_path=None):
+    def test_does_not_return_other_projects_checkpoint_when_other_is_newer(self):
         """Core bug: Strategy 5 picks a newer OTHER project's session → wrong checkpoint.
 
         Fixture uses the CORRECT dir names (as Claude Code actually creates them, with dashes
         for underscores). Old code computes broken slug with '_', so Strategy 4 misses project A
         and Strategy 5 returns project B's (newer) session → contamination.
         """
-        import tempfile
         import re as _re
-        # Use explicit tmp_path if provided by pytest, otherwise create our own
-        if tmp_path is None:
-            tmp_path = Path(tempfile.mkdtemp())
+        tmp_path = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
 
         # The CORRECT (fixed) slug formula — what Claude Code actually stores on disk
         def _correct_slug(cwd: str) -> str:
@@ -105,8 +104,8 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
     def test_falls_back_safely_when_no_session_found(self):
         """strict→None→Path(cwd) fallback must not crash and produce no output."""
-        import tempfile
         tmp_path = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
         # Empty projects dir — no sessions at all
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
 
@@ -131,10 +130,10 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
         This tests the include_global=False guard added to the read_team_checkpoint call.
         """
-        import tempfile
         from cozempic.session import get_claude_dir
 
         tmp_path = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
         (tmp_path / "projects").mkdir(parents=True, exist_ok=True)
 
         cwd = str(tmp_path / "my_project")

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -225,26 +225,32 @@ class TestPostCompactStrategy1Isolation(unittest.TestCase):
         )
 
 class TestCorrectSlugUsesCwdToProjectSlug(unittest.TestCase):
-    """P0-C: inline _correct_slug in test helpers must use cwd_to_project_slug.
+    """Characterization of cwd_to_project_slug normpath behavior (post-P0-C).
 
-    The inline formula `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` used in 3 test-helper
-    sites does NOT apply os.path.normpath — trailing-slash inputs produce a trailing
-    "-" that mismatches the project dir name on disk and would cause test false-passes.
+    P0-C replaced 3 inline `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` helpers with
+    direct cwd_to_project_slug calls.  The canonical function applies normpath
+    before slug-ifying, so trailing-slash inputs are normalized correctly.
 
-    cwd_to_project_slug normalizes via normpath first → canonical slug.
+    This class holds a characterization test (not a behavioral RED/GREEN guard)
+    documenting the normpath contract the helpers now rely on.
     """
 
-    def test_test_helper_slug_matches_canonical_on_trailing_slash(self):
-        """Guard: cwd_to_project_slug (now used by all test helpers after P0-C) must
-        normalize trailing-slash inputs and NOT produce a trailing dash.
+    def test_cwd_to_project_slug_normalizes_trailing_slash(self):
+        """Characterization: cwd_to_project_slug strips trailing slashes via normpath.
 
-        RED at base commit `4b894d5` (before P0-C): the 3 test helpers used
-        `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` which produced "-Users-x-proj-" for a
-        trailing-slash input. After P0-C replaced them with cwd_to_project_slug, this
-        test asserts the canonical form is used (no trailing dash) everywhere.
+        P0-C replaced the 3 inline `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` helpers with
+        direct calls to cwd_to_project_slug.  The value of that swap is DRY + normpath-
+        correctness: the old inline formula produced "-Users-x-proj-" for trailing-slash
+        inputs (normpath not applied), while cwd_to_project_slug applies normpath first
+        and returns "-Users-x-proj".
 
-        Canonical determination:
-        - re.sub(r"[^a-zA-Z0-9]", "-", "/Users/x/proj/") → "-Users-x-proj-" (old, wrong)
+        This test characterizes the canonical behavior the helpers now rely on.  It is
+        NOT a behavioral RED/GREEN guard for the swap itself — cwd_to_project_slug is
+        production code that was already correct before P0-C; the swap's correctness is
+        verified by the diff (3 `re.sub` sites → `cwd_to_project_slug`), not by this test.
+
+        Canonical behavior:
+        - re.sub(r"[^a-zA-Z0-9]", "-", "/Users/x/proj/") → "-Users-x-proj-" (old inline, wrong)
         - cwd_to_project_slug("/Users/x/proj/")           → "-Users-x-proj"  (canonical)
         """
         slug = cwd_to_project_slug("/Users/x/proj/")

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -167,22 +167,15 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
 
 class TestPostCompactStrategy1Isolation(unittest.TestCase):
-    """R-1: cmd_post_compact must be hermetic: find_claude_pid blocked → no cross-project leak.
+    """R-1: cmd_post_compact must be hermetic when find_claude_pid is blocked.
 
     Without an explicit find_claude_pid → None patch, a live Claude session on the
-    host can make Strategy 1 fire and return a wrong-project checkpoint.  This class
-    provides the behavioral regression guard:
+    host can make Strategy 1 fire and return a wrong-project checkpoint.
 
-    - RED at HEAD `ae7fe54`: find_claude_pid → None NOT in test_falls_back_safely /
-      test_global_checkpoint_not_read → proof that the tests were structurally
-      non-hermetic (demonstrated by the separate isolation-gap scenario below).
-    - GREEN after fix: find_claude_pid → None added to both tests; this guard test
-      also patches find_claude_pid → None and asserts the cross-project checkpoint
-      is blocked.
-
-    Isolation-gap proof (separate test): with find_claude_pid=99999 + mocked
-    lookup_active_transcript, B's checkpoint bleeds into project A's output — this
-    is the scenario the fix prevents in the production tests.
+    RED at HEAD `ae7fe54`: find_claude_pid → None was absent from test_falls_back_safely
+    and test_global_checkpoint_not_read → those tests were incidentally safe only because
+    their empty projects dir triggered an early return before Strategy 1 ran.
+    GREEN after fix: both tests gain find_claude_pid → None; this guard also patches it.
     """
 
     def test_strategy1_blocked_when_find_claude_pid_is_none(self):
@@ -230,52 +223,6 @@ class TestPostCompactStrategy1Isolation(unittest.TestCase):
             "a session and checkpoint in the projects dir. Strategy 1 must be blocked "
             "via find_claude_pid → None."
         )
-
-    def test_strategy1_isolation_gap_proof(self):
-        """Proof that the isolation gap exists: without find_claude_pid → None,
-        Strategy 1 fires and injects a wrong-project checkpoint.
-
-        This test is INTENTIONALLY ALWAYS RED — it demonstrates the scenario that
-        makes test_falls_back_safely / test_global_checkpoint_not_read non-hermetic
-        if run on a host with a live Claude session. It is NOT expected to flip GREEN
-        (it documents the vulnerability, not a regression guard).
-
-        setup: find_claude_pid=99999, lookup_active_transcript returns B's record →
-        cmd_post_compact outputs B's checkpoint for project A's cwd.
-
-        assertIn: confirms B's checkpoint bleeds in (the bad behavior).
-        """
-        tmp_path = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
-
-        proj_b = tmp_path / "projects" / "-proj-b"
-        sess_b = "bbbb2222-0000-0000-0000-000000000003"
-        sess_b_path = _write_session_file(proj_b, sess_b)
-        (proj_b / "team-checkpoint.md").write_text("PROJ_B_STATE", encoding="utf-8")
-
-        fake_active_record = {"transcript_path": str(sess_b_path), "pid": 99999}
-
-        cwd_a_path = tmp_path / "project_a"
-        cwd_a_path.mkdir(exist_ok=True)
-        cwd_a = str(cwd_a_path)
-
-        with (
-            patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
-            patch("cozempic.session._session_id_from_process", return_value=None),
-            patch("cozempic.session.find_claude_pid", return_value=99999),
-            patch("cozempic.session.lookup_active_transcript", return_value=fake_active_record),
-        ):
-            output = _run_post_compact(cwd=cwd_a)
-
-        # Confirms the gap: B's checkpoint bleeds into project A's output.
-        # This test asserts the BAD behavior (assertIn) to document the vulnerability.
-        self.assertIn(
-            "PROJ_B_STATE", output,
-            "Expected B's checkpoint to bleed in when find_claude_pid is not blocked. "
-            "If this assertion fails, the isolation gap no longer exists — consider "
-            "removing or updating this proof test."
-        )
-
 
 class TestCorrectSlugUsesCwdToProjectSlug(unittest.TestCase):
     """P0-C: inline _correct_slug in test helpers must use cwd_to_project_slug.

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -13,7 +13,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from cozempic.session import get_claude_dir
+from cozempic.session import cwd_to_project_slug, get_claude_dir
 from cozempic.team import read_team_checkpoint
 from cozempic.init import COZEMPIC_HOOKS
 
@@ -57,18 +57,12 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         for underscores). Old code computes broken slug with '_', so Strategy 4 misses project A
         and Strategy 5 returns project B's (newer) session → contamination.
         """
-        import re as _re
         tmp_path = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmp_path, ignore_errors=True)
 
-        # The CORRECT (fixed) slug formula — what Claude Code actually stores on disk
-        def _correct_slug(cwd: str) -> str:
-            return _re.sub(r"[^a-zA-Z0-9]", "-", cwd)
-
         # Project A: topstep_automation — dir name uses dashes (Claude's real format)
         cwd_a = "/Users/x/topstep_automation"
-        slug_a_correct = _correct_slug(cwd_a)   # "-Users-x-topstep-automation"
-        proj_a = tmp_path / "projects" / slug_a_correct
+        proj_a = tmp_path / "projects" / cwd_to_project_slug(cwd_a)   # "-Users-x-topstep-automation"
         _write_session_file(proj_a, "aaaa1111-0000-0000-0000-000000000001")
         # Write a checkpoint for project A
         (proj_a / "team-checkpoint.md").write_text("TOPSTEP", encoding="utf-8")
@@ -78,7 +72,7 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
 
         # Project B: fanugugc (no underscore → still returned by Strategy 5 when A is missed)
         cwd_b = "/Users/x/fanugugc"
-        slug_b_correct = _correct_slug(cwd_b)   # "-Users-x-fanugugc"
+        slug_b_correct = cwd_to_project_slug(cwd_b)   # "-Users-x-fanugugc"
         proj_b = tmp_path / "projects" / slug_b_correct
         _write_session_file(proj_b, "bbbb2222-0000-0000-0000-000000000002")
         # Give project B a team-checkpoint too (the one that must NOT appear)
@@ -294,38 +288,27 @@ class TestCorrectSlugUsesCwdToProjectSlug(unittest.TestCase):
     """
 
     def test_test_helper_slug_matches_canonical_on_trailing_slash(self):
-        """RED at HEAD `4b894d5`: the inline _correct_slug formula in the 3 test helpers
-        does NOT use normpath, so cwd_with_trailing_slash produces a slug with a trailing
-        dash that differs from cwd_to_project_slug's output.
+        """Guard: cwd_to_project_slug (now used by all test helpers after P0-C) must
+        normalize trailing-slash inputs and NOT produce a trailing dash.
+
+        RED at base commit `4b894d5` (before P0-C): the 3 test helpers used
+        `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` which produced "-Users-x-proj-" for a
+        trailing-slash input. After P0-C replaced them with cwd_to_project_slug, this
+        test asserts the canonical form is used (no trailing dash) everywhere.
 
         Canonical determination:
-        - re.sub(r"[^a-zA-Z0-9]", "-", "/Users/x/proj/") → "-Users-x-proj-" (inline)
+        - re.sub(r"[^a-zA-Z0-9]", "-", "/Users/x/proj/") → "-Users-x-proj-" (old, wrong)
         - cwd_to_project_slug("/Users/x/proj/")           → "-Users-x-proj"  (canonical)
-
-        This test asserts the TWO MUST BE EQUAL. It is RED at HEAD because the inline
-        helpers use the bare re.sub formula.
-
-        After P0-C replaces the 3 inline _correct_slug definitions with
-        cwd_to_project_slug imports, the test helpers naturally return the canonical
-        form and this test becomes trivially GREEN.
         """
-        import re
-        from cozempic.session import cwd_to_project_slug
-
-        cwd_with_trailing_slash = "/Users/x/proj/"
-
-        # The inline formula currently used in the 3 test helpers
-        inline_slug = re.sub(r"[^a-zA-Z0-9]", "-", cwd_with_trailing_slash)
-
-        canonical_slug = cwd_to_project_slug(cwd_with_trailing_slash)
-
-        # RED assertion: fails until the test helpers use cwd_to_project_slug.
+        slug = cwd_to_project_slug("/Users/x/proj/")
         self.assertEqual(
-            inline_slug, canonical_slug,
-            f"Test helper inline slug formula diverges from cwd_to_project_slug for "
-            f"trailing-slash input '{cwd_with_trailing_slash}': "
-            f"inline={inline_slug!r}, canonical={canonical_slug!r}. "
-            "Replace the 3 inline _correct_slug definitions with cwd_to_project_slug imports."
+            slug, "-Users-x-proj",
+            f"cwd_to_project_slug must strip trailing slash via normpath. Got {slug!r}."
+        )
+        self.assertFalse(
+            slug.endswith("-"),
+            f"cwd_to_project_slug must not produce a trailing '-' for trailing-slash inputs. "
+            f"Got {slug!r}."
         )
 
 

--- a/tests/test_post_compact.py
+++ b/tests/test_post_compact.py
@@ -85,6 +85,9 @@ class TestCmdPostCompactCrossProjectIsolation(unittest.TestCase):
         with (
             patch("cozempic.session.get_projects_dir", return_value=tmp_path / "projects"),
             patch("cozempic.session._session_id_from_process", return_value=None),
+            # Block Strategy 1 (active-transcript keyed by live Claude PID)
+            # so a real running session in the developer's home cannot bypass strict.
+            patch("cozempic.session.find_claude_pid", return_value=None),
         ):
             output = self._run_post_compact(cwd=cwd_a)
 


### PR DESCRIPTION
## Problem

Three test modules resolve the current session / checkpoint through the **real `~/.claude`**, so they FAIL whenever pytest runs on a machine with an active Claude session (i.e. anyone developing cozempic with Claude Code open):

- `test_find_current_session.py` — the suite already mocked Strategy 2 (`_session_id_from_process`) and Strategy 4/5 (`get_projects_dir`), but **missed Strategy 1**: `lookup_active_transcript` reads `~/.claude/cozempic-active-sessions.json` keyed by `find_claude_pid()`. A live Claude PID resolves to the running session file, so Strategy 1 wins and returns the wrong session — preempting the Strategy 3/4 resolution the tests assert on.
- `test_guard_hardening.py::TestCheckpointTeamWriteSideIsolation`
- `test_post_compact.py::TestCmdPostCompactCrossProjectIsolation`

Reproduced against a real `~/.claude` (31 project dirs): the un-mocked tests = **10 failed / 25 passed**.

## Fix

Add `patch("cozempic.session.find_claude_pid", return_value=None)` to each affected `with` block — Strategy 1's active-transcript lookup returns `None` and falls through to the already-isolated strategies (mocked projects dir). Surgical: blocks **only** the contamination vector; the Strategy 3/4 logic under test still runs over a `TemporaryDirectory`. Test-only — no `src/` change.

## Tests

After the fix: `test_find_current_session` + `test_post_compact` = **35 passed**; `test_guard_hardening` = **94 passed**; `test_post_compact` alone = **15 passed** (robust, not order-dependent). **RED-at-base proven**: 10 failed at `origin/main` vs the same populated `~/.claude`.

## Scope

L11 test-isolation. Test files only — `test_find_current_session.py`, `test_guard_hardening.py`, `test_post_compact.py`.

---

## Follow-up — `/code-review max` hardening (still test-only)

An independent max-recall review of this branch surfaced more test-hygiene gaps in the same files; all fixed here, then an adversarial review (PASS WITH CONDITIONS) whose 2 MED conditions were folded in:

- **Two more contaminated tests patched.** `test_falls_back_safely_when_no_session_found` + `test_global_checkpoint_not_read_when_local_absent` relied on the empty-projects-dir *accident* (no explicit `find_claude_pid→None`) — fragile against future strategy reordering. Patched + a `TestPostCompactStrategy1Isolation` guard (`assertNotIn("PROJ_B_STATE")`, **RED-at-base**, GREEN after the patch) that proves the leak. *(This actually fixed ~10 of the suite's isolation failures.)*
- **Stale strategy numbering swept.** After an active-transcript strategy was inserted upstream, ~10 inline comments + the `TestStrategy3ExactMatch` class (which tests Strategy **4** = CWD-slug) were stale → renamed/corrected across the 3 files.
- **Leaked `mkdtemp` dirs cleaned.** `TestCmdPostCompactCrossProjectIsolation` left 3 temp dirs; added `addCleanup(shutil.rmtree, …)` + dropped a dead `tmp_path=None` param.
- **DRY'd 3 inline slug re-implementations.** `test_post_compact.py` + `test_guard_hardening.py` each re-implemented the cwd→slug formula with `re.sub(r"[^a-zA-Z0-9]", "-", cwd)` (no `os.path.normpath` → a trailing-slash cwd produced a wrong `-…-proj-` slug, diverging from production); replaced with the canonical `cwd_to_project_slug`. A characterization test documents the normpath contract.
- Review round-2/3 removed an always-green "gap-proof" anti-pattern test (it asserted the *bad* behavior) and re-labeled the slug test honestly (no false "RED at base" on a pure call-site DRY swap).

### Note on the one remaining full-suite failure

`tests/test_active_session_detection.py::test_two_terminals_two_pids_resolve_independently` fails on this branch — but it is **already fixed on `main`** by #124 (`05d019b`, which wraps the `record_active_transcript` calls in the `_pid_alive→True` patch). This branch's base predates #124 and does **not** touch that file, so the failure **resolves on merge** (main's fixed version is preserved). No change made here to avoid a duplicate/conflicting fold.

Test-only; `git diff origin/main...HEAD -- src/` is empty.
