### PR TITLE
fix(#147): repair torn trailing line so guard reload can't brick claude --resume

### DIFF
--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1397,6 +1397,79 @@ def fix_zombie_teams() -> str:
 # ─── Registry ────────────────────────────────────────────────────────────────
 
 # (name, check_fn, fix_fn_or_None)
+def _has_torn_trailing_line(path: Path) -> bool:
+    """True if the session's last non-empty line is not valid JSON — a torn
+    write left when the writer was killed mid-append, which makes
+    ``claude --resume`` fail to parse the transcript (#147). Read-only."""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="surrogateescape")
+    except OSError:
+        return False
+    lines = raw.splitlines()
+    last = next((i for i in range(len(lines) - 1, -1, -1) if lines[i].strip()), None)
+    if last is None or last == 0:
+        return False  # empty file, or a single torn line we won't blank out
+    try:
+        json.loads(lines[last])
+        return False
+    except (ValueError, json.JSONDecodeError):
+        return True
+
+
+def check_unresumable_session() -> CheckResult:
+    """Check for sessions with a torn trailing line that breaks ``claude --resume``.
+
+    A process killed mid-append (e.g. a guard terminate-first reload that
+    SIGTERM'd Claude Code mid-line) leaves a partial last line. Claude then
+    can't parse the transcript: ``Failed to resume session <id>``. The torn line
+    is data the writer never finished, so dropping it is safe and restores
+    resume. Ref: Ruya-AI/cozempic#147.
+    """
+    sessions = find_sessions()
+    torn = []
+    for sess in sessions:
+        try:
+            if _has_torn_trailing_line(sess["path"]):
+                torn.append(sess)
+        except (OSError, UnicodeDecodeError):
+            continue
+
+    if not torn:
+        return CheckResult(
+            name="unresumable-session",
+            status="ok",
+            message=f"No sessions with a torn trailing line ({len(sessions)} checked)",
+        )
+
+    details = ", ".join(f"{s['session_id'][:8]}…" for s in torn[:5])
+    return CheckResult(
+        name="unresumable-session",
+        status="issue",
+        message=(
+            f"{len(torn)} session(s) with a torn trailing line: {details}. "
+            f"These fail `claude --resume` (#147)."
+        ),
+        fix_description="Drop the torn trailing line so the session resumes (a .torn.bak is kept)",
+    )
+
+
+def fix_unresumable_session() -> str:
+    """Repair sessions with a torn trailing line (drops the partial last line)."""
+    from .session import repair_torn_trailing_line
+
+    sessions = find_sessions()
+    repaired = 0
+    for sess in sessions:
+        try:
+            if _has_torn_trailing_line(sess["path"]) and repair_torn_trailing_line(sess["path"]):
+                repaired += 1
+        except (OSError, UnicodeDecodeError):
+            continue
+    if repaired == 0:
+        return "No torn trailing lines to repair."
+    return f"Repaired {repaired} session(s) (torn trailing line dropped; .torn.bak kept)."
+
+
 ALL_CHECKS: list[tuple[str, callable, callable | None]] = [
     ("trust-dialog-hang", check_trust_dialog_hang, fix_trust_dialog_hang),
     ("hooks-trust-flag", check_hooks_trust_flag, fix_hooks_trust_flag),
@@ -1406,6 +1479,7 @@ ALL_CHECKS: list[tuple[str, callable, callable | None]] = [
     ("claude-json-corruption", check_claude_json_corruption, fix_claude_json_corruption),
     ("corrupted-tool-use", check_corrupted_tool_use, fix_corrupted_tool_use),
     ("orphaned-tool-results", check_orphaned_tool_results, fix_orphaned_tool_results),
+    ("unresumable-session", check_unresumable_session, fix_unresumable_session),
     ("zombie-teams", check_zombie_teams, fix_zombie_teams),
     ("agent-model-mismatch", check_agent_model_mismatch, None),
     ("oversized-sessions", check_oversized_sessions, None),

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -213,6 +213,7 @@ from .session import (
     load_messages,
     load_messages_and_snapshot,
     load_messages_incremental,
+    repair_torn_trailing_line,
     save_messages,
     snapshot_session,
 )
@@ -1842,6 +1843,20 @@ def guard_prune_cycle(
     # full file — safe). Invoked by _terminate_and_resume after _wait_for_exit.
     _write_holder = {"backup": None, "written": False, "error": None}
 
+    def _repair_after_terminate():
+        """#147: when the deferred write is skipped (conflict) or fails, the
+        on-disk file is the one Claude held — and a terminate-first reload may
+        have SIGTERM'd Claude mid-append, leaving a torn trailing line that makes
+        ``claude --resume`` fail. We don't rewrite the file (per #106), but we DO
+        repair a single torn trailing line so the resume the guard is about to
+        trigger can actually succeed. Fully exception-isolated."""
+        try:
+            if repair_torn_trailing_line(session_path):
+                print(f"  [{_now()}] Repaired a torn trailing line for resume (#147).",
+                      file=sys.stderr)
+        except Exception:
+            pass
+
     def _write_pruned_after_exit():
         try:
             with _PruneLock(session_path):
@@ -1870,6 +1885,7 @@ def guard_prune_cycle(
         except (PruneConflictError, PruneLockError) as exc:
             _write_holder["error"] = "conflict"
             print(f"  [{_now()}] Deferred prune write skipped — {exc}", file=sys.stderr)
+            _repair_after_terminate()
         except OSError as exc:
             _write_holder["error"] = "oserror"
             # Disk-full / EIO / permission at the post-kill write instant. The
@@ -1880,6 +1896,7 @@ def guard_prune_cycle(
             # daemon, leaving Claude killed-but-not-resumed. Contain it: leave the
             # full file for resume (written stays False) and let the reload proceed.
             print(f"  [{_now()}] Deferred prune write failed ({exc}) — resuming from full file.", file=sys.stderr)
+            _repair_after_terminate()
 
     result = {
         "saved_mb": saved_bytes / 1024 / 1024,

--- a/src/cozempic/receipts.py
+++ b/src/cozempic/receipts.py
@@ -80,7 +80,9 @@ def _append_line(path: Path, line: str) -> None:
     any unparseable line and the prune itself is never affected.
     """
     data = (line + "\n").encode("utf-8")
-    fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    # 0o600: receipts are de-identified but still local provenance — keep them
+    # user-only so another local user on a shared host can't read them.
+    fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
     try:
         os.write(fd, data)
     finally:
@@ -95,6 +97,10 @@ def write_receipt(receipt: dict, *, base_dir: Path | None = None) -> Path | None
     try:
         directory = receipts_dir(base_dir)
         directory.mkdir(parents=True, exist_ok=True)
+        try:
+            directory.chmod(0o700)  # user-only (best-effort; harmless if unsupported)
+        except OSError:
+            pass
         path = directory / f"{_session_stem(receipt)}.jsonl"
         _append_line(path, serialize_receipt(receipt))
         _append_index(directory, receipt)

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -1147,6 +1147,57 @@ def save_messages(
     return backup_path
 
 
+def repair_torn_trailing_line(path: Path) -> bool:
+    """Make a session resumable after a writer was killed mid-append.
+
+    If the file's last non-empty line is not valid JSON — the signature of a
+    write torn off when Claude Code was SIGTERM'd mid-line (e.g. by a guard
+    terminate-first reload), which makes ``claude --resume`` fail to parse the
+    transcript — atomically drop that ONE line so the file parses again. The
+    torn line is data the writer never finished flushing, so it is already
+    unrecoverable; removing it is strictly safe and strictly improves resume.
+
+    Conservative by design:
+      * Only a SINGLE torn trailing line is removed (Claude appends one line at
+        a time, so only the in-flight line can be torn).
+      * If the last line is valid JSON, nothing changes (corruption — if any —
+        is elsewhere, and this helper must never mask a deeper problem).
+      * A file whose ONLY line is torn is left untouched (blanking it can't help
+        resume and would be needlessly destructive).
+      * A ``.torn.bak`` copy of the original is written first (best-effort).
+
+    Returns True iff a repair was written. Never raises.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8", errors="surrogateescape")
+    except OSError:
+        return False
+    if not raw:
+        return False
+    lines = raw.splitlines()
+    last = next((i for i in range(len(lines) - 1, -1, -1) if lines[i].strip()), None)
+    if last is None:
+        return False
+    try:
+        json.loads(lines[last])
+        return False  # trailing line parses → nothing torn to repair
+    except (ValueError, json.JSONDecodeError):
+        pass
+    kept = lines[:last]  # drop the torn line (and any trailing blank lines)
+    if not kept:
+        return False  # only line is torn — don't blank the file
+    try:
+        from .helpers import atomic_write_text
+        try:
+            shutil.copy2(path, path.with_suffix(path.suffix + ".torn.bak"))
+        except OSError:
+            pass
+        atomic_write_text(path, "\n".join(kept) + "\n", errors="surrogateescape")
+        return True
+    except Exception:
+        return False
+
+
 def cleanup_old_backups(session_path: Path, keep: int = 3) -> int:
     """Delete old timestamped .jsonl.bak files for this session, keeping the newest `keep`.
 

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -50,6 +50,16 @@ class TestWriteReceipt(unittest.TestCase):
     def tearDown(self):
         self._patch.stop()
 
+    def test_receipt_files_and_dir_are_user_only(self):
+        # de-identified but local provenance — must not be world-readable on a
+        # shared host (receipt file 0o600, receipts dir 0o700).
+        import stat
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _emit(tmp)
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode) & 0o077, 0)  # no group/other
+            self.assertEqual(stat.S_IMODE(path.parent.stat().st_mode) & 0o077, 0)
+
     def test_emit_creates_session_file_and_index(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = _emit(tmp)

--- a/tests/test_resume_torn_line.py
+++ b/tests/test_resume_torn_line.py
@@ -168,6 +168,47 @@ class TestGuardRepairsOnTerminate(unittest.TestCase):
             json.loads(l)
         self.assertEqual(len(lines), 2)
 
+    def test_oserror_skip_repairs_torn_line(self):
+        # the OSError branch (disk-full/EIO at the post-kill write) also leaves
+        # Claude's file in place -> it must repair the torn line too, and must
+        # not raise (it runs after terminate, before the resume watcher spawns).
+        from cozempic.guard import guard_prune_cycle
+        from cozempic.team import TeamState
+        from types import SimpleNamespace
+
+        team = MagicMock(spec=TeamState)
+        team.is_empty.return_value = True
+        team.team_name = None
+        team.message_count = 0
+        orig = [(0, {"type": "user"}, 100_000)]
+        pruned = [(0, {"type": "user"}, 40_000)]
+        totals = iter([100_000, 40_000])
+
+        def est(*a, **k):
+            try:
+                t = next(totals)
+            except StopIteration:
+                t = 40_000
+            return SimpleNamespace(total=t, context_pct=0.0, method="exact",
+                                   confidence="high", model="claude-opus-4-8", context_window=200000)
+
+        with patch("cozempic.guard._guard_tmp_root", return_value=self.tmp), \
+                patch("cozempic.guard.load_messages_and_snapshot", return_value=(orig, MagicMock())), \
+                patch("cozempic.guard.load_messages", return_value=orig), \
+                patch("cozempic.guard.prune_with_team_protect", return_value=(pruned, [], team)), \
+                patch("cozempic.guard.snapshot_session", return_value=MagicMock()), \
+                patch("cozempic.tokens.estimate_session_tokens", side_effect=est), \
+                patch("cozempic.tokens.calibrate_ratio", return_value=0.5), \
+                patch("cozempic.guard.save_messages", side_effect=OSError("disk full")):
+            result = guard_prune_cycle(session_path=self.session, rx_name="gentle",
+                                       config=None, auto_reload=False)
+            result.get("_deferred_writer")()  # OSError -> skip write -> repair, must not raise
+
+        lines = self.session.read_text().splitlines()
+        for l in lines:
+            json.loads(l)
+        self.assertEqual(len(lines), 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resume_torn_line.py
+++ b/tests/test_resume_torn_line.py
@@ -1,0 +1,173 @@
+"""#147: torn-trailing-line repair — shared helper, guard reload path, doctor check."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from cozempic.session import repair_torn_trailing_line
+
+
+def _write(path, lines):
+    path.write_text("".join(l + "\n" for l in lines), encoding="utf-8")
+
+
+def _valid(uuid, parent=None):
+    return json.dumps({"type": "user", "uuid": uuid, "parentUuid": parent,
+                       "message": {"role": "user", "content": "hi"}})
+
+
+class TestRepairHelper(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="cz147_"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_drops_torn_trailing_line(self):
+        p = self.tmp / "s.jsonl"
+        _write(p, [_valid("a"), _valid("b", "a"), '{"type":"user","uuid":"c","par'])  # torn
+        self.assertTrue(repair_torn_trailing_line(p))
+        lines = p.read_text().splitlines()
+        self.assertEqual(len(lines), 2)  # torn line dropped
+        for l in lines:
+            json.loads(l)  # all remaining lines valid -> resumable
+        # original preserved as .torn.bak
+        self.assertTrue((self.tmp / "s.jsonl.torn.bak").exists())
+
+    def test_noop_when_last_line_valid(self):
+        p = self.tmp / "s.jsonl"
+        _write(p, [_valid("a"), _valid("b", "a")])
+        before = p.read_text()
+        self.assertFalse(repair_torn_trailing_line(p))  # nothing torn
+        self.assertEqual(p.read_text(), before)  # untouched
+        self.assertFalse((self.tmp / "s.jsonl.torn.bak").exists())
+
+    def test_does_not_blank_single_torn_line(self):
+        p = self.tmp / "s.jsonl"
+        _write(p, ['{"torn'])  # only line is torn
+        self.assertFalse(repair_torn_trailing_line(p))  # too destructive -> leave it
+        self.assertTrue(p.read_text())  # not blanked
+
+    def test_tolerates_trailing_blank_lines_after_torn(self):
+        p = self.tmp / "s.jsonl"
+        p.write_text(_valid("a") + "\n" + '{"torn' + "\n\n", encoding="utf-8")
+        self.assertTrue(repair_torn_trailing_line(p))
+        self.assertEqual(p.read_text().splitlines(), [_valid("a")])
+
+    def test_missing_file_returns_false(self):
+        self.assertFalse(repair_torn_trailing_line(self.tmp / "nope.jsonl"))
+
+    def test_empty_file_returns_false(self):
+        p = self.tmp / "e.jsonl"
+        p.write_text("")
+        self.assertFalse(repair_torn_trailing_line(p))
+
+
+class TestDoctorUnresumable(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="cz147d_"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _session(self, name, lines):
+        p = self.tmp / name
+        _write(p, lines)
+        return {"session_id": name.replace(".jsonl", ""), "path": p}
+
+    def test_check_flags_and_fix_repairs(self):
+        from cozempic import doctor
+
+        torn = self._session("aaaaaaaa-torn.jsonl", [_valid("a"), '{"type":"user","par'])
+        clean = self._session("bbbbbbbb-ok.jsonl", [_valid("x")])
+        with patch.object(doctor, "find_sessions", return_value=[torn, clean]):
+            res = doctor.check_unresumable_session()
+            self.assertEqual(res.status, "issue")
+            self.assertIn("aaaaaaaa", res.message)
+            msg = doctor.fix_unresumable_session()
+            self.assertIn("Repaired 1", msg)
+            # re-check is clean now
+            self.assertEqual(doctor.check_unresumable_session().status, "ok")
+        # clean session untouched (no .torn.bak)
+        self.assertFalse((self.tmp / "bbbbbbbb-ok.jsonl.torn.bak").exists())
+
+    def test_check_ok_when_all_clean(self):
+        from cozempic import doctor
+
+        s = self._session("cccccccc.jsonl", [_valid("a"), _valid("b", "a")])
+        with patch.object(doctor, "find_sessions", return_value=[s]):
+            self.assertEqual(doctor.check_unresumable_session().status, "ok")
+
+    def test_registered_in_all_checks(self):
+        from cozempic import doctor
+
+        names = [n for n, _, _ in doctor.ALL_CHECKS]
+        self.assertIn("unresumable-session", names)
+        # it has a fix fn wired
+        fix = dict((n, f) for n, _, f in doctor.ALL_CHECKS)["unresumable-session"]
+        self.assertIsNotNone(fix)
+
+
+class TestGuardRepairsOnTerminate(unittest.TestCase):
+    """The guard's deferred-write conflict path repairs a torn trailing line."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="cz147g_"))
+        self.session = self.tmp / "fake.jsonl"
+        # a clean file + a torn trailing line, simulating Claude killed mid-append
+        self.session.write_text(_valid("a") + "\n" + _valid("b", "a") + "\n"
+                                + '{"type":"user","uuid":"c","par', encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_conflict_skip_repairs_torn_line(self):
+        from cozempic.guard import guard_prune_cycle
+        from cozempic.session import PruneConflictError
+        from cozempic.team import TeamState
+        from types import SimpleNamespace
+
+        team = MagicMock(spec=TeamState)
+        team.is_empty.return_value = True
+        team.team_name = None
+        team.message_count = 0
+        orig = [(0, {"type": "user"}, 100_000)]
+        pruned = [(0, {"type": "user"}, 40_000)]
+        totals = iter([100_000, 40_000])
+
+        def est(*a, **k):
+            try:
+                t = next(totals)
+            except StopIteration:
+                t = 40_000
+            return SimpleNamespace(total=t, context_pct=0.0, method="exact",
+                                   confidence="high", model="claude-opus-4-8", context_window=200000)
+
+        with patch("cozempic.guard._guard_tmp_root", return_value=self.tmp), \
+                patch("cozempic.guard.load_messages_and_snapshot", return_value=(orig, MagicMock())), \
+                patch("cozempic.guard.load_messages", return_value=orig), \
+                patch("cozempic.guard.prune_with_team_protect", return_value=(pruned, [], team)), \
+                patch("cozempic.guard.snapshot_session", return_value=MagicMock()), \
+                patch("cozempic.tokens.estimate_session_tokens", side_effect=est), \
+                patch("cozempic.tokens.calibrate_ratio", return_value=0.5), \
+                patch("cozempic.guard.save_messages", side_effect=PruneConflictError("changed")):
+            result = guard_prune_cycle(session_path=self.session, rx_name="gentle",
+                                       config=None, auto_reload=False)
+            writer = result.get("_deferred_writer")
+            self.assertIsNotNone(writer)
+            writer()  # conflict -> skip write -> repair torn line
+
+        # the torn trailing line is gone; the file is now fully parseable
+        lines = self.session.read_text().splitlines()
+        for l in lines:
+            json.loads(l)
+        self.assertEqual(len(lines), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #147 — the highest-priority data-loss class.

## Root cause
A guard terminate-first reload SIGTERMs Claude Code. If Claude was **mid-append**, it leaves a **torn/partial trailing JSON line**. The deferred writer then snapshot-conflicts (file changed) and — per the #106 invariant — **skips the write**, leaving Claude's file in place. Nothing repaired the torn line, so `claude --resume` could no longer parse the transcript: *"Failed to resume session."* cozempic's prune logic is sound (validation aborts a bad prune); it's the **terminate** that leaves the torn line.

## Fix
- **`session.repair_torn_trailing_line()`** — atomically drops a single torn trailing line (data the writer never finished → already unrecoverable; dropping it strictly improves resumability). Conservative: no-op if the last line is valid JSON; won't blank a file whose only line is torn; keeps a `.torn.bak`; never raises.
- **Guard** calls it on the deferred-write conflict/oserror branches (the cases that leave Claude's file), before the resume it triggers.
- **Doctor** new `unresumable-session` check + `--fix` so anyone who already hit this recovers in one command (`cozempic doctor --fix`).

## Safety
- Only ever drops a provably-unparseable trailing line — never a valid line, never violates #106.
- Fully exception-isolated in the guard's post-terminate cycle.
- Fleet-reviewed (5 dimensions, adversarial verify): data-safety / guard-cycle-safety / edge-cases found nothing; 2 low follow-ups (OSError-branch test + receipt-file 0o600 hardening) applied.

12 new tests (helper edge cases, doctor check/fix, end-to-end guard conflict **and** oserror paths; mutation-verified). Full suite **1757 passing**.

Follow-up (separate, tracked): `cozempic uninstall` to undo `init` (also requested in #147).