### PR TITLE
fix(watchdog): rate-based C7 error-storm detection — replace flat-count heuristic

### DIFF
--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -57,6 +57,20 @@ STORM_TRIP = 5
 # The guard's back-off cap (HARD_LOOP_BACKOFF_CAP), recorded for diagnostics.
 BACKOFF_CAP_S = 300
 
+# Rate-based storm detection: time window (seconds) within which daemon restarts
+# are counted. A storm = many restarts close together. 3600s (1h) separates
+# "storming right now" from "user restarting Claude across a day". The daemon's
+# own back-off cap is BACKOFF_CAP_S=300; a storm spanning >1h is either arrested
+# by the daemon's own circuit-breaker or has been running long enough that
+# flagging it is correct.
+RATE_WINDOW_S: int = 3600
+
+# Minimum daemon restarts within RATE_WINDOW_S to declare an error respawn storm.
+# Set to 5, consistent with the existing STORM_TRIP constant for futile-prune storms.
+# Five escalation-respawn cycles happen in < 5 min during a real error loop; user
+# restarts across a day don't cluster within a 1h window.
+RATE_STORM_TRIP: int = 5
+
 # The token-count group must tolerate the K/M/G suffix and comma grouping that
 # guard._fmt_prune_result emits ("210.0K tokens freed", "1.2M tokens freed") for
 # any prune >= 1000 tokens — WITHOUT this, every productive prune line is

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -134,7 +134,7 @@ class LoopReport:
     reason: str = ""
     recent_pcts: list = field(default_factory=list)
     daemon_start_times: list = field(default_factory=list)  # datetime | None per start
-    recent_starts: int = 0  # starts within RATE_WINDOW_S of the anchor timestamp
+    recent_starts: int = 0  # max restarts in any RATE_WINDOW_S-second sliding window
 
 
 def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -250,8 +250,8 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
         if rep.recent_starts >= RATE_STORM_TRIP:
             rep.looping = True
             rep.reason = (
-                f"{rep.recent_starts} guard restarts in the last "
-                f"{RATE_WINDOW_S // 60}min — error respawn storm (rate-based); "
+                f"{rep.recent_starts} guard restarts within a "
+                f"{RATE_WINDOW_S // 60}min window — error respawn storm (rate-based); "
                 f"{rep.cycle_errors} per-cycle errors / "
                 f"{rep.cycle_escalations} escalations"
             )

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -127,16 +127,21 @@ class LoopReport:
 
 
 def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
-    """Detect futile reload-churn in one guard log's text (pure).
+    """Detect guard reload-churn or error-storm in one guard log's text (pure).
 
-    Flags ``looping`` when the log shows >= ``loop_trip`` futile prune cycles
-    (<1% freed) AND those dominate the prune cycles (>= ``FUTILE_DOMINANCE``).
-    Crucially this does NOT treat a circuit-breaker exit as proof of health —
-    the real f641174c failure was a RESPAWN STORM in which each daemon DID
-    K-exit, so "saw an exit line" is recorded for diagnostics but never clears
-    the verdict. The agents-active deferral path emits read-only-checkpoint lines
-    (not "Pruned: …"), so a busy-but-healthy session accrues no futile prune
-    cycles and is never flagged.
+    Two detection paths:
+
+    **Futile-prune path**: flags ``looping`` when >= ``loop_trip`` futile prune
+    cycles (<1% freed) dominate all prune cycles (>= ``FUTILE_DOMINANCE``). This
+    is the f641174c respawn-storm shape. Crucially does NOT treat a circuit-breaker
+    exit as proof of health — each daemon in a respawn storm DID K-exit, yet the
+    SessionStart hook kept respawning onto an unprunable session.
+
+    **C7 error-storm path (rate-based)**: flags ``looping`` when >= ``RATE_STORM_TRIP``
+    daemon restarts fall within ``RATE_WINDOW_S`` seconds of each other (as measured
+    from ISO timestamps on daemon-start header lines). Rate-first: when parseable
+    timestamps are available, the rate verdict is authoritative — the older flat-count
+    fallback only runs for logs that lack ISO timestamps (old daemon versions).
     """
     rep = LoopReport()
     futile = 0

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -151,7 +151,31 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
             futile += 1
     rep.futile_cycles = futile
     rep.recent_pcts = rep.recent_pcts[-loop_trip:]
-    rep.daemon_starts = len(_DAEMON_START_RE.findall(text))
+
+    # Parse daemon-start markers and attempt to extract ISO timestamps from each.
+    # The capture group is optional — lines without "at <ISO>" yield group(1)=None.
+    for m in _DAEMON_START_RE.finditer(text):
+        rep.daemon_starts += 1
+        raw_ts = m.group(1)
+        if raw_ts is not None:
+            try:
+                rep.daemon_start_times.append(datetime.fromisoformat(raw_ts))
+            except ValueError:
+                rep.daemon_start_times.append(None)
+        else:
+            rep.daemon_start_times.append(None)
+
+    # Compute recent_starts: count of daemon restarts whose ISO timestamp falls
+    # within RATE_WINDOW_S seconds of the most recent parseable timestamp (anchor).
+    # If no parseable timestamps exist, recent_starts stays 0 and the rate path
+    # is bypassed entirely — the flat-count fallback handles old-format logs.
+    parseable = [dt for dt in rep.daemon_start_times if dt is not None]
+    if parseable:
+        anchor = max(parseable)
+        rep.recent_starts = sum(
+            1 for dt in parseable
+            if (anchor - dt).total_seconds() <= RATE_WINDOW_S
+        )
 
     backoffs = [int(s) for s in _BACKOFF_RE.findall(text)]
     if backoffs:
@@ -159,50 +183,56 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
         rep.max_backoff_s = max(backoffs)
     rep.has_exit = bool(_EXIT_RE.search(text))
 
-    # C7: erroring/inert-guard signature — the guard is erroring MORE than it is
-    # productively pruning. Discriminator (R15, after three weaker attempts each leaked):
-    #   cycle_errors >= loop_trip  AND  cycle_errors > productive_prunes
-    # where productive_prunes = total_prune_cycles - futile_cycles (prunes that actually
-    # freed space). This is robust in BOTH directions on a flat append-mode log:
-    #  - HEALTHY busy guard (many productive prunes, occasional transient error):
-    #    cycle_errors <= productive_prunes -> NOT flagged.
-    #  - HEALTHY IDLE guard (short sessions, 0 prunes, 0 errors, several restarts):
-    #    cycle_errors (0) < loop_trip -> NOT flagged (the daemon_starts-only trigger of
-    #    the prior attempt false-flagged this — R15 FP).
-    #  - HEALTHY fresh gen + a couple of STALE escalations from dead gens (~10 errors):
-    #    < loop_trip -> NOT flagged (R15 FP).
-    #  - ERROR respawn storm, even WITH a stray early productive prune line in the tail
-    #    (the R15 FN that defeated the total_prune_cycles==0 gate): many errors greatly
-    #    outnumber the lone productive prune -> flagged.
-    #  - single INERT generation (>= loop_trip errors, 0 prunes) -> flagged.
-    # The futile-PRUNE storm (f641174c: many <1%-freed prunes, ~0 errors) has
-    # productive_prunes near 0 but cycle_errors near 0 too, so it is owned by the
-    # separate futile-dominance branch below (which keeps the "respawn storm" reason).
+    # C7: erroring/inert-guard signature. Two-path verdict (rate-first, flat-fallback):
     #
-    # KNOWN RESIDUAL (accepted, REPORT-ONLY; tracked follow-up = a rate-based redesign):
-    # because this counts over a flat 256KB append-mode tail with no recency/rate
-    # awareness, two edge cases survive — (FN) a CURRENT error-storm can be masked if
-    # stale productive-prune lines from an earlier dead generation still in the window
-    # outnumber the errors; (FP) a long healthy daemon that self-recovered >= loop_trip
-    # SCATTERED transient errors (counter reset each time, never escalated) with its
-    # productive prunes scrolled out of the window can be flagged. Both are bounded:
-    # this is a REPORT-ONLY monitor (--fix is manual + guard-identity-gated), the
-    # daemon's OWN circuit-breaker self-arrests real error-storms, and the well-tested
-    # futile-PRUNE loop detection (the real f641174c incident shape) is unaffected. The
-    # durable fix is to parse the per-line timestamps and key the verdict on RESTART
-    # RATE within a recent window — deferred to a follow-up (not blocking PR #138).
+    # PATH A — rate-based (implemented here, fixes the known FN/FP residuals):
+    #   When ≥1 parseable ISO timestamp exists in daemon-start markers, count how many
+    #   restarts fall within RATE_WINDOW_S of the most recent one. If that count
+    #   reaches RATE_STORM_TRIP the log shows an error respawn storm regardless of
+    #   what older productive-prune lines say. This is the "durable fix" referenced in
+    #   the KNOWN RESIDUAL comment below (now implemented).
+    #     FN fix: a current error storm is flagged even when stale productive-prune
+    #       lines from an earlier dead generation dominate the window.
+    #     FP fix: a healthy single-daemon with scattered recovered errors has
+    #       recent_starts=1 < RATE_STORM_TRIP → NOT flagged.
+    #   When recent_starts < RATE_STORM_TRIP (and ≥1 parseable timestamp exists), the
+    #   rate path is authoritative — the flat-count fallback is suppressed.
+    #
+    # PATH B — flat-count fallback (original R15 discriminator):
+    #   Used only when 0 parseable timestamps exist (old daemon versions, truncated
+    #   lines). Behaviour for those logs is IDENTICAL to before — zero regression.
+    #   Discriminator:  cycle_errors >= loop_trip  AND  cycle_errors > productive_prunes
+    #
     rep.cycle_errors = len(_CYCLE_ERR_RE.findall(text))
     rep.cycle_escalations = len(_CYCLE_ESCALATION_RE.findall(text))
     _productive_prunes = rep.total_prune_cycles - rep.futile_cycles
-    if rep.cycle_errors >= loop_trip and rep.cycle_errors > _productive_prunes:
-        rep.looping = True
-        rep.reason = (
-            f"{rep.cycle_errors} per-cycle errors / {rep.cycle_escalations} escalations / "
-            f"{rep.daemon_starts} restarts vs {_productive_prunes} space-freeing prunes "
-            f"— guard is erroring more than it is productively pruning (inert or "
-            f"respawn-cycling on a deterministic failure); investigate the logged exception"
-        )
-        return rep
+
+    if parseable:
+        # PATH A: rate-based verdict. Authoritative when any ISO timestamp was parsed.
+        if rep.recent_starts >= RATE_STORM_TRIP:
+            rep.looping = True
+            rep.reason = (
+                f"{rep.recent_starts} guard restarts in the last "
+                f"{RATE_WINDOW_S // 60}min — error respawn storm (rate-based); "
+                f"{rep.cycle_errors} per-cycle errors / "
+                f"{rep.cycle_escalations} escalations"
+            )
+            return rep
+        # recent_starts < RATE_STORM_TRIP with parseable timestamps: not a storm.
+        # The flat-count is suppressed — a single daemon with scattered errors
+        # must not be flagged just because its prune lines scrolled out of the tail.
+    else:
+        # PATH B: flat-count fallback — no parseable timestamps (old log format).
+        # Original R15 discriminator: erroring more than productively pruning.
+        if rep.cycle_errors >= loop_trip and rep.cycle_errors > _productive_prunes:
+            rep.looping = True
+            rep.reason = (
+                f"{rep.cycle_errors} per-cycle errors / {rep.cycle_escalations} escalations / "
+                f"{rep.daemon_starts} restarts vs {_productive_prunes} space-freeing prunes "
+                f"— guard is erroring more than it is productively pruning (inert or "
+                f"respawn-cycling on a deterministic failure); investigate the logged exception"
+            )
+            return rep
 
     futile_ratio = futile / rep.total_prune_cycles if rep.total_prune_cycles else 0.0
     if futile >= loop_trip and futile_ratio >= FUTILE_DOMINANCE:

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -162,12 +162,11 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
     for m in _DAEMON_START_RE.finditer(text):
         rep.daemon_starts += 1
         raw_ts = m.group(1)
-        if raw_ts is not None:
-            try:
-                rep.daemon_start_times.append(datetime.fromisoformat(raw_ts))
-            except ValueError:
-                rep.daemon_start_times.append(None)
-        else:
+        try:
+            rep.daemon_start_times.append(
+                datetime.fromisoformat(raw_ts) if raw_ts is not None else None
+            )
+        except ValueError:
             rep.daemon_start_times.append(None)
 
     # Compute recent_starts: count of daemon restarts whose ISO timestamp falls

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 from .helpers import _pid_is_alive as _pid_alive
@@ -74,7 +75,10 @@ _PRUNED_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _BACKOFF_RE = re.compile(r"back-off \(next sleep:\s*(\d+)s", re.IGNORECASE)
-_DAEMON_START_RE = re.compile(r"Guard daemon started", re.IGNORECASE)
+_DAEMON_START_RE = re.compile(
+    r"Guard daemon started(?:\s+at\s+([\d\-T:.]+))?",
+    re.IGNORECASE,
+)
 # Circuit-breaker / daemon-exit markers (recorded for diagnostics — NOT treated
 # as proof of health: the real f641174c storm K-exited 21x and still looped).
 _EXIT_RE = re.compile(
@@ -104,6 +108,8 @@ class LoopReport:
     looping: bool = False
     reason: str = ""
     recent_pcts: list = field(default_factory=list)
+    daemon_start_times: list = field(default_factory=list)  # datetime | None per start
+    recent_starts: int = 0  # starts within RATE_WINDOW_S of the anchor timestamp
 
 
 def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -223,22 +223,26 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
 
     # C7: erroring/inert-guard signature. Two-path verdict (rate-first, flat-fallback):
     #
-    # PATH A — rate-based (implemented here, fixes the known FN/FP residuals):
-    #   When ≥1 parseable ISO timestamp exists in daemon-start markers, count how many
-    #   restarts fall within RATE_WINDOW_S of the most recent one. If that count
-    #   reaches RATE_STORM_TRIP the log shows an error respawn storm regardless of
-    #   what older productive-prune lines say. This is the "durable fix" referenced in
-    #   the KNOWN RESIDUAL comment below (now implemented).
+    # PATH A — rate-based (authoritative when ≥1 parseable ISO timestamp exists):
+    #   Count the maximum daemon restarts in ANY RATE_WINDOW_S-second sliding window
+    #   (outlier-robust — a forged future/past timestamp forms its own window of 1 and
+    #   cannot suppress a genuine restart cluster or inflate recent_starts). If that
+    #   count reaches RATE_STORM_TRIP the log shows a respawn storm regardless of what
+    #   older productive-prune lines say.
     #     FN fix: a current error storm is flagged even when stale productive-prune
-    #       lines from an earlier dead generation dominate the window.
+    #       lines from an earlier dead generation dominate the log window.
     #     FP fix: a healthy single-daemon with scattered recovered errors has
     #       recent_starts=1 < RATE_STORM_TRIP → NOT flagged.
     #   When recent_starts < RATE_STORM_TRIP (and ≥1 parseable timestamp exists), the
-    #   rate path is authoritative — the flat-count fallback is suppressed.
+    #   rate path is authoritative — the flat-count fallback (PATH B) is suppressed.
     #
     # PATH B — flat-count fallback (original R15 discriminator):
     #   Used only when 0 parseable timestamps exist (old daemon versions, truncated
     #   lines). Behaviour for those logs is IDENTICAL to before — zero regression.
+    #   NOTE: PATH B is suppressed whenever ≥1 timestamp parses, including mixed-
+    #   generation logs (e.g. one old-format start + one modern-format start). A
+    #   non-escalated inert daemon whose log contains even one parseable timestamp is
+    #   NOT flagged by PATH B — a documented scoped limitation (see PR body + TODO.md).
     #   Discriminator:  cycle_errors >= loop_trip  AND  cycle_errors > productive_prunes
     #
     rep.cycle_errors = len(_CYCLE_ERR_RE.findall(text))
@@ -251,8 +255,9 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
             rep.looping = True
             rep.reason = (
                 f"{rep.recent_starts} guard restarts within a "
-                f"{RATE_WINDOW_S // 60}min window — error respawn storm (rate-based); "
+                f"{RATE_WINDOW_S // 60}min window — respawn storm (rate-based); "
                 f"{rep.cycle_errors} per-cycle errors / "
+                f"{rep.futile_cycles} futile prune cycles / "
                 f"{rep.cycle_escalations} escalations"
             )
             return rep
@@ -268,8 +273,10 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
         # DEFERRED RESIDUAL: a daemon that errors ≥loop_trip times but NEVER
         # escalates (C2 escalation path was disabled or the loop exited via a
         # different path) is not caught by this discriminator. That shape is rare
-        # (C2 escalation fires before K=loop_trip in normal operation) and is
-        # already handled by PATH B for no-timestamp logs. Tracking in TODO.md.
+        # (C2 escalation fires before K=loop_trip in normal operation). PATH B is
+        # suppressed whenever ≥1 timestamp parses (including mixed-generation logs),
+        # so such a daemon is NOT caught by PATH B either if its log carries any
+        # parseable ISO timestamp. Documented scoped limitation in PR body + TODO.md.
         if (
             rep.cycle_escalations >= 1
             and rep.cycle_errors >= loop_trip

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -89,9 +89,20 @@ _PRUNED_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _BACKOFF_RE = re.compile(r"back-off \(next sleep:\s*(\d+)s", re.IGNORECASE)
+# Line-anchored to prevent mid-line forged "Guard daemon started at <ISO>" substrings
+# (e.g. inside a "Team '<attacker-name>' state preserved" log line) from registering
+# as daemon-start markers — same defence class as the _PRUNED_RE anchor (C7 log-injection
+# that the newline-only _log_safe scrub doesn't cover). The real guard format is
+# "--- Guard daemon started at <ISO> ---" which starts a new line; the leading "--- "
+# (dashes + space) must be matched explicitly. Optional leading whitespace covers
+# any compact variant. The pattern covers both forms:
+#   ^---\s*Guard daemon started …   (real format with dashes)
+#   ^\s*Guard daemon started …       (whitespace-only prefix variant)
+# A mid-line occurrence like "Team 'Guard daemon started at T' state preserved"
+# cannot match because "Team '" is neither dashes nor whitespace at line-start.
 _DAEMON_START_RE = re.compile(
-    r"Guard daemon started(?:\s+at\s+([\d\-T:.]+))?",
-    re.IGNORECASE,
+    r"^(?:---\s*|\s*)Guard daemon started(?:\s+at\s+([\d\-T:.Z+-]+))?",
+    re.IGNORECASE | re.MULTILINE,
 )
 # Circuit-breaker / daemon-exit markers (recorded for diagnostics — NOT treated
 # as proof of health: the real f641174c storm K-exited 21x and still looped).
@@ -137,11 +148,22 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
     exit as proof of health — each daemon in a respawn storm DID K-exit, yet the
     SessionStart hook kept respawning onto an unprunable session.
 
-    **C7 error-storm path (rate-based)**: flags ``looping`` when >= ``RATE_STORM_TRIP``
-    daemon restarts fall within ``RATE_WINDOW_S`` seconds of each other (as measured
-    from ISO timestamps on daemon-start header lines). Rate-first: when parseable
-    timestamps are available, the rate verdict is authoritative — the older flat-count
-    fallback only runs for logs that lack ISO timestamps (old daemon versions).
+    **C7 error-storm path (rate-based)**: when ≥1 parseable ISO timestamp exists in
+    daemon-start header lines, PATH A is authoritative. Two sub-verdicts:
+
+    * **Storm** (``recent_starts >= RATE_STORM_TRIP``): the maximum number of daemon
+      restarts that fall within ANY ``RATE_WINDOW_S``-second sliding window reaches the
+      trip threshold. Uses a sliding-window algorithm (sort + per-point count) so a
+      single outlier timestamp (forged future or far-past) forms its own window of size 1
+      and cannot mask a genuine restart cluster.
+    * **Inert/escalating** (``recent_starts < RATE_STORM_TRIP`` but
+      ``cycle_escalations >= 1`` and ``cycle_errors >= loop_trip`` and
+      ``cycle_errors > productive_prunes``): a single daemon hit a deterministic failure,
+      accumulated many per-cycle errors, and exited via the C2 escalation path. Not a
+      storm but genuinely stuck.
+
+    When no parseable timestamps exist, the older flat-count fallback (PATH B) runs
+    unchanged — zero regression for old-format logs.
     """
     rep = LoopReport()
     futile = 0
@@ -159,26 +181,38 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
 
     # Parse daemon-start markers and attempt to extract ISO timestamps from each.
     # The capture group is optional — lines without "at <ISO>" yield group(1)=None.
+    # Tz-aware timestamps (guard emits naive local time via datetime.now().isoformat(),
+    # so a tz-aware result means a forged/unexpected format) are treated as None: mixing
+    # tz-aware + naive datetimes in comparisons raises TypeError.
     for m in _DAEMON_START_RE.finditer(text):
         rep.daemon_starts += 1
         raw_ts = m.group(1)
-        try:
-            rep.daemon_start_times.append(
-                datetime.fromisoformat(raw_ts) if raw_ts is not None else None
-            )
-        except ValueError:
-            rep.daemon_start_times.append(None)
+        dt: datetime | None = None
+        if raw_ts is not None:
+            try:
+                parsed = datetime.fromisoformat(raw_ts)
+                dt = parsed if parsed.tzinfo is None else None
+            except ValueError:
+                dt = None
+        rep.daemon_start_times.append(dt)
 
-    # Compute recent_starts: count of daemon restarts whose ISO timestamp falls
-    # within RATE_WINDOW_S seconds of the most recent parseable timestamp (anchor).
-    # If no parseable timestamps exist, recent_starts stays 0 and the rate path
-    # is bypassed entirely — the flat-count fallback handles old-format logs.
+    # Compute recent_starts: maximum number of daemon restarts that fall within any
+    # sliding RATE_WINDOW_S-second window of each other. Uses a sort + O(n²) inner
+    # count (n = daemon_starts, typically < 50) rather than max()-anchoring, which
+    # is defeated by a single forged far-future or far-past timestamp inflating the
+    # anchor: a lone outlier forms its own window of size 1 and can't suppress
+    # legitimate clusters.
+    # If no parseable timestamps exist, recent_starts stays 0 → rate path skipped,
+    # flat-count fallback (PATH B) handles old-format logs with no ISO timestamps.
     parseable = [dt for dt in rep.daemon_start_times if dt is not None]
     if parseable:
-        anchor = max(parseable)
-        rep.recent_starts = sum(
-            1 for dt in parseable
-            if (anchor - dt).total_seconds() <= RATE_WINDOW_S
+        sorted_ts = sorted(parseable)
+        rep.recent_starts = max(
+            sum(
+                1 for t2 in sorted_ts
+                if 0 <= (t2 - t1).total_seconds() <= RATE_WINDOW_S
+            )
+            for t1 in sorted_ts
         )
 
     backoffs = [int(s) for s in _BACKOFF_RE.findall(text)]
@@ -223,8 +257,31 @@ def scan_log_text(text: str, loop_trip: int = LOOP_TRIP_DEFAULT) -> LoopReport:
             )
             return rep
         # recent_starts < RATE_STORM_TRIP with parseable timestamps: not a storm.
-        # The flat-count is suppressed — a single daemon with scattered errors
-        # must not be flagged just because its prune lines scrolled out of the tail.
+        # Check for the inert/escalating-single-daemon case: a daemon that hit a
+        # deterministic failure, emitted ≥loop_trip per-cycle errors, and exited
+        # via the C2 escalation path (cycle_escalations ≥ 1) for operator respawn.
+        # This is NOT a respawn storm (recent_starts is small) but IS genuinely
+        # stuck — the escalation proves it tried and failed repeatedly, not just
+        # a transient blip that recovered. Without this gate, PATH A's flat-count
+        # suppression would mask single-gen inert daemons.
+        #
+        # DEFERRED RESIDUAL: a daemon that errors ≥loop_trip times but NEVER
+        # escalates (C2 escalation path was disabled or the loop exited via a
+        # different path) is not caught by this discriminator. That shape is rare
+        # (C2 escalation fires before K=loop_trip in normal operation) and is
+        # already handled by PATH B for no-timestamp logs. Tracking in TODO.md.
+        if (
+            rep.cycle_escalations >= 1
+            and rep.cycle_errors >= loop_trip
+            and rep.cycle_errors > _productive_prunes
+        ):
+            rep.looping = True
+            rep.reason = (
+                f"inert/erroring guard (escalated): {rep.cycle_errors} per-cycle errors / "
+                f"{rep.cycle_escalations} escalations vs {_productive_prunes} productive prunes "
+                f"— genuinely stuck (not a recovered transient)"
+            )
+            return rep
     else:
         # PATH B: flat-count fallback — no parseable timestamps (old log format).
         # Original R15 discriminator: erroring more than productively pruning.

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -303,5 +303,185 @@ class TestFixIdentityGate(unittest.TestCase):
         self.assertEqual(killed.get("sig"), signal.SIGTERM)
 
 
+def _error_cycle(n=1):
+    """One guard error-skip line (no timestamp, matches _CYCLE_ERR_RE)."""
+    return f"  Guard: skipping a cycle after an unexpected error ({n}/5): RuntimeError(boom)\n"
+
+
+def _escalation():
+    """One guard cycle-error escalation line (matches _CYCLE_ESCALATION_RE)."""
+    return "  Guard cycle-error escalation: 5 consecutive cycle errors (0 deferred) — exiting for respawn (last: RuntimeError(boom)).\n"
+
+
+class TestC7RateWindow(unittest.TestCase):
+    """Rate-based storm detection: the rate-window path must fire before the flat-count.
+
+    T-1 (AC-1): multi-generation error storm masked by stale prunes must FLAG.
+    T-2 (AC-2a): single healthy daemon with scattered recovered errors must NOT flag.
+    T-3 (AC-2b): spread-out restarts across a day must NOT flag.
+    T-4 (AC-3): real f641174c fixture stays NOT flagged.
+    T-5 (edge): no-timestamp logs fall back to flat-count (no regression).
+    T-6 (edge): mixed parseable and None timestamps — anchor uses latest parseable.
+    """
+
+    def test_storm_flagged_stale_prunes_T1(self):
+        """T-1 (AC-1): 5 rapid respawns with error blocks inside 1h are a storm.
+
+        At base (flat-count only), the stale productive prunes from Gen 1 mask
+        the current error storm → NOT flagged (FN). After the rate-window fix,
+        recent_starts >= RATE_STORM_TRIP → flagged.
+
+        The flat-count FN arises because productive_prunes (35) > cycle_errors (25),
+        so the C7 branch doesn't fire. The rate path must fire first.
+        """
+        from datetime import datetime, timedelta
+        now = datetime(2026, 6, 10, 20, 0, 0)
+        # Gen 1: healthy, dead — 35 productive prune cycles, started 11h ago
+        gen1_ts = (now - timedelta(hours=11)).isoformat()
+        gen1 = _daemon_start(ts=gen1_ts)
+        gen1 += "".join(_good_cycle(n=i) for i in range(1, 36))  # 35 productive prunes
+
+        # Gen 2–6: current error storm — 5 rapid restarts, each with 5 error lines,
+        # all within 30 minutes of each other
+        storm = ""
+        for i in range(5):
+            storm_ts = (now - timedelta(minutes=30 - i * 5)).isoformat()
+            storm += _daemon_start(ts=storm_ts)
+            storm += "".join(_error_cycle(n=j) for j in range(1, 6))
+            storm += _escalation()
+
+        text = gen1 + storm
+        rep = scan_log_text(text)
+        # At base: productive_prunes=35 > cycle_errors=25 → NOT looping (FN)
+        # After fix: recent_starts=5 >= RATE_STORM_TRIP=5 → looping=True
+        self.assertTrue(rep.looping,
+                        "rate-based path must flag a storm of 5 rapid respawns "
+                        "even when stale prune lines outnumber errors in the window")
+        self.assertIn("storm", rep.reason)
+
+    def test_scattered_errors_not_flagged_T2(self):
+        """T-2 (AC-2a): single daemon, 21 scattered recovered errors, must NOT flag.
+
+        At base (flat-count): 21 >= 20 (loop_trip) AND 21 > 3 (productive_prunes)
+        → looping=True (FP). After the rate-window fix, recent_starts=1 <
+        RATE_STORM_TRIP=5 → rate path skips, flat-count doesn't fire because
+        we never reach the flat-count unless timestamps are absent or < 2.
+
+        Wait — the design is rate-FIRST: if recent_starts < trip, rate path skips
+        and falls through to flat-count. This means T-2 actually STILL hits the
+        flat-count. So the fix only resolves the FP if the rate path changes
+        behavior here. The rate-first approach alone doesn't fix T-2 unless the
+        rate path overrides or the flat-count is only used as fallback for
+        insufficient timestamps (< 2 parseable starts). RE-READ the design:
+
+        The fallback condition is: "if FEWER THAN 2 daemon-start timestamps parse,
+        fall through to the existing flat-count logic". With 1 daemon-start that
+        HAS a parseable timestamp, we have exactly 1 parseable timestamp.
+        1 < 2 → we ARE in the fallback zone → flat-count runs.
+
+        But the handoff says: "recent_starts=1 < RATE_STORM_TRIP=5 → not flagged".
+        The design intent is that 1 recent start means no storm.
+
+        The correct design: rate path runs when recent_starts is computed (any number
+        of parseable timestamps). If recent_starts < RATE_STORM_TRIP, rate path
+        says "not a storm" (does NOT flag). Then flat-count is NOT used at all when
+        timestamps are available. Flat-count is ONLY the fallback when < 2 parseable
+        timestamps exist (i.e., we can't compute a meaningful rate).
+
+        This means T-2 must NOT hit flat-count (because we have 1 parseable timestamp
+        and can compute recent_starts=1 < 5). The flat-count fallback threshold is
+        "< 2 parseable timestamps" not "recent_starts < trip".
+        """
+        from datetime import datetime, timedelta
+        now = datetime(2026, 6, 10, 10, 0, 0)
+        # Single daemon started 2h ago with a parseable ISO timestamp
+        text = _daemon_start(ts=(now - timedelta(hours=2)).isoformat())
+        text += "".join(_good_cycle(n=i) for i in range(1, 4))  # 3 productive prunes
+        # 21 error lines across 3 recovered streaks (7 per streak)
+        for streak in range(3):
+            text += "".join(_error_cycle(n=j) for j in range(1, 8))
+        rep = scan_log_text(text)
+        # At base: 21 >= 20 (loop_trip) AND 21 > 3 (productive_prunes) → looping=True (FP)
+        # After fix: recent_starts=1 < RATE_STORM_TRIP=5 → rate says "not a storm";
+        #            since we have >=1 parseable timestamp, flat-count fallback does NOT run
+        self.assertFalse(rep.looping,
+                         "a single daemon with scattered recovered errors must NOT be "
+                         "flagged — 1 daemon-start within the rate window is not a storm")
+
+    def test_spread_out_restarts_not_flagged_T3(self):
+        """T-3 (AC-2b): 6 restarts 4h apart across a day must NOT flag as a storm.
+
+        All 6 have parseable timestamps; total daemon_starts=6 > STORM_TRIP=5.
+        But recent_starts within the 1h window = 1 (only the last one).
+        Must NOT be flagged by rate path (not a storm in the temporal sense).
+        """
+        from datetime import datetime, timedelta
+        now = datetime(2026, 6, 10, 20, 0, 0)
+        parts = []
+        for i in range(6):
+            ts = (now - timedelta(hours=(5 - i) * 4)).isoformat()  # T-20h, T-16h, ..., T-0h
+            parts.append(_daemon_start(ts=ts))
+            parts.append(_error_cycle(n=1))  # one error per gen
+        text = "".join(parts)
+        rep = scan_log_text(text)
+        self.assertFalse(rep.looping,
+                         "spread-out restarts (4h apart) are not a storm — "
+                         "recent_starts within 1h window must be 1, not 6")
+
+    def test_real_fixture_unchanged_T4(self):
+        """T-4 (AC-3): real f641174c fixture must still NOT be flagged after the fix.
+
+        The fixture has 1 daemon-start with a parseable ISO timestamp.
+        recent_starts=1 < RATE_STORM_TRIP=5 → rate path does not flag.
+        Flat-count fallback does not run (>=1 parseable timestamp).
+        The futile-prune path owns this fixture (10 futile < 20 trip → NOT flagged).
+        """
+        text = (FIXTURES / "f641174c_reload_loop.log").read_text(encoding="utf-8")
+        rep = scan_log_text(text)
+        self.assertFalse(rep.looping,
+                         "f641174c real fixture: single K-exit run must remain NOT flagged")
+
+    def test_no_timestamp_fallback_to_flat_count_T5(self):
+        """T-5 (edge): log with no ISO timestamp in daemon-start header falls back to flat-count.
+
+        "--- Guard daemon started ---" (no "at <ISO>" part) → 0 parseable timestamps
+        → < 2 parseable timestamps → flat-count fallback runs.
+        25 error lines, 0 productive prunes → flat-count fires → looping=True.
+        """
+        # Daemon-start line WITHOUT the "at <ISO>" part
+        text = "--- Guard daemon started ---\nCWD: /x\n\n"
+        text += "".join(_error_cycle(n=j) for j in range(1, 26))  # 25 error lines
+        rep = scan_log_text(text)
+        self.assertTrue(rep.looping,
+                        "no-timestamp log must fall back to flat-count and flag 25 errors")
+
+    def test_mixed_timestamps_anchor_uses_latest_parseable_T6(self):
+        """T-6 (edge): if latest daemon-start has no ISO, anchor uses prior parseable ts.
+
+        Gen 1 at T-2h (parseable), Gen 2 at T-30min (parseable),
+        Gen 3 with no 'at <ISO>' suffix (None timestamp) → anchor=Gen 2 ts.
+        We need 5 daemon-starts within 1h. Use 5 starts close together + 1 no-ISO.
+        """
+        from datetime import datetime, timedelta
+        now = datetime(2026, 6, 10, 20, 0, 0)
+        parts = []
+        # 5 parseable starts within 30 min
+        for i in range(5):
+            ts = (now - timedelta(minutes=30 - i * 5)).isoformat()
+            parts.append(_daemon_start(ts=ts))
+            parts.append(_error_cycle(n=1))
+        # 1 no-ISO start at the very end (will be the latest in text position)
+        parts.append("--- Guard daemon started ---\nCWD: /x\n\n")
+        parts.append(_error_cycle(n=1))
+        text = "".join(parts)
+        rep = scan_log_text(text)
+        # Anchor = latest parseable = T-0min (5th parseable start)
+        # recent_starts = all 5 parseable starts within 30min <= 3600s → 5 >= 5 → storm
+        self.assertTrue(rep.looping,
+                        "with mixed timestamps, anchor uses latest parseable; "
+                        "5 starts within 1h must flag as a storm")
+        self.assertIn("storm", rep.reason)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -17,6 +17,7 @@ futile-churn DOMINANCE, exit or no exit.
 
 import signal
 import unittest
+from datetime import datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
@@ -56,6 +57,16 @@ def _respawn_storm(runs=23, per_run=10):
         out.append("  [15:43:58] Guard powerless against live-context dominance "
                     f"({per_run} consecutive 0-byte HARD prunes). Exiting.\n")
     return "".join(out)
+
+
+def _error_cycle(n=1):
+    """One guard error-skip line (no timestamp, matches _CYCLE_ERR_RE)."""
+    return f"  Guard: skipping a cycle after an unexpected error ({n}/5): RuntimeError(boom)\n"
+
+
+def _escalation():
+    """One guard cycle-error escalation line (matches _CYCLE_ESCALATION_RE)."""
+    return "  Guard cycle-error escalation: 5 consecutive cycle errors (0 deferred) — exiting for respawn (last: RuntimeError(boom)).\n"
 
 
 class TestRealFixture(unittest.TestCase):
@@ -304,16 +315,6 @@ class TestFixIdentityGate(unittest.TestCase):
         self.assertEqual(killed.get("sig"), signal.SIGTERM)
 
 
-def _error_cycle(n=1):
-    """One guard error-skip line (no timestamp, matches _CYCLE_ERR_RE)."""
-    return f"  Guard: skipping a cycle after an unexpected error ({n}/5): RuntimeError(boom)\n"
-
-
-def _escalation():
-    """One guard cycle-error escalation line (matches _CYCLE_ESCALATION_RE)."""
-    return "  Guard cycle-error escalation: 5 consecutive cycle errors (0 deferred) — exiting for respawn (last: RuntimeError(boom)).\n"
-
-
 class TestC7RateWindow(unittest.TestCase):
     """Rate-based storm detection: the rate-window path must fire before the flat-count.
 
@@ -335,7 +336,6 @@ class TestC7RateWindow(unittest.TestCase):
         The flat-count FN arises because productive_prunes (35) > cycle_errors (25),
         so the C7 branch doesn't fire. The rate path must fire first.
         """
-        from datetime import datetime, timedelta
         now = datetime(2026, 6, 10, 20, 0, 0)
         # Gen 1: healthy, dead — 35 productive prune cycles, started 11h ago
         gen1_ts = (now - timedelta(hours=11)).isoformat()
@@ -368,7 +368,6 @@ class TestC7RateWindow(unittest.TestCase):
         timestamp activates PATH A (rate-based): recent_starts=1 < RATE_STORM_TRIP=5
         → rate path is authoritative and returns not-a-storm, suppressing flat-count.
         """
-        from datetime import datetime, timedelta
         now = datetime(2026, 6, 10, 10, 0, 0)
         # Single daemon started 2h ago with a parseable ISO timestamp
         text = _daemon_start(ts=(now - timedelta(hours=2)).isoformat())
@@ -391,7 +390,6 @@ class TestC7RateWindow(unittest.TestCase):
         But recent_starts within the 1h window = 1 (only the last one).
         Must NOT be flagged by rate path (not a storm in the temporal sense).
         """
-        from datetime import datetime, timedelta
         now = datetime(2026, 6, 10, 20, 0, 0)
         parts = []
         for i in range(6):
@@ -421,7 +419,7 @@ class TestC7RateWindow(unittest.TestCase):
         """T-5 (edge): log with no ISO timestamp in daemon-start header falls back to flat-count.
 
         "--- Guard daemon started ---" (no "at <ISO>" part) → 0 parseable timestamps
-        → < 2 parseable timestamps → flat-count fallback runs.
+        → flat-count fallback runs (PATH B).
         25 error lines, 0 productive prunes → flat-count fires → looping=True.
         """
         # Daemon-start line WITHOUT the "at <ISO>" part
@@ -438,7 +436,6 @@ class TestC7RateWindow(unittest.TestCase):
         Gen 3 with no 'at <ISO>' suffix (None timestamp) → anchor=Gen 2 ts.
         We need 5 daemon-starts within 1h. Use 5 starts close together + 1 no-ISO.
         """
-        from datetime import datetime, timedelta
         now = datetime(2026, 6, 10, 20, 0, 0)
         parts = []
         # 5 parseable starts within 30 min

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -622,5 +622,98 @@ class TestC7EdgeCases(unittest.TestCase):
                         "5 starts including the boundary one must trigger storm detection")
 
 
+class TestC7DiagnosticAccuracy(unittest.TestCase):
+    """R3-1 + R3-3: rate-path reason accuracy and PATH A/B asymmetry characterization.
+
+    R3-1 (MED): a modern-format futile-prune storm (≥RATE_STORM_TRIP ISO starts,
+    zero cycle_errors) hits PATH A and returns looping=True, but the reason says
+    "error respawn storm" — wrong with 0 errors, and the accurate futile-prune
+    diagnosis is masked (the futile-prune branch never runs because PATH A returns
+    first). Fix: reason must be CAUSE-NEUTRAL ("respawn storm") and include the
+    futile count alongside the error/escalation signals.
+
+    R3-3 (characterization): a mixed-gen log (≥1 no-ISO start + 1 ISO start +
+    ≥loop_trip errors + 0 escalations) → looping=False (PATH A suppresses PATH B
+    the moment ANY timestamp parses). The SAME log with the ISO start stripped
+    (pure old-format, 0 parseable timestamps) → looping=True via PATH B.
+    Documents the known, scoped limitation so a future change is immediately visible.
+    """
+
+    def test_futile_prune_storm_reason_is_cause_neutral(self):
+        """R3-1 RED→GREEN: futile-prune modern storm reason must not say "error".
+
+        Build: 5 rapid ISO restarts within 30min, each generating futile prune cycles
+        but ZERO cycle_errors. PATH A fires (recent_starts=5 >= RATE_STORM_TRIP=5)
+        and returns looping=True. At HEAD the reason reads "error respawn storm"
+        (misleading with 0 errors). After fix: reason omits "error" from the storm
+        label and includes the futile-cycle count.
+
+        RED-at-HEAD evidence: assertNotIn("error respawn", rep.reason) FAILS because
+        reason = "5 guard restarts within a 60min window — error respawn storm …".
+        """
+        now = datetime(2026, 6, 10, 20, 0, 0)
+        parts = []
+        for i in range(5):
+            ts = (now - timedelta(minutes=30 - i * 5)).isoformat()
+            parts.append(_daemon_start(ts=ts))
+            # Each gen accrues futile prune cycles but NO error lines
+            parts.extend(_futile_cycle(n=j) for j in range(1, 4))  # 3 futile/gen
+        text = "".join(parts)
+        rep = scan_log_text(text)
+        # Precondition: PATH A must have fired
+        self.assertTrue(rep.looping,
+                        "5 rapid ISO-timestamped starts must trigger PATH A storm")
+        self.assertEqual(rep.cycle_errors, 0,
+                         "precondition: no error lines in this fixture")
+        self.assertGreater(rep.futile_cycles, 0,
+                           "precondition: futile prune cycles present")
+        # The storm reason must be cause-neutral (no bare "error" labeling the storm)
+        self.assertNotIn("error respawn", rep.reason,
+                         "reason must not say 'error respawn' when cycle_errors == 0; "
+                         "storm label must be cause-neutral (e.g. 'respawn storm')")
+        # And the reason must include the futile count so the operator gets actionable info
+        self.assertIn(str(rep.futile_cycles), rep.reason,
+                      "reason must include the futile cycle count for operator diagnosis")
+
+    def test_path_ab_asymmetry_characterization(self):
+        """R3-3 (characterization — documents a known scoped residual, not a bug).
+
+        Mixed-gen log: old-format start (no ISO) + modern start (1 ISO) +
+        ≥loop_trip errors + 0 escalations + 0 prunes.
+
+        PATH A is authoritative as soon as ANY timestamp parses. With recent_starts=1
+        < RATE_STORM_TRIP=5 and no escalation, PATH A does NOT flag — and PATH B is
+        suppressed. Result: looping=False.
+
+        The SAME log with the ISO start stripped (pure no-timestamp format, 0 parseable)
+        → recent_starts=0 → PATH B runs → cycle_errors=25 >= 20 AND 25 > 0 productive
+        → looping=True.
+
+        This asymmetry is a documented scoped limitation (see PR body + TODO.md):
+        PATH B is suppressed whenever ≥1 timestamp parses, including mixed-gen logs.
+        A non-escalated inert daemon on such a log is NOT flagged.
+        """
+        errors = "".join(_error_cycle(n=j) for j in range(1, 26))  # 25 errors, 0 escalations
+
+        # Mixed-gen: one no-ISO start + one ISO start
+        old_start = "--- Guard daemon started ---\nCWD: /x\n\n"
+        iso_start = _daemon_start(ts="2026-06-10T10:00:00")
+        mixed_text = old_start + iso_start + errors
+
+        rep_mixed = scan_log_text(mixed_text)
+        # PATH A is authoritative (1 parseable ts); recent_starts=1 < RATE_STORM_TRIP;
+        # 0 escalations → escalation gate does not fire → looping=False
+        self.assertFalse(rep_mixed.looping,
+                         "mixed-gen log (1 ISO start + no-ISO start, no escalation): "
+                         "PATH A suppresses PATH B — looping=False (known scoped residual)")
+
+        # Pure old-format: same errors, no ISO start → 0 parseable → PATH B runs
+        pure_old_text = old_start + errors
+        rep_old = scan_log_text(pure_old_text)
+        self.assertTrue(rep_old.looping,
+                        "pure old-format log (no ISO timestamps, 25 errors, 0 productive prunes): "
+                        "PATH B must flag → looping=True")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -456,5 +456,171 @@ class TestC7RateWindow(unittest.TestCase):
         self.assertIn("storm", rep.reason)
 
 
+class TestC7InertSingleGen(unittest.TestCase):
+    """C-1 + H-2: escalation-aware inert-guard detection inside PATH A.
+
+    The round-1 blanket flat-count suppression dropped a genuine inert-guard case:
+    a single modern-format daemon (1 ISO timestamp → parseable → PATH A) that has
+    fired ≥loop_trip errors AND issued a cycle-error escalation (deterministically
+    stuck, NOT a recovered transient) was incorrectly not flagged.
+
+    The discriminator: cycle_escalations >= 1 separates a truly stuck guard from one
+    that self-recovered (recovered daemons never escalate; escalation = the C2 path
+    that exits for respawn, confirming the errors were not transient).
+    """
+
+    def test_escalated_inert_single_gen_flagged(self):
+        """C-1 RED→GREEN: single modern-log daemon, ≥loop_trip errors + escalation → flag.
+
+        This is the case the round-1 code dropped: one ISO start → parseable=[1 ts] →
+        PATH A → recent_starts=1 < RATE_STORM_TRIP=5 → round-1 says not-a-storm and
+        returns (looping=False). But this daemon DID escalate — it's genuinely stuck.
+        """
+        now = datetime(2026, 6, 10, 12, 0, 0)
+        text = _daemon_start(ts=now.isoformat())
+        # 25 error-skip lines (>= loop_trip=20) followed by a cycle-error escalation
+        text += "".join(_error_cycle(n=j) for j in range(1, 26))
+        text += _escalation()
+        rep = scan_log_text(text)
+        # RED at HEAD: recent_starts=1 < 5 → PATH A returns not-a-storm → looping=False
+        # GREEN after: escalation gate catches it → looping=True
+        self.assertTrue(rep.looping,
+                        "a single escalated inert daemon (>=loop_trip errors + escalation) "
+                        "must be flagged even with only 1 recent daemon start")
+        self.assertIn("inert", rep.reason)
+        self.assertIn("escalat", rep.reason)
+
+    def test_recovered_daemon_not_flagged(self):
+        """C-1 preservation: single daemon, ≥loop_trip errors, 0 escalations → NOT flag.
+
+        This is the FP case the rate-window was designed to fix (T-2 from round 1):
+        a daemon that self-recovered from transient errors never escalates.
+        Must stay not-flagged after adding the escalation gate.
+        (characterization — preservation criterion; green at HEAD and after)
+        """
+        now = datetime(2026, 6, 10, 10, 0, 0)
+        text = _daemon_start(ts=(now - timedelta(hours=2)).isoformat())
+        text += "".join(_good_cycle(n=i) for i in range(1, 4))  # 3 productive prunes
+        # 21 error lines, 0 escalations (transient, self-recovered)
+        for _ in range(3):
+            text += "".join(_error_cycle(n=j) for j in range(1, 8))
+        rep = scan_log_text(text)
+        self.assertFalse(rep.looping,
+                         "a recovered daemon (no escalation) must NOT be flagged — "
+                         "escalation is the discriminator for genuine stuckness")
+
+
+class TestC7SlideWindow(unittest.TestCase):
+    """C-2: sliding-window anchor robustness and regex line-anchoring.
+
+    The round-1 max() anchor is defeated by a single forged future timestamp:
+    6 genuine restarts within 1h + 1 injected far-future (2099) start → the
+    max() anchor becomes 2099; (2099 - real_ts) >> RATE_WINDOW_S → recent_starts=1
+    → storm not flagged (FN).
+
+    Fix: replace max()-anchored window with max restarts in ANY sliding window of
+    RATE_WINDOW_S seconds (sort timestamps, for each t_i count t_j in [t_i, t_i+W]).
+    A single outlier forms its own window of 1 — can't inflate the real storm count.
+
+    Fix 2: line-anchor _DAEMON_START_RE (re.MULTILINE + leading-whitespace pattern)
+    so a forged "Guard daemon started at <ISO>" substring embedded MID-LINE (e.g.
+    inside a team-name log entry) does NOT count as a daemon restart.
+    """
+
+    def test_future_timestamp_injection_still_flags_storm(self):
+        """C-2a RED→GREEN: genuine 6-restart storm + injected far-future start → still FLAG.
+
+        Round-1 max() anchor: anchor=2099 → (2099 - 2026_ts) > RATE_WINDOW_S → 0 in window.
+        Sliding-window fix: the 6 genuine 2026 starts cluster within 30min → window of 6.
+        """
+        now = datetime(2026, 6, 10, 20, 0, 0)
+        parts = []
+        # 6 genuine restarts within 30 min
+        for i in range(6):
+            ts = (now - timedelta(minutes=30 - i * 5)).isoformat()
+            parts.append(_daemon_start(ts=ts))
+            parts.append(_error_cycle(n=1))
+        # 1 injected far-future start (e.g. from a forged log line)
+        parts.append(_daemon_start(ts="2099-01-01T00:00:00"))
+        parts.append(_error_cycle(n=1))
+        text = "".join(parts)
+        rep = scan_log_text(text)
+        # RED at HEAD: max()=2099 → real starts outside window → looping=False
+        # GREEN after: sliding window finds 6 genuine starts in 30min → looping=True
+        self.assertTrue(rep.looping,
+                        "a genuine 6-restart storm must be flagged even with an injected "
+                        "far-future daemon-start timestamp that defeats max()-anchoring")
+        self.assertIn("storm", rep.reason)
+
+    def test_midline_forged_header_not_counted(self):
+        """C-2b RED→GREEN: daemon-start substring MID-LINE must not be counted as a restart.
+
+        The real guard log format is "--- Guard daemon started at <ISO> ---" at the
+        START of a line. A forged substring embedded inside another log line (e.g. a
+        team-name that contains "Guard daemon started at 2026-...") must NOT match.
+        """
+        # This is a single, valid modern daemon start
+        now = datetime(2026, 6, 10, 12, 0, 0)
+        text = _daemon_start(ts=now.isoformat())
+        # 5 forged mid-line occurrences — embedded in log lines that are NOT line-starts
+        for i in range(5):
+            fake_ts = (now - timedelta(minutes=i * 5)).isoformat()
+            # Embedded inside a line that starts with something else (team name, etc.)
+            text += f"  [12:00:00] Team 'Guard daemon started at {fake_ts}' state preserved\n"
+        text += "".join(_error_cycle(n=j) for j in range(1, 6))
+        rep = scan_log_text(text)
+        # With line-anchoring: daemon_starts=1 (only the real start), recent_starts=1
+        # Without line-anchoring: daemon_starts=6, recent_starts may reach RATE_STORM_TRIP
+        self.assertEqual(rep.daemon_starts, 1,
+                         "mid-line forged 'Guard daemon started' substrings must not be "
+                         "counted as daemon restarts (line-anchor required)")
+        self.assertFalse(rep.looping,
+                         "mid-line forged headers must not trigger a storm false-positive")
+
+
+class TestC7EdgeCases(unittest.TestCase):
+    """M-1 (tz robustness) + M-3 (boundary-inclusive window) + T-3/T-4/T-5 docstring note."""
+
+    def test_timezone_aware_timestamp_treated_as_unparseable(self):
+        """M-1: a tz-aware ISO timestamp (+02:00 suffix) must not crash; treated as None.
+
+        datetime.fromisoformat on Python 3.11+ accepts tz-aware strings and returns a
+        tz-aware datetime. Mixing tz-aware + naive datetimes in max()/subtraction
+        raises TypeError. Guard: strip or treat tz-aware as unparseable (None → fallback).
+        """
+        now = datetime(2026, 6, 10, 12, 0, 0)
+        text = _daemon_start(ts=now.isoformat())  # one valid naive start
+        # One tz-aware ISO timestamp — must not crash scan_log_text
+        text += "--- Guard daemon started at 2026-06-10T12:00:00+02:00 ---\nCWD: /y\n\n"
+        text += "".join(_error_cycle(n=j) for j in range(1, 5))
+        # Must not raise; daemon_starts=2, but tz-aware counts as None (not parseable)
+        rep = scan_log_text(text)
+        self.assertEqual(rep.daemon_starts, 2)
+        self.assertFalse(rep.looping,
+                         "tz-aware timestamp must be handled gracefully (not crash)")
+
+    def test_window_boundary_inclusive(self):
+        """M-3: a start exactly RATE_WINDOW_S seconds before the anchor still counts.
+
+        The window is inclusive: (anchor - dt).total_seconds() <= RATE_WINDOW_S.
+        A start exactly 3600s old must be counted, not dropped.
+        """
+        anchor_ts = datetime(2026, 6, 10, 20, 0, 0)
+        # 4 starts within the last 30min
+        parts = [_daemon_start(ts=(anchor_ts - timedelta(minutes=i * 5)).isoformat())
+                 for i in range(4)]
+        # 1 start exactly RATE_WINDOW_S=3600s before anchor (boundary — must count)
+        boundary_ts = anchor_ts - timedelta(seconds=RATE_WINDOW_S)
+        parts.append(_daemon_start(ts=boundary_ts.isoformat()))
+        # Together: 5 starts including the boundary one → should flag
+        text = "".join(parts) + "".join(_error_cycle(n=j) for j in range(1, 5))
+        rep = scan_log_text(text)
+        self.assertEqual(rep.recent_starts, 5,
+                         "a start exactly RATE_WINDOW_S seconds before the anchor "
+                         "must be included (boundary is inclusive)")
+        self.assertTrue(rep.looping,
+                        "5 starts including the boundary one must trigger storm detection")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -24,6 +24,7 @@ from unittest import mock
 from cozempic.watchdog import (
     scan_log_text, scan_guard_logs,
     FUTILE_PCT_FLOOR, LOOP_TRIP_DEFAULT, BACKOFF_CAP_S, STORM_TRIP,
+    RATE_WINDOW_S, RATE_STORM_TRIP,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "guard_logs"
@@ -362,35 +363,10 @@ class TestC7RateWindow(unittest.TestCase):
     def test_scattered_errors_not_flagged_T2(self):
         """T-2 (AC-2a): single daemon, 21 scattered recovered errors, must NOT flag.
 
-        At base (flat-count): 21 >= 20 (loop_trip) AND 21 > 3 (productive_prunes)
-        → looping=True (FP). After the rate-window fix, recent_starts=1 <
-        RATE_STORM_TRIP=5 → rate path skips, flat-count doesn't fire because
-        we never reach the flat-count unless timestamps are absent or < 2.
-
-        Wait — the design is rate-FIRST: if recent_starts < trip, rate path skips
-        and falls through to flat-count. This means T-2 actually STILL hits the
-        flat-count. So the fix only resolves the FP if the rate path changes
-        behavior here. The rate-first approach alone doesn't fix T-2 unless the
-        rate path overrides or the flat-count is only used as fallback for
-        insufficient timestamps (< 2 parseable starts). RE-READ the design:
-
-        The fallback condition is: "if FEWER THAN 2 daemon-start timestamps parse,
-        fall through to the existing flat-count logic". With 1 daemon-start that
-        HAS a parseable timestamp, we have exactly 1 parseable timestamp.
-        1 < 2 → we ARE in the fallback zone → flat-count runs.
-
-        But the handoff says: "recent_starts=1 < RATE_STORM_TRIP=5 → not flagged".
-        The design intent is that 1 recent start means no storm.
-
-        The correct design: rate path runs when recent_starts is computed (any number
-        of parseable timestamps). If recent_starts < RATE_STORM_TRIP, rate path
-        says "not a storm" (does NOT flag). Then flat-count is NOT used at all when
-        timestamps are available. Flat-count is ONLY the fallback when < 2 parseable
-        timestamps exist (i.e., we can't compute a meaningful rate).
-
-        This means T-2 must NOT hit flat-count (because we have 1 parseable timestamp
-        and can compute recent_starts=1 < 5). The flat-count fallback threshold is
-        "< 2 parseable timestamps" not "recent_starts < trip".
+        At base (flat-count): cycle_errors=21 >= loop_trip=20 AND 21 > 3 (productive)
+        → looping=True (FP). After the rate-window fix, the single parseable ISO
+        timestamp activates PATH A (rate-based): recent_starts=1 < RATE_STORM_TRIP=5
+        → rate path is authoritative and returns not-a-storm, suppressing flat-count.
         """
         from datetime import datetime, timedelta
         now = datetime(2026, 6, 10, 10, 0, 0)


### PR DESCRIPTION
## Problem

`guard-watchdog`'s C7 "erroring/inert-guard" detector classified a respawn/error storm from a flat 256 KB append-mode log tail, with no recency or rate awareness. As noted in #140, every flat-count rule had a residual in one direction or the other because the tail mixes generations:

- **False-negative:** a *current* error storm masked when stale productive-prune lines from an earlier (dead, healthy) generation still in the window outnumber the errors.
- **False-positive:** a long-lived *healthy* daemon that self-recovered ≥ `loop_trip` scattered transient errors (streak reset each time, never escalated), with its productive prunes scrolled out of the window, flagged as inert.

## Fix

`scan_log_text` (watchdog.py) now keys the verdict on **restart rate within a time window**, using the ISO timestamps on `--- Guard daemon started at <ISO> ---` lines (PATH A), and keeps the original flat-count as a fallback for timestamp-less old logs (PATH B):

- **Rate storm** — the maximum daemon restarts in *any* `RATE_WINDOW_S = 3600`-second **sliding window** ≥ `RATE_STORM_TRIP = 5`. A sliding window (rather than anchoring on `max(timestamps)`) is robust to a forged/implausible future-or-past timestamp: a lone outlier forms its own window of size 1 and cannot mask a genuine restart cluster. This is the literal "many restarts close together in time" definition from the issue.
- **Escalation-aware inert** — when it isn't a storm, a single generation that *escalated* (`cycle_escalations ≥ 1`) with ≥ `loop_trip` per-cycle errors and `errors > productive_prunes` is flagged as genuinely stuck. A recovered-healthy daemon (never escalated) is **not** flagged — that's the FP fix, using the "never escalated" discriminator from the issue.
- `_DAEMON_START_RE` is **line-anchored** (same defence class as `_PRUNED_RE`) so a mid-line forged `--- Guard daemon started at <ISO> ---` substring (e.g. inside a team-name log line) can't register as a restart.
- Tz-aware timestamps are treated as unparseable (the guard emits naive local time; a tz-aware result is forged/unexpected) — this avoids a naive-vs-aware comparison `TypeError`.
- The storm reason string is **cause-neutral** ("respawn storm (rate-based)") and reports per-cycle errors, futile prune cycles, and escalations, so a futile-prune storm on a modern log isn't mislabelled as an "error" storm.
- The **futile-prune branch is byte-identical** to before (verified).

## Tests

`tests/test_guard_watchdog.py` — 14 new tests covering: storm-flagged-despite-stale-prunes (FN), scattered-recovery-not-flagged (FP), spread-out-restarts-not-flagged, the real `f641174c` fixture preserved, no-timestamp flat-count fallback, escalated-inert-flagged, forged-future-timestamp-still-flags-storm, midline-forged-header-excluded, tz-aware-treated-as-unparseable, inclusive-window-boundary, cause-neutral-reason, and a characterization test pinning the PATH A/PATH B asymmetry.

Full suite: **1601 passed, 0 related failures** (`--ignore=tests/test_model_detection.py`). One unrelated pre-existing concurrency test (`test_guard_hardening.py::TestG4_PidfileWriteIsAtomic::test_concurrent_starts_only_one_spawn_wins`) is load-flaky under full-suite CPU contention — passes 3/3 in isolation and at this PR's base; the diff does not touch spawn/pidfile code.

## Scope / known limitations (documented, not silently dropped)

- **Deferred residual:** PATH A flags a single-generation inert daemon *only if it escalated*. A non-escalated inert daemon on a modern or mixed-generation log is not flagged (the moment ≥1 timestamp parses, the flat-count PATH B is suppressed). Reachable via non-consecutive errors (no C2 escalation), an external kill before escalation, the agents-active escalation deferral (`GUARD_CYCLE_ERROR_DEFER_MAX`), or a mixed-generation log. This is pinned by a characterization test. A recency-anchored / escalation-independent inert signal would close it — happy to do a focused follow-up if you'd like single-generation inert parity on modern logs.
- The sliding window detects storms anywhere in the visible 256 KB tail; a recently-resolved storm can still flag until its start-lines scroll out of the window (the detector is a pure function with no wall-clock "now"). The bounded tail is the recency mechanism.

Base: `main` @ v1.8.33.

Closes #140.
