### PR TITLE
fix(guard): bound reload-ledger env knobs so the storm-guard can't be silently disabled (L1)

### DIFF
--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -267,8 +267,13 @@ def parse_env_bool(name: str, default: bool = False, warn: bool = True) -> bool:
     returns `default`.  Empty / absent / whitespace-only: returns `default`
     silently.
 
-    Follows the warn+fallback contract of parse_env_positive_int:
-    env vars are ambient config; an unrecognized value must not crash.
+    Follows the warn+fallback contract of parse_env_positive_int for
+    unrecognized non-empty values: emits a warning and returns `default`.
+    Deliberate divergence: whitespace-only input is treated as absent and
+    returns `default` silently (no warning), unlike parse_env_positive_int
+    which warns on whitespace-only.  Bool knobs have no numeric parse step
+    where whitespace ambiguity is meaningful, so the silent-absent treatment
+    is more appropriate.
 
     The `warn` parameter suppresses the warning when set to False — useful
     for in-body re-reads that run on every call (e.g. _debug()) where a

--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -188,10 +188,10 @@ def parse_env_positive_int(name: str, *, maximum: int | None = None) -> int | No
     ``pct = total / window`` rounds toward 0 when window is huge).
     """
     raw = os.environ.get(name)
-    if raw is None or raw == "":
+    if raw is None or raw.strip() == "":
         return None
     try:
-        value = int(raw)
+        value = int(raw.strip())
     except ValueError:
         _env_warn(name, raw, "must be an integer")
         return None
@@ -217,10 +217,10 @@ def parse_env_non_negative_int(name: str, *, maximum: int | None = None) -> int 
     context window would zero out usable context — cap at the default window.
     """
     raw = os.environ.get(name)
-    if raw is None or raw == "":
+    if raw is None or raw.strip() == "":
         return None
     try:
-        value = int(raw)
+        value = int(raw.strip())
     except ValueError:
         _env_warn(name, raw, "must be an integer")
         return None

--- a/src/cozempic/_validation.py
+++ b/src/cozempic/_validation.py
@@ -188,10 +188,20 @@ def parse_env_positive_int(name: str, *, maximum: int | None = None) -> int | No
     ``pct = total / window`` rounds toward 0 when window is huge).
     """
     raw = os.environ.get(name)
-    if raw is None or raw.strip() == "":
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if stripped == "":
+        # Whitespace-only (raw non-empty) is set but carries no integer — warn
+        # so the user knows their override was ignored.  Genuine empty string
+        # (export VAR=) is unset-equivalent; silently ignore it.
+        # (Regression fix: ae85bcc dropped whitespace-only silently; origin/main
+        # let int(raw) raise ValueError → same "must be an integer" warn path.)
+        if raw:  # whitespace-only; raw=="" is the silent empty-string case
+            _env_warn(name, raw, "must be an integer")
         return None
     try:
-        value = int(raw.strip())
+        value = int(stripped)
     except ValueError:
         _env_warn(name, raw, "must be an integer")
         return None
@@ -217,10 +227,15 @@ def parse_env_non_negative_int(name: str, *, maximum: int | None = None) -> int 
     context window would zero out usable context — cap at the default window.
     """
     raw = os.environ.get(name)
-    if raw is None or raw.strip() == "":
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if stripped == "":
+        if raw:  # whitespace-only; raw=="" is the silent empty-string case
+            _env_warn(name, raw, "must be an integer")
         return None
     try:
-        value = int(raw.strip())
+        value = int(stripped)
     except ValueError:
         _env_warn(name, raw, "must be an integer")
         return None

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2369,7 +2369,11 @@ def _guard_tmp_root() -> Path:
 # respawn: if a session reloads too many times within a window, the guard stops
 # auto-reloading it (and accounts it to the breaker so the daemon exits) rather
 # than churning kill→resume→re-bloat forever. Window/cap are env-overridable.
-_RELOAD_LEDGER_HIST_CAP = 50  # write-cap for hist slice AND ceiling for RELOAD_MAX
+# INVARIANT: RELOAD_MAX ceiling MUST equal the hist write-cap.
+# A ceiling ABOVE the write-cap silently disables the storm-guard for the
+# (write-cap, ceiling] range: hist[-cap:] bounds len(hist) to write-cap, so
+# len(hist) >= max is always False for any max > write-cap. Tune both together.
+_RELOAD_LEDGER_HIST_CAP = 50
 
 
 def _reload_ledger_window_s() -> int:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2367,17 +2367,15 @@ def _guard_tmp_root() -> Path:
 # auto-reloading it (and accounts it to the breaker so the daemon exits) rather
 # than churning kill→resume→re-bloat forever. Window/cap are env-overridable.
 def _reload_ledger_window_s() -> int:
-    try:
-        return max(60, int(os.environ.get("COZEMPIC_RELOAD_WINDOW_S", "600")))
-    except Exception:
-        return 600
+    from ._validation import parse_env_positive_int
+    v = parse_env_positive_int("COZEMPIC_RELOAD_WINDOW_S", maximum=86400)
+    return max(60, v) if v is not None else 600
 
 
 def _reload_ledger_max() -> int:
-    try:
-        return max(1, int(os.environ.get("COZEMPIC_RELOAD_MAX", "3")))
-    except Exception:
-        return 3
+    from ._validation import parse_env_positive_int
+    v = parse_env_positive_int("COZEMPIC_RELOAD_MAX", maximum=100)
+    return max(1, v) if v is not None else 3
 
 
 # ── In-flight work detector (1.8.22 safe-point gate, component A) ─────────────

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2369,6 +2369,9 @@ def _guard_tmp_root() -> Path:
 # respawn: if a session reloads too many times within a window, the guard stops
 # auto-reloading it (and accounts it to the breaker so the daemon exits) rather
 # than churning kill→resume→re-bloat forever. Window/cap are env-overridable.
+_RELOAD_LEDGER_HIST_CAP = 50  # write-cap for hist slice AND ceiling for RELOAD_MAX
+
+
 def _reload_ledger_window_s() -> int:
     from ._validation import parse_env_positive_int
     v = parse_env_positive_int("COZEMPIC_RELOAD_WINDOW_S", maximum=86400)
@@ -2377,8 +2380,12 @@ def _reload_ledger_window_s() -> int:
 
 def _reload_ledger_max() -> int:
     from ._validation import parse_env_positive_int
-    v = parse_env_positive_int("COZEMPIC_RELOAD_MAX", maximum=100)
-    return max(1, v) if v is not None else 3
+    # Ceiling = _RELOAD_LEDGER_HIST_CAP: values above the write-cap make
+    # len(hist) >= max always False (hist[-cap:] bounds the list on write),
+    # silently disabling the storm-guard for the entire [cap+1, old-100] range.
+    # max(1, v) removed: parse_env_positive_int guarantees v >= 1 when non-None.
+    v = parse_env_positive_int("COZEMPIC_RELOAD_MAX", maximum=_RELOAD_LEDGER_HIST_CAP)
+    return v if v is not None else 3
 
 
 # ── In-flight work detector (1.8.22 safe-point gate, component A) ─────────────
@@ -2868,7 +2875,7 @@ def _reload_rate_exceeded(ledger_path: Path, now: float | None = None) -> tuple[
         return True, len(hist)
     hist.append(now)
     try:
-        ledger_path.write_text(_json.dumps(hist[-50:]))
+        ledger_path.write_text(_json.dumps(hist[-_RELOAD_LEDGER_HIST_CAP:]))
     except Exception:
         pass
     return False, len(hist)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1317,11 +1317,14 @@ def _reload_warn_grace() -> float:
     wait (reload as soon as idle)."""
     try:
         v = float(os.environ.get("COZEMPIC_RELOAD_WARN_GRACE", "120"))
-        # Reject NaN/inf: a non-finite grace makes `elapsed >= grace` always False,
-        # which permanently DISABLES this fallback (the exact gate-disable bug class
-        # as the CLI/config thresholds — IEEE-754: every NaN/inf comparison fails),
-        # silently wedging the interactive idle reload. Mirror _read_min_prune_ratio.
-        return v if math.isfinite(v) else 120.0
+        # Reject NaN/inf OR huge-finite (> 3600, 1h): both classes make
+        # `elapsed >= grace` permanently False, silently disabling the fallback.
+        # 1h is the meaningful ceiling for an interactive session grace period —
+        # same large-finite gate-disable class as COZEMPIC_RELOAD_WINDOW_S.
+        # (<=0 "disable" semantic is preserved — falls through to `return v`.)
+        if not math.isfinite(v) or v > 3600:
+            return 120.0
+        return v
     except (TypeError, ValueError):
         return 120.0
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2875,7 +2875,19 @@ def _reload_rate_exceeded(ledger_path: Path, now: float | None = None) -> tuple[
         return True, len(hist)
     hist.append(now)
     try:
-        ledger_path.write_text(_json.dumps(hist[-_RELOAD_LEDGER_HIST_CAP:]))
+        # Atomic write (tmp + os.replace): a SIGKILL mid-write leaves a stale
+        # .tmp rather than a partial ledger, preventing the `except Exception:
+        # hist = []` silent reset that would clear the storm-guard count.
+        # Mirrors _write_armed_atomic (guard.py:2780) — same pattern, string payload.
+        _tmp = ledger_path.with_suffix(ledger_path.suffix + f".tmp{os.getpid()}")
+        try:
+            _tmp.write_text(_json.dumps(hist[-_RELOAD_LEDGER_HIST_CAP:]))
+            os.replace(_tmp, ledger_path)
+        finally:
+            try:
+                _tmp.unlink(missing_ok=True)  # no-op after a successful replace
+            except Exception:
+                pass
     except Exception:
         pass
     return False, len(hist)

--- a/tests/test_input_coercion_corpus.py
+++ b/tests/test_input_coercion_corpus.py
@@ -102,13 +102,16 @@ def _assert_finite_inrange(tc, r):
 # (validator, ENV var) — these return a default on bad input (never raise), so the
 # RETURN value must always be sane.
 _ENV_VALIDATORS = [
-    (g._reload_warn_grace, "COZEMPIC_RELOAD_WARN_GRACE"),
-    (g._force_reload_pct, "COZEMPIC_FORCE_RELOAD_PCT"),
-    (g._idle_reload_cycles, "COZEMPIC_IDLE_RELOAD_CYCLES"),
-    (g._idle_backoff_cycles, "COZEMPIC_IDLE_BACKOFF_CYCLES"),
-    (g._read_min_prune_ratio, "COZEMPIC_MIN_PRUNE_RATIO"),
+    (g._reload_warn_grace,        "COZEMPIC_RELOAD_WARN_GRACE"),
+    (g._force_reload_pct,         "COZEMPIC_FORCE_RELOAD_PCT"),
+    (g._idle_reload_cycles,       "COZEMPIC_IDLE_RELOAD_CYCLES"),
+    (g._idle_backoff_cycles,      "COZEMPIC_IDLE_BACKOFF_CYCLES"),
+    (g._read_min_prune_ratio,     "COZEMPIC_MIN_PRUNE_RATIO"),
     (g._read_hard_exit_threshold, "COZEMPIC_GUARD_HARD_EXIT_K"),
-    (t.get_chars_per_token, "COZEMPIC_CHARS_PER_TOKEN"),
+    (t.get_chars_per_token,       "COZEMPIC_CHARS_PER_TOKEN"),
+    # ── PR #137 additions — maintenance contract: one row per new knob ────────
+    (g._reload_ledger_window_s,   "COZEMPIC_RELOAD_WINDOW_S"),
+    (g._reload_ledger_max,        "COZEMPIC_RELOAD_MAX"),
 ]
 
 

--- a/tests/test_reload_ledger_env_bounds.py
+++ b/tests/test_reload_ledger_env_bounds.py
@@ -311,18 +311,60 @@ class TestReloadWarnGraceBounds(unittest.TestCase):
 
 
 class TestReloadLedgerAtomicWrite(unittest.TestCase):
-    """Invariant tests for the atomic ledger write in _reload_rate_exceeded.
+    """Regression tests for the atomic ledger write in _reload_rate_exceeded.
 
-    The SIGKILL-mid-write failure mode cannot be tested deterministically in
-    a unit test.  These tests verify the two observable post-write properties:
-      1. No .tmp orphan is left after a clean write path.
-      2. The ledger contains valid JSON after one or more calls.
+    Three properties are guarded:
 
-    RED proof is by code inspection: the pre-fix `ledger_path.write_text(…)`
-    is non-atomic; the post-fix tmp+os.replace+finally-cleanup pattern matches
-    _write_armed_atomic (guard.py:2780), which is the sister-module pattern for
-    this class of write.
+      1. Crash-safety: a failed os.replace (simulating SIGKILL-mid-rename)
+         leaves the OLD ledger byte-intact and cleans the .tmp orphan.
+         RED at base ae85bcc: the old bare `ledger_path.write_text(...)` never
+         calls os.replace, so the patch is inert, the write succeeds, and the
+         pre-existing ledger is overwritten → assertion fails.  GREEN at HEAD:
+         the atomic tmp+os.replace+finally path sees the raised OSError, the
+         live file is untouched, and the finally block unlinks the .tmp.
+
+      2. No .tmp orphan is left after a clean (successful) write path.
+
+      3. The ledger contains valid JSON after one or more calls.
     """
+
+    def test_crash_safety_old_ledger_preserved_on_failed_replace(self):
+        """A simulated crash mid-rename must leave the pre-existing ledger intact.
+
+        RED at base ae85bcc: the non-atomic `ledger_path.write_text(...)` never
+        calls `os.replace`, so `patch('cozempic.guard.os.replace', side_effect=OSError)`
+        is inert — the write succeeds, overwriting the old ledger.
+        GREEN at HEAD: the atomic write calls `os.replace`; the patch raises OSError;
+        the live file is untouched; the `finally` block unlinks the .tmp orphan.
+        """
+        import json
+        import pathlib
+        import tempfile
+        import time
+
+        with tempfile.TemporaryDirectory() as d:
+            ledger = pathlib.Path(d) / "test_ledger.history"
+            old_content = json.dumps([100.0, 200.0])
+            ledger.write_text(old_content)
+
+            from cozempic.guard import _reload_rate_exceeded
+
+            with patch("cozempic.guard.os.replace", side_effect=OSError("simulated mid-rename crash")):
+                _reload_rate_exceeded(ledger, now=time.time())
+
+            # (a) old ledger must survive byte-intact
+            self.assertEqual(
+                ledger.read_text(),
+                old_content,
+                "Pre-existing ledger was overwritten — atomicity guarantee violated",
+            )
+            # (b) no .tmp orphan left in the directory
+            orphans = list(pathlib.Path(d).glob("*.tmp*"))
+            self.assertEqual(
+                orphans,
+                [],
+                f".tmp orphan not cleaned after failed replace: {orphans}",
+            )
 
     def test_no_tmp_orphan_on_clean_write(self):
         """A successful write must leave no .tmp* file in the ledger directory."""

--- a/tests/test_reload_ledger_env_bounds.py
+++ b/tests/test_reload_ledger_env_bounds.py
@@ -1,4 +1,4 @@
-"""Tests for reload-storm guard env-var upper clamps.
+"""Tests for reload-storm guard env-var upper bounds.
 
 The reload-rate ledger uses two env-overridable knobs:
 
@@ -11,10 +11,16 @@ the ledger window effectively infinite, so the storm guard NEVER fires.
 This silently disables the protection for the session's lifetime.
 
 RED-at-base proof strategy:
-  - Set env var to a value far above the expected ceiling.
+  - Set env var to a value above the ceiling.
   - Call the ledger accessor function.
-  - Assert the returned value is <= the ceiling.
+  - Assert the returned value equals the safe default (not a huge int).
   - These assertions FAIL at base (raw huge int passes through), PASS after fix.
+
+Rejection semantics (not clamp semantics):
+  Out-of-range values are REJECTED → the safe default is returned (not
+  clamped to the ceiling). This is the conservative choice for a
+  storm-guard knob: an absurd value falls to the strict default, not the
+  lenient ceiling.
 
 Regression guard:
   - Normal in-range values must not be altered by the fix.
@@ -29,7 +35,11 @@ from unittest.mock import patch
 
 
 class TestReloadLedgerWindowSEnvBounds(unittest.TestCase):
-    """_reload_ledger_window_s() must clamp to <= 86400 s (1 day)."""
+    """_reload_ledger_window_s() rejects out-of-range values → safe default 600.
+
+    Out-of-range env values are REJECTED → the safe default (not clamped to
+    the bound) — the conservative choice for a storm-guard knob.
+    """
 
     def _call(self, env_val=None):
         # Import inside test to get the live (post-patch) definition.
@@ -43,37 +53,37 @@ class TestReloadLedgerWindowSEnvBounds(unittest.TestCase):
                 os.environ.pop("COZEMPIC_RELOAD_WINDOW_S", None)
             return _reload_ledger_window_s()
 
-    # ── RED-at-base: huge value must not pass through ─────────────────────────
+    # ── RED-at-base: out-of-range values must be rejected to default ──────────
 
-    def test_huge_window_env_is_clamped(self):
+    def test_huge_window_env_rejected_falls_back_to_default(self):
         """A 23-digit env value silently disables the storm guard at base.
 
         RED at base: max(60, int('10000000000000000000000')) == 10^22
         (>> 86400 s / 1 day), so the ledger never expires and the guard
         never fires.
-        GREEN after fix: parse_env_positive_int with maximum=86400 warns
-        and returns None → fallback 600.
+        GREEN after fix: parse_env_positive_int with maximum=86400 rejects
+        the value, returns None → fallback default 600.
         """
         result = self._call("10000000000000000000000")
-        self.assertLessEqual(
+        self.assertEqual(
             result,
-            86400,
+            600,
             f"_reload_ledger_window_s returned {result} for a huge env value "
-            f"— storm guard is silently disabled",
+            f"— expected rejection to safe default 600",
         )
 
-    def test_value_above_ceiling_is_clamped(self):
-        """86401 is just one second above the documented 86400 ceiling.
+    def test_window_above_ceiling_rejected_to_default(self):
+        """86401 is just one second above the 86400 ceiling.
 
-        RED at base: max(60, 86401) == 86401 (passes through unclamped).
-        GREEN after fix: warns and returns fallback 600.
+        RED at base: max(60, 86401) == 86401 (passes through unchecked).
+        GREEN after fix: rejected → fallback default 600.
         """
         result = self._call("86401")
-        self.assertLessEqual(
+        self.assertEqual(
             result,
-            86400,
+            600,
             f"_reload_ledger_window_s returned {result} for env=86401 "
-            f"— must reject values above the 86400 ceiling",
+            f"— expected rejection to safe default 600",
         )
 
     # ── Regression guards (must pass at base AND after fix) ──────────────────
@@ -83,11 +93,11 @@ class TestReloadLedgerWindowSEnvBounds(unittest.TestCase):
         self.assertEqual(self._call(), 600)
 
     def test_valid_value_within_bounds(self):
-        """A value well within [60, 86400] is returned as-is (clamped to floor)."""
+        """A value well within [60, 86400] is returned as-is."""
         self.assertEqual(self._call("1800"), 1800)
 
     def test_floor_clamp_at_60(self):
-        """Values below the floor 60 are raised to 60."""
+        """Values below the floor 60 are raised to 60 (genuine clamp, not reject)."""
         result = self._call("30")
         self.assertGreaterEqual(result, 60)
 
@@ -102,7 +112,11 @@ class TestReloadLedgerWindowSEnvBounds(unittest.TestCase):
 
 
 class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
-    """_reload_ledger_max() must clamp to <= 100 reloads per window."""
+    """_reload_ledger_max() rejects out-of-range values → safe default 3.
+
+    Out-of-range env values are REJECTED → the safe default (not clamped to
+    the bound) — the conservative choice for a storm-guard knob.
+    """
 
     def _call(self, env_val=None):
         from cozempic.guard import _reload_ledger_max
@@ -115,35 +129,35 @@ class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
                 os.environ.pop("COZEMPIC_RELOAD_MAX", None)
             return _reload_ledger_max()
 
-    # ── RED-at-base: huge value must not pass through ─────────────────────────
+    # ── RED-at-base: out-of-range values must be rejected to default ──────────
 
-    def test_huge_max_env_is_clamped(self):
+    def test_huge_max_env_rejected_falls_back_to_default(self):
         """999999999 reloads allowed → storm guard never trips.
 
         RED at base: max(1, int('999999999')) == 999999999 (guard never fires).
-        GREEN after fix: parse_env_positive_int with maximum=100 warns and
-        returns None → fallback 3.
+        GREEN after fix: parse_env_positive_int with maximum=100 rejects
+        the value, returns None → fallback default 3.
         """
         result = self._call("999999999")
-        self.assertLessEqual(
+        self.assertEqual(
             result,
-            100,
+            3,
             f"_reload_ledger_max returned {result} for a huge env value "
-            f"— storm guard is silently disabled",
+            f"— expected rejection to safe default 3",
         )
 
-    def test_value_above_ceiling_is_clamped(self):
-        """101 is just one above the documented 100 ceiling.
+    def test_max_above_ceiling_rejected_to_default(self):
+        """101 is just one above the 100 ceiling.
 
-        RED at base: max(1, 101) == 101 (passes through unclamped).
-        GREEN after fix: warns and returns fallback 3.
+        RED at base: max(1, 101) == 101 (passes through unchecked).
+        GREEN after fix: rejected → fallback default 3.
         """
         result = self._call("101")
-        self.assertLessEqual(
+        self.assertEqual(
             result,
-            100,
+            3,
             f"_reload_ledger_max returned {result} for env=101 "
-            f"— must reject values above the 100 ceiling",
+            f"— expected rejection to safe default 3",
         )
 
     # ── Regression guards (must pass at base AND after fix) ──────────────────
@@ -157,7 +171,7 @@ class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
         self.assertEqual(self._call("10"), 10)
 
     def test_floor_clamp_at_1(self):
-        """Values below the floor 1 are raised to 1."""
+        """Values below the floor 1 are raised to 1 (genuine clamp, not reject)."""
         result = self._call("0")
         self.assertGreaterEqual(result, 1)
 

--- a/tests/test_reload_ledger_env_bounds.py
+++ b/tests/test_reload_ledger_env_bounds.py
@@ -97,9 +97,13 @@ class TestReloadLedgerWindowSEnvBounds(unittest.TestCase):
         self.assertEqual(self._call("1800"), 1800)
 
     def test_floor_clamp_at_60(self):
-        """Values below the floor 60 are raised to 60 (genuine clamp, not reject)."""
+        """Values below the floor 60 are clamped exactly to 60 (not reject).
+
+        Input "30" → max(60, 30) = 60 exactly. assertGreaterEqual would not
+        catch a future regression to max(90, v) = 90; assertEqual is precise.
+        """
         result = self._call("30")
-        self.assertGreaterEqual(result, 60)
+        self.assertEqual(result, 60)
 
     def test_ceiling_value_exact(self):
         """86400 exactly is at the boundary — must be accepted (not rejected)."""
@@ -147,17 +151,49 @@ class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
         )
 
     def test_max_above_ceiling_rejected_to_default(self):
-        """101 is just one above the 100 ceiling.
+        """51 is just one above the new 50 ceiling (was 100 at ae85bcc).
 
-        RED at base: max(1, 101) == 101 (passes through unchecked).
-        GREEN after fix: rejected → fallback default 3.
+        RED at base: max(1, 51) == 51 (passes through unchecked).
+        GREEN after fix: parse_env_positive_int with maximum=50 rejects → 3.
         """
-        result = self._call("101")
+        result = self._call("51")
         self.assertEqual(
             result,
             3,
-            f"_reload_ledger_max returned {result} for env=101 "
+            f"_reload_ledger_max returned {result} for env=51 "
             f"— expected rejection to safe default 3",
+        )
+
+    def test_max_above_write_cap_rejected_to_default(self):
+        """RELOAD_MAX=80 passes maximum=100 at base and returns 80.
+
+        The storm-guard fires when len(hist) >= max; hist is capped at 50 on
+        write, so len(hist) <= 50, making 50 >= 80 always False — guard never
+        trips for any value in [51, 100].
+
+        RED at base: max(1, 80) == 80 (accepted; storm-guard silently disabled).
+        GREEN after fix: 80 > 50 (new ceiling) → rejected → returns default 3.
+        """
+        result = self._call("80")
+        self.assertEqual(
+            result,
+            3,
+            f"_reload_ledger_max returned {result} for env=80 "
+            f"— expected rejection to safe default 3 (incoherent with hist[-50:] write-cap)",
+        )
+
+    def test_ceiling_100_rejected_after_fix(self):
+        """100 was the former ceiling; after fix it must be rejected.
+
+        RED at base: max(1, 100) == 100 (returned as ceiling).
+        GREEN after fix: 100 > 50 → rejected → 3.
+        """
+        result = self._call("100")
+        self.assertEqual(
+            result,
+            3,
+            f"_reload_ledger_max returned {result} for env=100 "
+            f"— expected rejection to 3 (old ceiling, no longer valid)",
         )
 
     # ── Regression guards (must pass at base AND after fix) ──────────────────
@@ -167,18 +203,24 @@ class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
         self.assertEqual(self._call(), 3)
 
     def test_valid_value_within_bounds(self):
-        """A value well within [1, 100] is returned as-is."""
+        """A value well within [1, 50] is returned as-is."""
         self.assertEqual(self._call("10"), 10)
 
-    def test_floor_clamp_at_1(self):
-        """Values below the floor 1 are raised to 1 (genuine clamp, not reject)."""
+    def test_zero_rejected_to_default(self):
+        """COZEMPIC_RELOAD_MAX=0 is rejected (not positive) → default 3.
+
+        parse_env_positive_int rejects 0 (not positive) → None → default 3.
+        This is rejection, not a clamp: max(1, v) was dead code, now removed.
+        The old test (test_floor_clamp_at_1) had a misleading docstring
+        asserting a "genuine clamp" that never happened.
+        """
         result = self._call("0")
-        self.assertGreaterEqual(result, 1)
+        self.assertEqual(result, 3, "0 must be rejected to default 3, not clamped to 1")
 
     def test_ceiling_value_exact(self):
-        """100 exactly is at the boundary — must be accepted (not rejected)."""
-        result = self._call("100")
-        self.assertEqual(result, 100)
+        """50 exactly is at the new boundary — must be accepted (not rejected)."""
+        result = self._call("50")
+        self.assertEqual(result, 50)
 
     def test_invalid_string_returns_fallback(self):
         """Non-numeric env var falls back to 3 (pre-existing behaviour)."""

--- a/tests/test_reload_ledger_env_bounds.py
+++ b/tests/test_reload_ledger_env_bounds.py
@@ -308,3 +308,52 @@ class TestReloadWarnGraceBounds(unittest.TestCase):
     def test_ceiling_value_exact(self):
         """3600 exactly is at the boundary — must be accepted (not rejected)."""
         self.assertAlmostEqual(self._call("3600"), 3600.0)
+
+
+class TestReloadLedgerAtomicWrite(unittest.TestCase):
+    """Invariant tests for the atomic ledger write in _reload_rate_exceeded.
+
+    The SIGKILL-mid-write failure mode cannot be tested deterministically in
+    a unit test.  These tests verify the two observable post-write properties:
+      1. No .tmp orphan is left after a clean write path.
+      2. The ledger contains valid JSON after one or more calls.
+
+    RED proof is by code inspection: the pre-fix `ledger_path.write_text(…)`
+    is non-atomic; the post-fix tmp+os.replace+finally-cleanup pattern matches
+    _write_armed_atomic (guard.py:2780), which is the sister-module pattern for
+    this class of write.
+    """
+
+    def test_no_tmp_orphan_on_clean_write(self):
+        """A successful write must leave no .tmp* file in the ledger directory."""
+        import tempfile
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as d:
+            ledger = pathlib.Path(d) / "test_ledger.history"
+            from cozempic.guard import _reload_rate_exceeded
+
+            _reload_rate_exceeded(ledger)
+            orphans = list(pathlib.Path(d).glob("*.tmp*"))
+            self.assertEqual(
+                orphans,
+                [],
+                f".tmp orphan left after clean write: {orphans}",
+            )
+
+    def test_ledger_valid_json_after_write(self):
+        """After two calls the ledger file must be parseable JSON."""
+        import json
+        import tempfile
+        import pathlib
+        import time
+
+        with tempfile.TemporaryDirectory() as d:
+            ledger = pathlib.Path(d) / "test_ledger.history"
+            from cozempic.guard import _reload_rate_exceeded
+
+            _reload_rate_exceeded(ledger)
+            _reload_rate_exceeded(ledger, now=time.time() + 1)
+            data = json.loads(ledger.read_text())
+            self.assertIsInstance(data, list)
+            self.assertGreater(len(data), 0)

--- a/tests/test_reload_ledger_env_bounds.py
+++ b/tests/test_reload_ledger_env_bounds.py
@@ -1,0 +1,171 @@
+"""Tests for reload-storm guard env-var upper clamps.
+
+The reload-rate ledger uses two env-overridable knobs:
+
+  COZEMPIC_RELOAD_WINDOW_S  — look-back window in seconds (default 600)
+  COZEMPIC_RELOAD_MAX       — max reloads allowed per window (default 3)
+
+Without upper bounds, a huge env value (e.g. from a typo like
+COZEMPIC_RELOAD_WINDOW_S=86400000 meaning "86400 with extra zeros") makes
+the ledger window effectively infinite, so the storm guard NEVER fires.
+This silently disables the protection for the session's lifetime.
+
+RED-at-base proof strategy:
+  - Set env var to a value far above the expected ceiling.
+  - Call the ledger accessor function.
+  - Assert the returned value is <= the ceiling.
+  - These assertions FAIL at base (raw huge int passes through), PASS after fix.
+
+Regression guard:
+  - Normal in-range values must not be altered by the fix.
+  - Default (env unset) must return the documented default.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestReloadLedgerWindowSEnvBounds(unittest.TestCase):
+    """_reload_ledger_window_s() must clamp to <= 86400 s (1 day)."""
+
+    def _call(self, env_val=None):
+        # Import inside test to get the live (post-patch) definition.
+        from cozempic.guard import _reload_ledger_window_s
+
+        env = {}
+        if env_val is not None:
+            env["COZEMPIC_RELOAD_WINDOW_S"] = env_val
+        with patch.dict(os.environ, env, clear=False):
+            if env_val is None:
+                os.environ.pop("COZEMPIC_RELOAD_WINDOW_S", None)
+            return _reload_ledger_window_s()
+
+    # ── RED-at-base: huge value must not pass through ─────────────────────────
+
+    def test_huge_window_env_is_clamped(self):
+        """A 23-digit env value silently disables the storm guard at base.
+
+        RED at base: max(60, int('10000000000000000000000')) == 10^22
+        (>> 86400 s / 1 day), so the ledger never expires and the guard
+        never fires.
+        GREEN after fix: parse_env_positive_int with maximum=86400 warns
+        and returns None → fallback 600.
+        """
+        result = self._call("10000000000000000000000")
+        self.assertLessEqual(
+            result,
+            86400,
+            f"_reload_ledger_window_s returned {result} for a huge env value "
+            f"— storm guard is silently disabled",
+        )
+
+    def test_value_above_ceiling_is_clamped(self):
+        """86401 is just one second above the documented 86400 ceiling.
+
+        RED at base: max(60, 86401) == 86401 (passes through unclamped).
+        GREEN after fix: warns and returns fallback 600.
+        """
+        result = self._call("86401")
+        self.assertLessEqual(
+            result,
+            86400,
+            f"_reload_ledger_window_s returned {result} for env=86401 "
+            f"— must reject values above the 86400 ceiling",
+        )
+
+    # ── Regression guards (must pass at base AND after fix) ──────────────────
+
+    def test_default_when_unset(self):
+        """Env absent → default 600 seconds."""
+        self.assertEqual(self._call(), 600)
+
+    def test_valid_value_within_bounds(self):
+        """A value well within [60, 86400] is returned as-is (clamped to floor)."""
+        self.assertEqual(self._call("1800"), 1800)
+
+    def test_floor_clamp_at_60(self):
+        """Values below the floor 60 are raised to 60."""
+        result = self._call("30")
+        self.assertGreaterEqual(result, 60)
+
+    def test_ceiling_value_exact(self):
+        """86400 exactly is at the boundary — must be accepted (not rejected)."""
+        result = self._call("86400")
+        self.assertEqual(result, 86400)
+
+    def test_invalid_string_returns_fallback(self):
+        """Non-numeric env var falls back to 600 (pre-existing behaviour)."""
+        self.assertEqual(self._call("not-a-number"), 600)
+
+
+class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
+    """_reload_ledger_max() must clamp to <= 100 reloads per window."""
+
+    def _call(self, env_val=None):
+        from cozempic.guard import _reload_ledger_max
+
+        env = {}
+        if env_val is not None:
+            env["COZEMPIC_RELOAD_MAX"] = env_val
+        with patch.dict(os.environ, env, clear=False):
+            if env_val is None:
+                os.environ.pop("COZEMPIC_RELOAD_MAX", None)
+            return _reload_ledger_max()
+
+    # ── RED-at-base: huge value must not pass through ─────────────────────────
+
+    def test_huge_max_env_is_clamped(self):
+        """999999999 reloads allowed → storm guard never trips.
+
+        RED at base: max(1, int('999999999')) == 999999999 (guard never fires).
+        GREEN after fix: parse_env_positive_int with maximum=100 warns and
+        returns None → fallback 3.
+        """
+        result = self._call("999999999")
+        self.assertLessEqual(
+            result,
+            100,
+            f"_reload_ledger_max returned {result} for a huge env value "
+            f"— storm guard is silently disabled",
+        )
+
+    def test_value_above_ceiling_is_clamped(self):
+        """101 is just one above the documented 100 ceiling.
+
+        RED at base: max(1, 101) == 101 (passes through unclamped).
+        GREEN after fix: warns and returns fallback 3.
+        """
+        result = self._call("101")
+        self.assertLessEqual(
+            result,
+            100,
+            f"_reload_ledger_max returned {result} for env=101 "
+            f"— must reject values above the 100 ceiling",
+        )
+
+    # ── Regression guards (must pass at base AND after fix) ──────────────────
+
+    def test_default_when_unset(self):
+        """Env absent → default 3."""
+        self.assertEqual(self._call(), 3)
+
+    def test_valid_value_within_bounds(self):
+        """A value well within [1, 100] is returned as-is."""
+        self.assertEqual(self._call("10"), 10)
+
+    def test_floor_clamp_at_1(self):
+        """Values below the floor 1 are raised to 1."""
+        result = self._call("0")
+        self.assertGreaterEqual(result, 1)
+
+    def test_ceiling_value_exact(self):
+        """100 exactly is at the boundary — must be accepted (not rejected)."""
+        result = self._call("100")
+        self.assertEqual(result, 100)
+
+    def test_invalid_string_returns_fallback(self):
+        """Non-numeric env var falls back to 3 (pre-existing behaviour)."""
+        self.assertEqual(self._call("not-a-number"), 3)

--- a/tests/test_reload_ledger_env_bounds.py
+++ b/tests/test_reload_ledger_env_bounds.py
@@ -183,3 +183,86 @@ class TestReloadLedgerMaxEnvBounds(unittest.TestCase):
     def test_invalid_string_returns_fallback(self):
         """Non-numeric env var falls back to 3 (pre-existing behaviour)."""
         self.assertEqual(self._call("not-a-number"), 3)
+
+
+class TestReloadWarnGraceBounds(unittest.TestCase):
+    """_reload_warn_grace() rejects huge finite values → safe default 120.0.
+
+    Cap = 3600 (1h): a grace period above 1h is functionally infinite for any
+    interactive session. Values above 3600 must be rejected to default 120.0;
+    the <=0 disable-semantic must be preserved.
+    """
+
+    def _call(self, env_val=None):
+        from cozempic.guard import _reload_warn_grace
+
+        env = {}
+        if env_val is not None:
+            env["COZEMPIC_RELOAD_WARN_GRACE"] = env_val
+        with patch.dict(os.environ, env, clear=False):
+            if env_val is None:
+                os.environ.pop("COZEMPIC_RELOAD_WARN_GRACE", None)
+            return _reload_warn_grace()
+
+    # ── RED-at-base: huge finite values must be rejected to default ──────────
+
+    def test_huge_grace_rejected_to_default(self):
+        """99999999999s (~3170 years) makes elapsed >= grace permanently False.
+
+        RED at base: math.isfinite(99999999999.0) is True → returns 99999999999.0,
+        silently disabling the idle-reload fallback forever.
+        GREEN after fix: v > 3600 → returns 120.0.
+        """
+        result = self._call("99999999999")
+        self.assertEqual(
+            result,
+            120.0,
+            f"_reload_warn_grace returned {result} for '99999999999' "
+            f"— expected rejection to safe default 120.0 (large-finite gate-disable class)",
+        )
+
+    def test_above_ceiling_rejected(self):
+        """3601 is one second above the 3600 (1h) ceiling — must be rejected.
+
+        RED at base: isfinite(3601.0) True → 3601.0 returned.
+        GREEN after fix: > 3600 → 120.0.
+        """
+        result = self._call("3601")
+        self.assertEqual(
+            result,
+            120.0,
+            f"_reload_warn_grace returned {result} for '3601' "
+            f"— expected rejection to 120.0",
+        )
+
+    # ── Regression guards (must pass at base AND after fix) ──────────────────
+
+    def test_disable_semantic_preserved_negative(self):
+        """<= 0 DISABLES the grace wait (per docstring); negative still works."""
+        result = self._call("-1")
+        self.assertLessEqual(result, 0)
+
+    def test_disable_semantic_zero(self):
+        """Zero disables the grace wait."""
+        result = self._call("0")
+        self.assertLessEqual(result, 0)
+
+    def test_default_when_unset(self):
+        """Env absent → default 120.0 seconds."""
+        self.assertEqual(self._call(), 120.0)
+
+    def test_valid_value_passthrough(self):
+        """300s is well within the ceiling — returned as-is."""
+        self.assertAlmostEqual(self._call("300"), 300.0)
+
+    def test_nan_rejected(self):
+        """NaN already handled by isfinite; ensure it survives the refactor."""
+        self.assertEqual(self._call("nan"), 120.0)
+
+    def test_inf_rejected(self):
+        """Inf already handled by isfinite; ensure it survives the refactor."""
+        self.assertEqual(self._call("inf"), 120.0)
+
+    def test_ceiling_value_exact(self):
+        """3600 exactly is at the boundary — must be accepted (not rejected)."""
+        self.assertAlmostEqual(self._call("3600"), 3600.0)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -185,6 +185,36 @@ class TestParseEnvPositiveInt(unittest.TestCase):
                 parse_env_positive_int("TEST_ENV_POSINT")
         self.assertEqual(buf.getvalue(), "")
 
+    def test_warns_on_whitespace_only(self):
+        """Whitespace-only env var must warn — the user set the var but it
+        carries no integer.  Regression check: ae85bcc silently returned None
+        for whitespace-only values; origin/main raised ValueError on int(raw)
+        which produced 'must be an integer' via _env_warn.
+
+        RED at ae85bcc: raw.strip()=="" triggers silent early return (no warn).
+        GREEN after fix: whitespace-only → _env_warn('must be an integer').
+        """
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": "   "}):
+            with contextlib.redirect_stderr(buf):
+                result = parse_env_positive_int("TEST_ENV_POSINT")
+        self.assertIsNone(result)
+        self.assertIn("TEST_ENV_POSINT", buf.getvalue(), "warning must name the env var")
+        self.assertIn("integer", buf.getvalue(), "warning must say 'must be an integer'")
+
+    def test_silent_when_empty_string(self):
+        """Genuine empty string (unset-equivalent) must NOT warn — the env
+        key exists but carries no value (e.g. ``export VAR=`` in shell)."""
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"TEST_ENV_POSINT": ""}):
+            with contextlib.redirect_stderr(buf):
+                parse_env_positive_int("TEST_ENV_POSINT")
+        self.assertEqual(buf.getvalue(), "")
+
 
 class TestParseEnvNonNegativeInt(unittest.TestCase):
     """Like positive-int but accepts 0 (valid for system_overhead_tokens —
@@ -205,6 +235,22 @@ class TestParseEnvNonNegativeInt(unittest.TestCase):
     def test_rejects_non_numeric(self):
         with patch.dict(os.environ, {"TEST_ENV_NNINT": "xyz"}):
             self.assertIsNone(parse_env_non_negative_int("TEST_ENV_NNINT"))
+
+    def test_warns_on_whitespace_only(self):
+        """Whitespace-only must warn — same regression class as parse_env_positive_int.
+
+        RED at ae85bcc: silent early return.
+        GREEN after fix: _env_warn fires ('must be an integer').
+        """
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"TEST_ENV_NNINT": "   "}):
+            with contextlib.redirect_stderr(buf):
+                result = parse_env_non_negative_int("TEST_ENV_NNINT")
+        self.assertIsNone(result)
+        self.assertIn("TEST_ENV_NNINT", buf.getvalue())
+        self.assertIn("integer", buf.getvalue())
 
 
 # ── Backwards compat: re-exports from strategies/_config still work ────────


### PR DESCRIPTION
## Problem — the reload-storm guard can be silently disabled

The reload-**storm** guard (which stops a runaway reload→regrow→reload loop) could be silently defeated four ways:

1. **Unbounded env knobs.** \`_reload_ledger_window_s\` / \`_reload_ledger_max\` read \`COZEMPIC_RELOAD_WINDOW_S\` / \`COZEMPIC_RELOAD_MAX\` with a floor but **no upper bound** — a huge value (\`COZEMPIC_RELOAD_MAX=999999999\`) makes the threshold astronomically large → it never trips.
2. **Incoherent ceiling vs write-cap.** Even the original ceiling of \`100\` was incoherent with the \`hist[-50:]\` write-cap: the ledger never holds >50 entries, so any \`RELOAD_MAX ∈ [51, 100]\` made \`len(hist) >= max\` **permanently False** — the guard was silently inert for that whole range.
3. **Large-finite gate-disable class.** \`_reload_warn_grace\` capped NaN/inf but not huge-finite values: \`COZEMPIC_RELOAD_WARN_GRACE=99999999999\` passes \`math.isfinite()\` but makes \`elapsed >= grace\` permanently False — the idle-reload fallback never fires.
4. **Non-atomic ledger write.** A bare \`ledger_path.write_text(…)\` can produce a half-written ledger on SIGKILL mid-write, which \`_reload_rate_exceeded\` would silently reset to \`[]\` — erasing the storm-guard counter and allowing unlimited reloads after a crash.

A removed-behavior regression was also folded in: the \`ae85bcc\` base commit silently dropped the whitespace-only-env warning in \`parse_env_positive_int\` / \`parse_env_non_negative_int\` (an undocumented behavior change).

## Fix

**P0-A** (\`guard.py\` \`_reload_warn_grace\`): add \`or v > 3600\` to the isfinite reject condition. Cap = 3600 s (1 h): a grace period above 1 h is functionally infinite for any interactive session. Preserve the \`≤0\` disable semantic.

**P0-B+C** (\`guard.py\` \`_reload_ledger_max\`): extract \`_RELOAD_LEDGER_HIST_CAP = 50\` (a named constant shared by the \`maximum=\` argument and the \`hist[-cap:]\` write-cap slice), lower the effective ceiling from 100 to 50, and remove the now-dead \`max(1, v)\` (parse_env_positive_int guarantees ≥1 when non-None). An explicit INVARIANT comment documents the coupling: a ceiling above the write-cap silently disables the guard for the (write-cap, ceiling] range.

**Atomic write** (\`guard.py\` \`_reload_rate_exceeded\`): replace bare \`write_text\` with the inline \`tmp + os.replace + finally-cleanup\` pattern (mirrors \`_write_armed_atomic\` at guard.py:2780). SIGKILL between the tmp write and the rename corrupts only the tmp — the live ledger is untouched and the finally block unlinks the orphan.

**P0-D** (\`tests/test_input_coercion_corpus.py\`): add rows for \`_reload_ledger_window_s\` / COZEMPIC_RELOAD_WINDOW_S and \`_reload_ledger_max\` / COZEMPIC_RELOAD_MAX to the \`_ENV_VALIDATORS\` table (the qa-fleet L1 maintenance contract: every knob must have a corpus row).

**Q-A** (\`_validation.py\`): restore whitespace-only-env warning in \`parse_env_positive_int\` and \`parse_env_non_negative_int\`. The \`ae85bcc\` base used \`raw.strip() == ""\` as the early-return guard, silently treating whitespace-only env vars as absent; origin/main warned. Restored with \`if raw:\` guard that keeps genuine empty string silent.

**Round-2 (reviewer findings):**
- **M-1**: Added \`test_crash_safety_old_ledger_preserved_on_failed_replace\` — patches \`cozempic.guard.os.replace → OSError\`, asserts (a) pre-existing ledger byte-intact and (b) no \`.tmp*\` orphan. RED at base ae85bcc (bare \`write_text\` never calls \`os.replace\` → patch inert → old content overwritten). GREEN at HEAD (atomic path raises, live file untouched, finally cleans tmp).
- **L-1**: Updated \`parse_env_bool\` docstring to document the deliberate whitespace-only divergence from \`parse_env_positive_int\`.
- **L-2**: Expanded \`_RELOAD_LEDGER_HIST_CAP\` inline comment into an explicit INVARIANT block.

**WONTFIX (documented):**
- L-3 (SIGKILL \`.tmp\` orphan not GC'd): inherited from the \`_write_armed_atomic\` sister pattern — low rate, no corruption, no fix needed.

## Tests

**New test classes / updates (7 commits):**
- \`TestReloadWarnGraceBounds\` (9 tests): huge-finite rejected, 3601 rejected, 3600 accepted, 0/negative disable-semantic preserved, nan/inf rejected.
- \`TestReloadLedgerMaxEnvBounds\`: corrected clamp→reject semantics; ceiling 100→50; \`test_max_above_write_cap_rejected_to_default\` (RELOAD_MAX=80 now rejected); \`test_ceiling_100_rejected_after_fix\`; \`test_zero_rejected_to_default\` (honest docstring).
- \`TestReloadLedgerWindowSEnvBounds\`: \`test_floor_clamp_at_60\` upgraded to \`assertEqual\` (not \`assertGreaterEqual\`).
- \`TestReloadLedgerAtomicWrite\` (3 tests): crash-safety (patch os.replace→OSError), no-orphan on clean write, valid JSON after write.
- \`TestParseEnvPositiveInt.test_warns_on_whitespace_only\`, \`TestParseEnvNonNegativeInt.test_warns_on_whitespace_only\` — Q-A regression guard.
- \`_ENV_VALIDATORS\` corpus: 7 → 9 rows.

**Suite:** 1400 passed, 5 skipped, 271 subtests, 0 failures (baseline 1383/233 on origin/main).

**RED-at-base proof (7 behavioral tests):** Each new bug-capture test was verified RED at ae85bcc (the PR branch base) and GREEN at HEAD. The M-1 atomicity test was independently reproduced by the lead.

## Scope

- \`src/cozempic/guard.py\` — \`_reload_warn_grace\`, \`_RELOAD_LEDGER_HIST_CAP\`, \`_reload_ledger_max\`, \`_reload_rate_exceeded\`
- \`src/cozempic/_validation.py\` — \`parse_env_positive_int\`, \`parse_env_non_negative_int\`, \`parse_env_bool\` (docstring)
- \`tests/test_reload_ledger_env_bounds.py\` — new test file
- \`tests/test_input_coercion_corpus.py\` — corpus extension
- \`tests/test_validation.py\` — Q-A regression guards

No changes to the public API, CLI, or PyPI packaging. Zero new dependencies.