### PR TITLE
fix(reload_lock): lowercase _slug_for for cross-producer slug parity (L5 split-brain)

### DIFF
--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2232,7 +2232,7 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
     # The slug uses reload_lock._slug_for so it matches _reload_sentinel_path_for.
     from .reload_lock import _slug_for as _rl_slug_for
     if session_id:
-        sid12 = _rl_slug_for(session_id)[:12]
+        sid12 = _rl_slug_for(session_id)
         sentinel_path = f"/tmp/cozempic_reload_{sid12}.in-flight"
         status_path = f"/tmp/cozempic_reload_{sid12}.status"
         pgrep_pattern = f"claude.*{sid12}"

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2755,8 +2755,9 @@ def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
 # precondition). `cozempic reload` clears the sentinel (user took control).
 # Shared by guard (write) and cli `nudge` (read/warn).
 def _reload_armed_path(session_id: str | None, session_path: Path | None = None) -> Path:
-    raw = (session_id or (session_path.stem if session_path else None) or "session")
-    slug = re.sub(r"[^a-z0-9_-]", "_", str(raw).lower())[:12] or "session"
+    from .reload_lock import _slug_for as _rl_slug_for  # lazy — matches guard.py:2233 pattern
+    raw = session_id or (session_path.stem if session_path else None) or None
+    slug = _rl_slug_for(raw) if raw else "default"
     return _guard_tmp_root() / f"cozempic_reload_armed_{slug}.json"
 
 
@@ -2837,8 +2838,9 @@ def clear_armed(session_id, session_path: Path | None = None) -> None:
 
 
 def _reload_ledger_path(session_id: str | None, session_path: Path) -> Path:
-    raw = (session_id or session_path.stem or "session")
-    slug = re.sub(r"[^a-z0-9_-]", "_", raw.lower())[:12] or "session"
+    from .reload_lock import _slug_for as _rl_slug_for  # lazy — matches guard.py:2233 pattern
+    raw = session_id or session_path.stem or None
+    slug = _rl_slug_for(raw) if raw else "default"
     return _guard_tmp_root() / f"cozempic_reload_{slug}.history"
 
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2757,7 +2757,9 @@ def safe_to_reload(team_state, messages, session_path) -> tuple[bool, str]:
 def _reload_armed_path(session_id: str | None, session_path: Path | None = None) -> Path:
     from .reload_lock import _slug_for as _rl_slug_for  # lazy — matches guard.py:2233 pattern
     raw = session_id or (session_path.stem if session_path else None) or None
-    slug = _rl_slug_for(raw) if raw else "default"
+    # str() restores the coercion the old inline formula provided via str(raw);
+    # callers are typed str|None but we keep defensive parity for non-str inputs.
+    slug = _rl_slug_for(str(raw)) if raw is not None else "default"
     return _guard_tmp_root() / f"cozempic_reload_armed_{slug}.json"
 
 
@@ -2840,7 +2842,9 @@ def clear_armed(session_id, session_path: Path | None = None) -> None:
 def _reload_ledger_path(session_id: str | None, session_path: Path) -> Path:
     from .reload_lock import _slug_for as _rl_slug_for  # lazy — matches guard.py:2233 pattern
     raw = session_id or session_path.stem or None
-    slug = _rl_slug_for(raw) if raw else "default"
+    # str() restores the coercion the old inline formula provided via str(raw);
+    # callers are typed str|None but we keep defensive parity for non-str inputs.
+    slug = _rl_slug_for(str(raw)) if raw is not None else "default"
     return _guard_tmp_root() / f"cozempic_reload_{slug}.history"
 
 

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -104,16 +104,24 @@ def _lock_path_for(session_id: str) -> Path:
 
 
 def _is_process_alive(pid: int) -> bool:
-    """Returns True if `pid` is a live process owned by us."""
+    """Return True if ``pid`` is a live process (or owned by another user).
+
+    ``kill(pid, 0)`` returns 0 if the signal could be delivered, raises
+    ``ProcessLookupError`` if no such process exists, and
+    ``PermissionError`` if the process exists but we lack permission.
+    Conservative interpretation: PermissionError → alive (not ours, but
+    real), since a reload lock held by another user's process must not be
+    stolen. Matches spawn_lock._is_process_alive semantics exactly.
+    """
+    if pid <= 0:
+        return False
     try:
         os.kill(pid, 0)
         return True
-    except (ProcessLookupError, PermissionError):
-        # ProcessLookupError = no such process
-        # PermissionError = process exists but owned by another user (don't
-        # touch — but treat as "not ours", which means lock is owned by a
-        # different user's process and we shouldn't disturb it)
+    except ProcessLookupError:
         return False
+    except PermissionError:
+        return True  # cross-user process is alive; don't steal its lock
     except OSError:
         return False
 

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -364,10 +364,9 @@ def _reload_sentinel_path_for(session_id: str) -> Path:
     Validates that the slug contains no path separators to prevent traversal.
     """
     slug = _slug_for(session_id)
-    # The slug comes from _slug_for which already returns ≤12 chars (truncated
-    # internally). A second [:12] here would be a no-op today but would diverge
-    # from _lock_path_for (line 102) if _slug_for is ever widened.
-    # [^a-z0-9_-] with _, so it cannot contain path separators. Belt-and-suspenders check:
+    # _slug_for already returns ≤12 chars. A second [:12] would be a no-op today
+    # but would diverge from _lock_path_for (line 102) if _slug_for is ever widened.
+    # Belt-and-suspenders: confirm no path separators survived sanitization.
     if "/" in slug or "\\" in slug:
         raise ValueError(
             f"sentinel slug contains path separator (session_id type "

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -355,8 +355,10 @@ def _reload_sentinel_path_for(session_id: str) -> Path:
 
     Validates that the slug contains no path separators to prevent traversal.
     """
-    slug = _slug_for(session_id)[:12]
-    # The slug comes from _slug_for which lowercases then substitutes
+    slug = _slug_for(session_id)
+    # The slug comes from _slug_for which already returns ≤12 chars (truncated
+    # internally). A second [:12] here would be a no-op today but would diverge
+    # from _lock_path_for (line 102) if _slug_for is ever widened.
     # [^a-z0-9_-] with _, so it cannot contain path separators. Belt-and-suspenders check:
     if "/" in slug or "\\" in slug:
         raise ValueError(

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -68,22 +68,32 @@ INIT_RELOAD_SENTINEL = "reload-sentinel"
 # UUIDs are hex+dashes (32 chars + 4 dashes), but session_id can be passed
 # as a path (e.g. from $TRANSCRIPT) which we normalize. Strip to first 12
 # chars for the lock filename so paths and UUIDs both produce a short slug.
-_SAFE_CHARS_RE = re.compile(r"[^a-zA-Z0-9_-]")
+# Lowercase-only char class: we .lower() before substitution (XF-1 fix) so
+# uppercase letters survive as their lowercase equivalent rather than as '_'.
+_SAFE_CHARS_RE = re.compile(r"[^a-z0-9_-]")
 
 
 def _slug_for(session_id: str) -> str:
     """Reduce session_id to a 12-char safe slug for the lock filename.
 
-    Mirrors the pid-file naming convention in guard.py — same session
-    always produces the same slug, so the lock and pid file co-locate.
+    Mirrors ``spawn_lock._slug_for`` and ``guard._reload_armed_path`` —
+    same session_id always produces the same slug across all three producers,
+    so the lock, pid file, and reload-sentinel co-locate correctly.
+
+    Lowercases BEFORE substitution (XF-1 fix): uppercase inputs such as a
+    UUID received before normalization produce the same slug as their
+    lowercase equivalents, preventing split-brain where the lock lives at
+    a different path than the pid/sentinel files.
     """
     if not session_id:
         return "default"
     # If it looks like a path, take the basename and drop suffix
     if "/" in session_id or "\\" in session_id or session_id.endswith(".jsonl"):
         session_id = Path(session_id).stem
-    # Sanitize and truncate
-    sanitized = _SAFE_CHARS_RE.sub("_", session_id)
+    # Lowercase BEFORE substitution so uppercase letters survive as their
+    # lowercase equivalents (a real character), not as the underscore
+    # placeholder. Matches spawn_lock._slug_for and guard._reload_armed_path.
+    sanitized = _SAFE_CHARS_RE.sub("_", session_id.lower())
     return sanitized[:12] or "default"
 
 

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -356,8 +356,8 @@ def _reload_sentinel_path_for(session_id: str) -> Path:
     Validates that the slug contains no path separators to prevent traversal.
     """
     slug = _slug_for(session_id)[:12]
-    # The slug comes from _slug_for which substitutes [^a-zA-Z0-9_-] with _,
-    # so it cannot contain path separators. Belt-and-suspenders check:
+    # The slug comes from _slug_for which lowercases then substitutes
+    # [^a-z0-9_-] with _, so it cannot contain path separators. Belt-and-suspenders check:
     if "/" in slug or "\\" in slug:
         raise ValueError(
             f"sentinel slug contains path separator (session_id type "

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -200,9 +200,9 @@ _SAFE_CHARS_RE = re.compile(r"[^a-z0-9_-]")
 def _slug_for(session_id: str) -> str:
     """Reduce session_id to a 12-char safe slug for the PID file path.
 
-    Mirrors ``reload_lock._slug_for`` (relaxed char class) AND
-    ``guard._pid_file_for_session`` (lowercases first, then keeps only
-    ``[a-z0-9_-]``). Same session_id → same slug across all three.
+    Mirrors ``reload_lock._slug_for`` and ``guard._reload_armed_path`` —
+    all three lowercase BEFORE substitution so the same session_id always
+    maps to the same slug regardless of case (XF-1 parity fix).
     """
     if not session_id:
         return "default"

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -188,12 +188,9 @@ def _parse_pidfile_pid(pid_path: Path) -> int:
     return pid if pid > 0 else 0
 
 
-# Round-3 C2 (Option B) alignment: char class kept relaxed (mirrors
-# reload_lock._SAFE_CHARS_RE) but inputs are now lowercased before
-# substitution to align with guard._pid_file_for_session which
-# lowercases before applying its (also relaxed) _SESSION_ID_RE. Without
-# the lowercase, a mixed-case session_id would produce one slug here
-# and a different (lowercased) slug in guard.py.
+# XF-1 parity: lowercase-only char class, matching reload_lock._SAFE_CHARS_RE.
+# Lowercasing BEFORE substitution ensures uppercase session_id inputs map to
+# the same slug as their lowercase equivalents (XF-1 split-brain fix).
 _SAFE_CHARS_RE = re.compile(r"[^a-z0-9_-]")
 
 

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -561,38 +561,43 @@ class TestRound2ReviewerFindings(unittest.TestCase):
     # ── M-1 — watcher slug must equal _reload_sentinel_path_for slug ─────────
 
     def test_watcher_slug_matches_sentinel_path_under_widened_slug_for(self):
-        """M-1 (RED at HEAD): guard.py:2235 still applies [:12] to _slug_for().
+        """M-1 (RED at bc7ba80 / pre-fix): guard.py:2235 still applies [:12]
+        to _slug_for(), while _reload_sentinel_path_for (after P0-C) does not.
 
-        When _slug_for is mocked to return a 15-char slug, the watcher path
-        expression (_slug_for(sid)[:12]) truncates to 12 chars while
-        _reload_sentinel_path_for returns the full 15-char slug — divergence
-        that P0-C was filed to eliminate (same class, different site).
+        This test inspects the source of _spawn_reload_watcher to confirm that
+        the [:12] truncation has been removed.  It is RED at bc7ba80 (the commit
+        that introduced the RED-test suite) because guard.py still contained
+        _rl_slug_for(session_id)[:12] at that point, and GREEN after M-1 drops
+        the [:12].
 
-        We simulate this by calling the watcher expression (_rl_slug_for(sid)[:12])
-        and comparing it to _reload_sentinel_path_for's slug extraction.  At HEAD
-        the two diverge when _slug_for returns >12 chars; after the fix they agree.
+        Secondary behavioural check: mock _slug_for to return a 15-char slug and
+        verify that the sentinel path produced by _reload_sentinel_path_for is
+        NOT truncated (proving the parity contract holds with a widened _slug_for).
         """
+        import inspect
+        from cozempic import guard
         from cozempic.reload_lock import _reload_sentinel_path_for
 
-        session_id = "my-test-session-99"
-        wide_slug = "abcdefghijklmno"  # 15 chars — wider than current 12-char cap
+        # --- structural check ---
+        source = inspect.getsource(guard._spawn_reload_watcher)
+        self.assertNotIn(
+            "_rl_slug_for(session_id)[:12]",
+            source,
+            "guard._spawn_reload_watcher still applies [:12] to _rl_slug_for — "
+            "M-1 fold gap: drops identical double-truncation that P0-C removed "
+            "from _reload_sentinel_path_for."
+        )
 
-        with patch('cozempic.guard._rl_slug_for', return_value=wide_slug, create=True), \
-             patch('cozempic.reload_lock._slug_for', return_value=wide_slug):
-
-            # Sentinel reader (after P0-C): uses _slug_for directly — no [:12]
-            sentinel_slug = _reload_sentinel_path_for(session_id).name[
+        # --- behavioural parity under widened _slug_for ---
+        wide_slug = "abcdefghijklmno"  # 15 chars
+        with patch('cozempic.reload_lock._slug_for', return_value=wide_slug):
+            sentinel_slug = _reload_sentinel_path_for("my-test-session-99").name[
                 len("cozempic_reload_"):-len(".in-flight")
             ]
-            # Watcher writer (before M-1 fix): uses _rl_slug_for(sid)[:12]
-            from cozempic.guard import _rl_slug_for as _watcher_slug_fn  # noqa
-            watcher_slug = _watcher_slug_fn(session_id)[:12]
-
         self.assertEqual(
-            watcher_slug, sentinel_slug,
-            f"Watcher slug {watcher_slug!r} != sentinel slug {sentinel_slug!r}: "
-            "guard.py:2235 still truncates to 12 while _reload_sentinel_path_for "
-            "does not — split-brain risk if _slug_for is ever widened."
+            sentinel_slug, wide_slug,
+            f"_reload_sentinel_path_for slug {sentinel_slug!r} != {wide_slug!r}: "
+            "P0-C should have removed all [:12] truncation from the sentinel reader."
         )
 
     # ── M-2 — non-str session_id must not raise TypeError ────────────────────

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -311,6 +311,52 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         self.assertEqual(guard_slug, expected)
 
 
+class TestReloadLockProcessAlive(unittest.TestCase):
+    """T6 — _is_process_alive must return True on PermissionError.
+
+    A cross-user process that owns the reload lock raises PermissionError
+    on os.kill(pid, 0). The correct semantic is ALIVE (don't steal the lock),
+    matching spawn_lock._is_process_alive. At HEAD, reload_lock wrongly
+    returns False, allowing _acquire to unlink a live holder's lock.
+    """
+
+    def test_permissionerror_treats_as_alive(self):
+        """PermissionError on kill(pid,0) must return True (cross-user = alive)."""
+        from cozempic.reload_lock import _is_process_alive
+        with patch('cozempic.reload_lock.os.kill', side_effect=PermissionError):
+            result = _is_process_alive(1234)
+        self.assertTrue(result,
+            "_is_process_alive must return True for PermissionError — "
+            "cross-user process is alive and we must not steal its lock")
+
+    def test_processlookuperror_treats_as_dead(self):
+        """ProcessLookupError on kill(pid,0) must still return False (no such process)."""
+        from cozempic.reload_lock import _is_process_alive
+        with patch('cozempic.reload_lock.os.kill', side_effect=ProcessLookupError):
+            result = _is_process_alive(1234)
+        self.assertFalse(result,
+            "_is_process_alive must return False for ProcessLookupError")
+
+    def test_pid_zero_or_negative_returns_false(self):
+        """pid <= 0 is invalid — must return False without calling os.kill."""
+        from cozempic.reload_lock import _is_process_alive
+        self.assertFalse(_is_process_alive(0))
+        self.assertFalse(_is_process_alive(-1))
+        self.assertFalse(_is_process_alive(-999))
+
+    def test_parity_with_spawn_lock(self):
+        """reload_lock and spawn_lock must agree on PermissionError semantics."""
+        from cozempic.reload_lock import _is_process_alive as rl_alive
+        from cozempic.spawn_lock import _is_process_alive as sl_alive
+        with patch('cozempic.reload_lock.os.kill', side_effect=PermissionError), \
+             patch('cozempic.spawn_lock.os.kill', side_effect=PermissionError):
+            rl_result = rl_alive(1234)
+            sl_result = sl_alive(1234)
+        self.assertEqual(rl_result, sl_result,
+            f"reload_lock._is_process_alive({rl_result!r}) != "
+            f"spawn_lock._is_process_alive({sl_result!r}) on PermissionError")
+
+
 class TestReloadLockSymlinkDefense(unittest.TestCase):
     """Defense against symlink attacks via /tmp: if a malicious local user
     plants a symlink at our lock path, O_NOFOLLOW makes us fail rather

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -300,15 +300,169 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         """
         from cozempic.reload_lock import _slug_for as rl_slug
         from cozempic.spawn_lock import _slug_for as sl_slug
+        from cozempic.guard import _reload_armed_path
 
         uuid = "f641174c-d784-4aab-8f29-3a1c2b456def"
         expected = "f641174c-d78"  # first 12 chars, all lowercase already
 
-        guard_slug = re.sub(r"[^a-z0-9_-]", "_", uuid.lower())[:12]
+        # Call the REAL guard function — not an inlined copy of its formula.
+        _PREFIX = "cozempic_reload_armed_"
+        _SUFFIX = ".json"
+        armed_path = _reload_armed_path(uuid)
+        guard_slug = armed_path.name[len(_PREFIX):-len(_SUFFIX)]
 
         self.assertEqual(rl_slug(uuid), expected)
         self.assertEqual(sl_slug(uuid), expected)
         self.assertEqual(guard_slug, expected)
+
+    # ── UUID invariance — production session_ids must be unaffected ───────────
+
+    def test_uuid_session_id_armed_path_invariant(self):
+        """Regression guard: _reload_armed_path filename is UNCHANGED for a UUID session_id.
+
+        UUIDs have no dots and no path separators, so Path(uuid).stem == uuid.
+        _slug_for(uuid) must produce the same result as the pre-fix inline formula
+        for any standard lowercase UUID, ensuring live armed-sentinels are not
+        orphaned on upgrade.
+        """
+        from cozempic.guard import _reload_armed_path
+        import re as _re
+
+        uuid = "f641174c-d784-4aab-8f29-3a1c2b456def"
+        # Pre-fix formula (the inline that was in guard before P0-A)
+        pre_fix_slug = _re.sub(r"[^a-z0-9_-]", "_", str(uuid).lower())[:12] or "session"
+
+        armed_path = _reload_armed_path(uuid)
+        _PREFIX = "cozempic_reload_armed_"
+        _SUFFIX = ".json"
+        post_fix_slug = armed_path.name[len(_PREFIX):-len(_SUFFIX)]
+
+        self.assertEqual(post_fix_slug, pre_fix_slug,
+            f"UUID session_id armed-path slug changed after fix: "
+            f"{pre_fix_slug!r} → {post_fix_slug!r}. "
+            "Live armed-sentinels would be orphaned on upgrade.")
+
+    # ── T1 — path-form session_id: _reload_armed_path must match _slug_for ───
+
+    def test_reload_armed_path_path_input_matches_slug_for(self):
+        """T1 (RED at HEAD): _reload_armed_path must use reload_lock._slug_for for path inputs.
+
+        At HEAD, _reload_armed_path inlines re.sub on the raw path string, producing
+        '_users_foo_m' for '/Users/foo/MySession-ABC.jsonl'. _slug_for extracts the
+        stem first, producing 'mysession-ab'. This is the split-brain XF-1 for path
+        inputs: the reload-lock and the armed sentinel live under different slugs.
+        """
+        from cozempic.guard import _reload_armed_path
+        from cozempic.reload_lock import _slug_for as rl_slug
+
+        path_input = '/Users/foo/MySession-ABC.jsonl'
+        armed_path = _reload_armed_path(path_input)
+        _PREFIX = "cozempic_reload_armed_"
+        _SUFFIX = ".json"
+        armed_slug = armed_path.name[len(_PREFIX):-len(_SUFFIX)]
+
+        self.assertEqual(armed_slug, rl_slug(path_input),
+            f"_reload_armed_path slug {armed_slug!r} != _slug_for slug "
+            f"{rl_slug(path_input)!r} for path input {path_input!r}")
+
+    # ── T2 — path-form session_id: _reload_ledger_path must match _slug_for ──
+
+    def test_reload_ledger_path_path_input_matches_slug_for(self):
+        """T2 (RED at HEAD): _reload_ledger_path must use reload_lock._slug_for for path inputs.
+
+        Same divergence as T1 but on the ledger path producer.
+        """
+        from cozempic.guard import _reload_ledger_path
+        from cozempic.reload_lock import _slug_for as rl_slug
+
+        path_input = '/Users/foo/MySession-ABC.jsonl'
+        ledger_path = _reload_ledger_path(path_input, Path('/dummy'))
+        _PREFIX = "cozempic_reload_"
+        _SUFFIX = ".history"
+        ledger_slug = ledger_path.name[len(_PREFIX):-len(_SUFFIX)]
+
+        self.assertEqual(ledger_slug, rl_slug(path_input),
+            f"_reload_ledger_path slug {ledger_slug!r} != _slug_for slug "
+            f"{rl_slug(path_input)!r} for path input {path_input!r}")
+
+    # ── T3 — empty/None session: fallback must be 'default', not 'session' ───
+
+    def test_reload_armed_path_empty_session_uses_default_slug(self):
+        """T3 (RED at HEAD): _reload_armed_path(None, None) must produce slug 'default'.
+
+        At HEAD, the fallback is 'session' (inline formula's or "session").
+        _slug_for("") returns "default". The mismatch means the armed sentinel
+        and the reload sentinel target different conceptual session slots when
+        both have None/empty session_id.
+        """
+        from cozempic.guard import _reload_armed_path
+
+        armed_path = _reload_armed_path(None, None)
+        self.assertIn("default", armed_path.name,
+            f"Expected 'default' in armed path for None session, "
+            f"got: {armed_path.name!r}")
+        self.assertNotIn("session", armed_path.name,
+            f"Expected 'session' fallback to be replaced by 'default', "
+            f"got: {armed_path.name!r}")
+
+    # ── T8 — armed + ledger slugs must agree with each other for path input ──
+
+    def test_reload_armed_ledger_parity(self):
+        """T8 (RED at HEAD): armed and ledger slugs must agree for path-form session_id.
+
+        Both functions inline the same (broken) formula — both produce '_users_foo_m'
+        for the path input, while _slug_for produces 'mysession-ab'. After P0-A both
+        call _slug_for, so they agree with each other AND with the lock.
+        """
+        from cozempic.guard import _reload_armed_path, _reload_ledger_path
+        from cozempic.reload_lock import _slug_for as rl_slug
+
+        path_input = '/Users/foo/MySession-ABC.jsonl'
+        armed_path = _reload_armed_path(path_input)
+        ledger_path = _reload_ledger_path(path_input, Path('/dummy'))
+
+        armed_slug = armed_path.name[len("cozempic_reload_armed_"):-len(".json")]
+        ledger_slug = ledger_path.name[len("cozempic_reload_"):-len(".history")]
+        expected_slug = rl_slug(path_input)
+
+        self.assertEqual(armed_slug, expected_slug,
+            f"armed slug {armed_slug!r} != rl_slug {expected_slug!r}")
+        self.assertEqual(ledger_slug, expected_slug,
+            f"ledger slug {ledger_slug!r} != rl_slug {expected_slug!r}")
+        self.assertEqual(armed_slug, ledger_slug,
+            f"armed slug {armed_slug!r} != ledger slug {ledger_slug!r}")
+
+    # ── Regression guard: path-branch uppercase _slug_for ────────────────────
+
+    def test_slug_for_path_branch_uppercase_stem(self):
+        """Regression guard: _slug_for with an uppercase-stem path must lowercase
+        AFTER stem extraction.
+
+        A refactor that moves .lower() to BEFORE Path().stem would leave the
+        uppercase stem un-lowercased, producing 'ABCDEF123456' instead of
+        'abcdef123456' — the XF-1 regression for path inputs. This test is
+        GREEN at HEAD (the code is correct) and guards against future ordering
+        regressions.
+        """
+        from cozempic.reload_lock import _slug_for
+        slug = _slug_for('/Users/foo/ABCDEF123456.jsonl')
+        self.assertEqual(slug, 'abcdef123456')
+        self.assertEqual(slug, slug.lower(), "Slug must be fully lowercase")
+
+    # ── T: parity test for _reload_ledger_path ───────────────────────────────
+
+    def test_slug_parity_ledger_path_matches_reload_lock(self):
+        """_reload_ledger_path must use the same slug as reload_lock._slug_for."""
+        from cozempic.guard import _reload_ledger_path
+        from cozempic.reload_lock import _slug_for as rl_slug
+
+        raw = "ABCD1234EFGH-XX"
+        ledger_path = _reload_ledger_path(raw, Path("/tmp/ignored.jsonl"))
+        _PREFIX = "cozempic_reload_"
+        _SUFFIX = ".history"
+        ledger_slug = ledger_path.name[len(_PREFIX):-len(_SUFFIX)]
+        self.assertEqual(ledger_slug, rl_slug(raw),
+            f"ledger slug {ledger_slug!r} != rl_slug {rl_slug(raw)!r} for {raw!r}")
 
 
 class TestReloadLockProcessAlive(unittest.TestCase):

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -9,6 +9,7 @@ This is the primary cascade fix from the production incident.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import tempfile
 import threading
@@ -265,7 +266,6 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         (uppercase kept), while spawn_lock._slug_for produces "abcd1234efgh"
         and guard._reload_armed_path produces "abcd1234efgh" → assertEqual FAILS.
         """
-        import re
         from cozempic.reload_lock import _slug_for as rl_slug
         from cozempic.spawn_lock import _slug_for as sl_slug
 
@@ -298,7 +298,6 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         and dashes) is already lowercase, so .lower() is a no-op. The slug must
         equal the first 12 chars of the UUID across all three producers.
         """
-        import re
         from cozempic.reload_lock import _slug_for as rl_slug
         from cozempic.spawn_lock import _slug_for as sl_slug
 

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -553,6 +553,82 @@ class TestReloadLockSymlinkDefense(unittest.TestCase):
                 lock_path.unlink(missing_ok=True)
 
 
+# ─── Round-2 reviewer findings (M-1 / M-2) ───────────────────────────────────
+
+class TestRound2ReviewerFindings(unittest.TestCase):
+    """RED tests for M-1 (guard.py:2235 double-truncation) and M-2 (str coercion)."""
+
+    # ── M-1 — watcher slug must equal _reload_sentinel_path_for slug ─────────
+
+    def test_watcher_slug_matches_sentinel_path_under_widened_slug_for(self):
+        """M-1 (RED at HEAD): guard.py:2235 still applies [:12] to _slug_for().
+
+        When _slug_for is mocked to return a 15-char slug, the watcher path
+        expression (_slug_for(sid)[:12]) truncates to 12 chars while
+        _reload_sentinel_path_for returns the full 15-char slug — divergence
+        that P0-C was filed to eliminate (same class, different site).
+
+        We simulate this by calling the watcher expression (_rl_slug_for(sid)[:12])
+        and comparing it to _reload_sentinel_path_for's slug extraction.  At HEAD
+        the two diverge when _slug_for returns >12 chars; after the fix they agree.
+        """
+        from cozempic.reload_lock import _reload_sentinel_path_for
+
+        session_id = "my-test-session-99"
+        wide_slug = "abcdefghijklmno"  # 15 chars — wider than current 12-char cap
+
+        with patch('cozempic.guard._rl_slug_for', return_value=wide_slug, create=True), \
+             patch('cozempic.reload_lock._slug_for', return_value=wide_slug):
+
+            # Sentinel reader (after P0-C): uses _slug_for directly — no [:12]
+            sentinel_slug = _reload_sentinel_path_for(session_id).name[
+                len("cozempic_reload_"):-len(".in-flight")
+            ]
+            # Watcher writer (before M-1 fix): uses _rl_slug_for(sid)[:12]
+            from cozempic.guard import _rl_slug_for as _watcher_slug_fn  # noqa
+            watcher_slug = _watcher_slug_fn(session_id)[:12]
+
+        self.assertEqual(
+            watcher_slug, sentinel_slug,
+            f"Watcher slug {watcher_slug!r} != sentinel slug {sentinel_slug!r}: "
+            "guard.py:2235 still truncates to 12 while _reload_sentinel_path_for "
+            "does not — split-brain risk if _slug_for is ever widened."
+        )
+
+    # ── M-2 — non-str session_id must not raise TypeError ────────────────────
+
+    def test_reload_armed_path_non_str_session_id_does_not_raise(self):
+        """M-2 (RED at HEAD): _reload_armed_path(123, None) raises TypeError.
+
+        The old inline formula used str(raw) before re.sub, safely converting
+        any truthy non-str.  P0-A switched to _slug_for(raw) which executes
+        '/' in session_id — TypeError for int/Path.  Restore coercion at call site.
+        """
+        from cozempic.guard import _reload_armed_path
+        try:
+            result = _reload_armed_path(123, None)
+        except TypeError as exc:
+            self.fail(
+                f"_reload_armed_path(123, None) raised TypeError: {exc!r}. "
+                "Non-str session_id should be coerced to str at the call site."
+            )
+        # Ensure we got a real path back
+        self.assertIn("cozempic_reload_armed_", result.name)
+
+    def test_reload_ledger_path_non_str_session_id_does_not_raise(self):
+        """M-2 parity: _reload_ledger_path(123, ...) must not raise TypeError."""
+        from cozempic.guard import _reload_ledger_path
+        from pathlib import Path
+        try:
+            result = _reload_ledger_path(123, Path("/tmp/dummy.jsonl"))
+        except TypeError as exc:
+            self.fail(
+                f"_reload_ledger_path(123, ...) raised TypeError: {exc!r}. "
+                "Non-str session_id should be coerced to str at the call site."
+            )
+        self.assertIn("cozempic_reload_", result.name)
+
+
 # ─── CLI integration: --wait flag exists ─────────────────────────────────────
 
 class TestReloadCliWaitFlag(unittest.TestCase):

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -268,12 +268,18 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         """
         from cozempic.reload_lock import _slug_for as rl_slug
         from cozempic.spawn_lock import _slug_for as sl_slug
+        from cozempic.guard import _reload_armed_path
 
         # Non-UUID uppercase input: 12+ chars, contains upper letters.
         raw = "ABCD1234EFGH-XX"
 
-        # guard._reload_armed_path inline formula (re.sub + .lower(), truncate 12)
-        guard_slug = re.sub(r"[^a-z0-9_-]", "_", raw.lower())[:12]
+        # Call the REAL guard function — not an inlined copy of its formula.
+        # If _reload_armed_path drifts (different regex, truncation, path-stripping),
+        # this test will catch it. An inline formula copy would not.
+        _PREFIX = "cozempic_reload_armed_"
+        _SUFFIX = ".json"
+        armed_path = _reload_armed_path(raw)
+        guard_slug = armed_path.name[len(_PREFIX):-len(_SUFFIX)]
 
         rl = rl_slug(raw)
         sl = sl_slug(raw)

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -252,6 +252,65 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         self.assertEqual(path.parent, Path(tempfile.gettempdir()))
         self.assertEqual(path.name, "cozempic_reload_abc123.lock")
 
+    def test_slug_parity_three_producers_agree_on_uppercase_input(self):
+        """All three slug producers must produce identical output for an uppercase input.
+
+        reload_lock._slug_for was missing .lower() (XF-1 / L5): for a session_id
+        with uppercase letters (e.g. a UUID received before normalization), it
+        produced a DIFFERENT slug than spawn_lock._slug_for and guard._reload_armed_path.
+        That split-brain causes the lock and the pid/sentinel files to live at
+        different paths — the concurrency guard is silently bypassed.
+
+        RED-at-base: reload_lock._slug_for("ABCD1234EFGH-XX") == "ABCD1234EFGH"
+        (uppercase kept), while spawn_lock._slug_for produces "abcd1234efgh"
+        and guard._reload_armed_path produces "abcd1234efgh" → assertEqual FAILS.
+        """
+        import re
+        from cozempic.reload_lock import _slug_for as rl_slug
+        from cozempic.spawn_lock import _slug_for as sl_slug
+
+        # Non-UUID uppercase input: 12+ chars, contains upper letters.
+        raw = "ABCD1234EFGH-XX"
+
+        # guard._reload_armed_path inline formula (re.sub + .lower(), truncate 12)
+        guard_slug = re.sub(r"[^a-z0-9_-]", "_", raw.lower())[:12]
+
+        rl = rl_slug(raw)
+        sl = sl_slug(raw)
+
+        self.assertEqual(
+            rl, sl,
+            f"reload_lock slug {rl!r} != spawn_lock slug {sl!r} for uppercase input {raw!r}. "
+            "reload_lock._slug_for is missing .lower() — XF-1 split-brain bug."
+        )
+        self.assertEqual(
+            rl, guard_slug,
+            f"reload_lock slug {rl!r} != guard slug {guard_slug!r} for uppercase input {raw!r}."
+        )
+        # Sanity: all three must be fully lowercase (no uppercase can survive)
+        self.assertEqual(rl, rl.lower(), f"Slug {rl!r} contains uppercase letters.")
+
+    def test_slug_parity_uuid_input_unchanged(self):
+        """Standard lowercase UUID inputs must produce identical slugs across all three
+        producers both before and after the XF-1 fix — no regression.
+
+        This is a zero-change verification: a well-formed UUID (all lowercase hex
+        and dashes) is already lowercase, so .lower() is a no-op. The slug must
+        equal the first 12 chars of the UUID across all three producers.
+        """
+        import re
+        from cozempic.reload_lock import _slug_for as rl_slug
+        from cozempic.spawn_lock import _slug_for as sl_slug
+
+        uuid = "f641174c-d784-4aab-8f29-3a1c2b456def"
+        expected = "f641174c-d78"  # first 12 chars, all lowercase already
+
+        guard_slug = re.sub(r"[^a-z0-9_-]", "_", uuid.lower())[:12]
+
+        self.assertEqual(rl_slug(uuid), expected)
+        self.assertEqual(sl_slug(uuid), expected)
+        self.assertEqual(guard_slug, expected)
+
 
 class TestReloadLockSymlinkDefense(unittest.TestCase):
     """Defense against symlink attacks via /tmp: if a malicious local user

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -332,11 +332,10 @@ class TestReloadLockSessionIdSanitization(unittest.TestCase):
         orphaned on upgrade.
         """
         from cozempic.guard import _reload_armed_path
-        import re as _re
 
         uuid = "f641174c-d784-4aab-8f29-3a1c2b456def"
         # Pre-fix formula (the inline that was in guard before P0-A)
-        pre_fix_slug = _re.sub(r"[^a-z0-9_-]", "_", str(uuid).lower())[:12] or "session"
+        pre_fix_slug = re.sub(r"[^a-z0-9_-]", "_", str(uuid).lower())[:12] or "session"
 
         armed_path = _reload_armed_path(uuid)
         _PREFIX = "cozempic_reload_armed_"


### PR DESCRIPTION
## Problem — slug split-brain

`reload_lock._slug_for` was the **only** slug producer that did not lowercase its input:

| producer | behaviour |
|---|---|
| `reload_lock._slug_for` | `_SAFE_CHARS_RE = [^a-zA-Z0-9_-]`, **no `.lower()`** |
| `spawn_lock._slug_for` | lowercases first |
| `guard._reload_armed_path` | lowercases first |
| SessionStart hook sanitiser | `re.sub(r'[^a-z0-9_-]', '_', s.lower())` |

For any uppercase-containing `session_id`, the producers emit **different** slugs → the reload lock lives at a different path than the pid / sentinel / armed files → the concurrency guard is silently bypassed. This violates the co-location invariant documented at `reload_lock.py:78` and `spawn_lock.py:205` (*"Same session_id → same slug across all three"*) — `spawn_lock`'s docstring asserted the very parity that was broken.

Practical trigger is nil today (session IDs are lowercase UUIDs), so this is **latent / defensive** — but it's a real cross-module desync plus a false docstring, and the slug functions also accept path-derived inputs which on case-preserving filesystems could carry uppercase.

## Fix

`reload_lock._slug_for` now lowercases before substitution (`session_id.lower()`), with its char class tightened to `[^a-z0-9_-]` (accurately reflecting what it matches post-lowercase — functionally identical, since uppercase is already gone). Docstrings corrected on both `reload_lock._slug_for` and `spawn_lock._slug_for`.

## Tests — `tests/test_reload_lock_wave2.py`

- `test_slug_parity_three_producers_agree_on_uppercase_input` — **RED-at-base** (`'ABCD1234EFGH' != 'abcd1234efgh'`) → GREEN (reload == spawn == guard slug).
- `test_slug_parity_uuid_input_unchanged` — passes at base **and** after the fix (zero regression for the lowercase-UUID inputs that actually occur).
- 17/17 reload_lock tests green.

## Scope

L5 cross-platform / slug co-location parity. `reload_lock.py` + `spawn_lock.py` (docstring) + tests. stdlib only.

---

## Follow-up — `/code-review max` hardening

An independent max-recall review of this branch surfaced a cluster of related latent gaps; all fixed here (one commit per pillar, each RED-at-HEAD where behavioral), then an adversarial review (min-10 findings, 3 gates: pre-existing-test / fold-invariant / zero-dep) returned **PASS WITH CONDITIONS** → its 2 MED conditions were folded in round-2:

- **P0-A** — `guard._reload_armed_path` + `_reload_ledger_path` now call the canonical `reload_lock._slug_for` instead of **inlining** the slug formula. The inline copies stemmed differently for path-form inputs and used a `"session"` (not `"default"`) empty-fallback — so the documented "same slug across all producers" invariant only held for UUID inputs. Calling `_slug_for` makes it hold universally (class-of-bug fold: both functions). **UUID slug-invariance preserved** — `Path(uuid).stem == uuid`, so live armed-sentinels are not orphaned on upgrade (regression test added).
- **P0-B** — `reload_lock._is_process_alive` now returns **True** on `PermissionError` (byte-parity with `spawn_lock._is_process_alive`): a live cross-user process must not be treated as dead and have its lock unlinked.
- **P0-C / M-1** — removed the redundant `[:12]` double-truncation at **both** sites that re-slice an already-≤12-char `_slug_for` result (`_reload_sentinel_path_for` and the bash-watcher writer in `_spawn_reload_watcher`) — they must byte-match or the daemon can't find the sentinel the watcher wrote if `_slug_for` is ever widened.
- **P0-D** — corrected a stale char-class comment in `spawn_lock`.
- **P0-E** — the parity tests now call the **real** `_reload_armed_path`/`_reload_ledger_path` rather than re-implementing the formula, so they can't stay green if the guard functions drift.
- **M-2** — restored the `str()` coercion the old inline formula provided, so a non-str `session_id` is handled defensively at the call site (callers are typed `str|None`; parity kept).

stdlib only; full suite green (pre-existing env-isolation flakes excluded).
