### PR TITLE
fix(#147): harden torn-line repair (splitlines data-loss) + auto-heal on any command

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -247,6 +247,19 @@ def cmd_list(args):
     print()
 
 
+def _auto_heal_session(path):
+    """#147: silently repair a torn trailing line on an IDLE (dead) session so a
+    user troubleshooting a 'Failed to resume' just by running a cozempic command
+    auto-recovers — without ever racing a live write (gated on mtime staleness).
+    Best-effort; never raises."""
+    try:
+        from .session import auto_repair_unresumable
+        if path and auto_repair_unresumable(path):
+            print(f"  Repaired a torn trailing line — this session can resume again (.torn.bak kept). (#147)")
+    except Exception:
+        pass
+
+
 def cmd_current(args):
     cwd = args.cwd or None
     match_text = getattr(args, "match", None)
@@ -260,6 +273,7 @@ def cmd_current(args):
     print(f"    ID:      {sess['session_id']}")
     print(f"    Size:    {fmt_bytes(sess['size'])} ({sess['lines']} messages)")
 
+    _auto_heal_session(sess["path"])
     from .tokens import detect_context_window, detect_model
     messages_for_model = load_messages(sess["path"])
     context_window = detect_context_window(messages_for_model)
@@ -306,6 +320,7 @@ def cmd_current(args):
 
 def cmd_diagnose(args):
     path = resolve_session(args.session, getattr(args, "project", None))
+    _auto_heal_session(path)
     messages = load_messages(path)
     diag = diagnose_session(messages)
     print_diagnosis(diag, path)

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1405,7 +1405,8 @@ def _has_torn_trailing_line(path: Path) -> bool:
         raw = path.read_text(encoding="utf-8", errors="surrogateescape")
     except OSError:
         return False
-    lines = raw.splitlines()
+    from .session import _split_physical_lines  # \n-only split (NOT splitlines:
+    lines = _split_physical_lines(raw)          # U+2028/2029/0085 are legal in JSON)
     last = next((i for i in range(len(lines) - 1, -1, -1) if lines[i].strip()), None)
     if last is None or last == 0:
         return False  # empty file, or a single torn line we won't blank out

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -1175,7 +1175,11 @@ def repair_torn_trailing_line(path: Path) -> bool:
         return False
     if not raw:
         return False
-    lines = raw.splitlines()
+    # MUST use _split_physical_lines, NOT str.splitlines(): the latter also breaks
+    # on U+2028/U+2029/U+0085 + C0 controls, which are LEGAL raw inside JSON strings
+    # (CC's JS JSON.stringify emits them unescaped). splitlines() would tear a VALID
+    # last line into fragments → false "torn" → drop real data on a healthy session.
+    lines = _split_physical_lines(raw)
     last = next((i for i in range(len(lines) - 1, -1, -1) if lines[i].strip()), None)
     if last is None:
         return False

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -1196,6 +1197,29 @@ def repair_torn_trailing_line(path: Path) -> bool:
         return True
     except Exception:
         return False
+
+
+def auto_repair_unresumable(path: Path, min_idle_seconds: float = 10.0) -> bool:
+    """Auto-repair a torn trailing line, but ONLY when no live writer is active.
+
+    A torn trailing line on a freshly-written file is almost always Claude Code
+    **mid-append** — it will be a complete line milliseconds later. Repairing
+    THAT would race and clobber a live write (the #106 data-loss class we exist
+    to prevent). So we only repair when the file has been idle for at least
+    ``min_idle_seconds`` (mtime staleness = no active writer): a real crash
+    artifact (a session Claude can no longer resume) is always stale, while a
+    live mid-write is not. This makes recovery automatic for silently-affected
+    users (any cozempic command that touches the dead session heals it) without
+    ever risking a healthy live session.
+
+    Returns True iff a repair was written. Never raises.
+    """
+    try:
+        if time.time() - path.stat().st_mtime < min_idle_seconds:
+            return False  # possibly a live mid-write — never race it
+    except OSError:
+        return False
+    return repair_torn_trailing_line(path)
 
 
 def cleanup_old_backups(session_path: Path, keep: int = 3) -> int:

--- a/tests/test_resume_torn_line.py
+++ b/tests/test_resume_torn_line.py
@@ -60,6 +60,34 @@ class TestRepairHelper(unittest.TestCase):
         self.assertTrue(repair_torn_trailing_line(p))
         self.assertEqual(p.read_text().splitlines(), [_valid("a")])
 
+    def test_valid_last_line_with_unicode_separators_NOT_touched(self):
+        # CC's JS JSON.stringify emits U+2028/U+2029/U+0085 raw inside strings.
+        # str.splitlines() would tear such a VALID last line into fragments and
+        # corrupt it; _split_physical_lines must not. (Fleet HIGH regression.)
+        from cozempic.doctor import _has_torn_trailing_line
+
+        for sep in (chr(0x2028), chr(0x2029), chr(0x85), chr(0x0b), chr(0x1e)):
+            p = self.tmp / f"u{ord(sep)}.jsonl"
+            valid_last = json.dumps({"type": "user", "uuid": "z", "text": f"a{sep}b"},
+                                    ensure_ascii=False)
+            p.write_text(_valid("a") + "\n" + valid_last + "\n", encoding="utf-8")
+            before = p.read_bytes()
+            self.assertFalse(_has_torn_trailing_line(p), f"U+{ord(sep):04X} mis-flagged as torn")
+            self.assertFalse(repair_torn_trailing_line(p), f"U+{ord(sep):04X} wrongly repaired")
+            self.assertEqual(p.read_bytes(), before)  # byte-identical, untouched
+            self.assertFalse((self.tmp / f"u{ord(sep)}.jsonl.torn.bak").exists())
+
+    def test_multibyte_truncation_torn_line_repaired(self):
+        # a realistic torn write: valid non-ASCII line + a line truncated mid-UTF8
+        p = self.tmp / "mb.jsonl"
+        good = json.dumps({"type": "user", "uuid": "g", "text": "café 日本語"}, ensure_ascii=False)
+        data = (good + "\n").encode("utf-8") + '{"type":"user","text":"中'.encode("utf-8")[:-1]  # chop a multibyte
+        p.write_bytes(data)
+        self.assertTrue(repair_torn_trailing_line(p))
+        lines = p.read_text(encoding="utf-8", errors="surrogateescape").splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(json.loads(lines[0])["text"], "café 日本語")  # non-ASCII preserved exactly
+
     def test_missing_file_returns_false(self):
         self.assertFalse(repair_torn_trailing_line(self.tmp / "nope.jsonl"))
 

--- a/tests/test_resume_torn_line.py
+++ b/tests/test_resume_torn_line.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -66,6 +67,84 @@ class TestRepairHelper(unittest.TestCase):
         p = self.tmp / "e.jsonl"
         p.write_text("")
         self.assertFalse(repair_torn_trailing_line(p))
+
+
+class TestAutoRepairIdleGate(unittest.TestCase):
+    """The critical safety property: auto-repair must NEVER race a live write."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="cz147a_"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _torn(self):
+        p = self.tmp / "s.jsonl"
+        _write(p, [_valid("a")])
+        with open(p, "a") as f:
+            f.write('{"type":"user","par')  # torn, no newline
+        return p
+
+    def test_repairs_when_idle(self):
+        from cozempic.session import auto_repair_unresumable
+        import os as _os
+
+        p = self._torn()
+        old = time.time() - 3600
+        _os.utime(p, (old, old))  # make it stale (dead session)
+        self.assertTrue(auto_repair_unresumable(p, min_idle_seconds=10))
+        for l in p.read_text().splitlines():
+            json.loads(l)
+
+    def test_does_NOT_repair_fresh_file(self):
+        # a torn line on a just-written file may be Claude mid-append — must NOT
+        # be touched (would race/clobber a live write, #106).
+        from cozempic.session import auto_repair_unresumable
+
+        p = self._torn()  # mtime = now
+        self.assertFalse(auto_repair_unresumable(p, min_idle_seconds=10))
+        self.assertIn('{"type":"user","par', p.read_text())  # left intact
+        self.assertFalse((self.tmp / "s.jsonl.torn.bak").exists())
+
+    def test_idle_valid_file_untouched(self):
+        from cozempic.session import auto_repair_unresumable
+        import os as _os
+
+        p = self.tmp / "ok.jsonl"
+        _write(p, [_valid("a"), _valid("b", "a")])
+        old = time.time() - 3600
+        _os.utime(p, (old, old))
+        self.assertFalse(auto_repair_unresumable(p))  # nothing torn
+
+
+class TestCliAutoHeal(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="cz147c_"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_cmd_diagnose_heals_idle_torn_session(self):
+        import os as _os
+        from cozempic import cli
+
+        p = self.tmp / "sess.jsonl"
+        _write(p, [_valid("a"), _valid("b", "a")])
+        with open(p, "a") as f:
+            f.write('{"torn')
+        old = time.time() - 3600
+        _os.utime(p, (old, old))  # idle/dead
+        with patch("cozempic.cli.resolve_session", return_value=p), \
+                patch("cozempic.cli.load_config"), \
+                patch("cozempic.cli.print_diagnosis"), patch("cozempic.cli.diagnose_session", return_value={}):
+            from types import SimpleNamespace
+            try:
+                cli.cmd_diagnose(SimpleNamespace(session="x", project=None))
+            except Exception:
+                pass  # downstream printing may need more; we only assert the heal
+        for l in p.read_text().splitlines():
+            json.loads(l)  # file is now resumable
+        self.assertTrue((self.tmp / "sess.jsonl.torn.bak").exists())
 
 
 class TestDoctorUnresumable(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #147 (shipped in 1.8.35). Two things, both fleet-reviewed:

## 1. HARDEN — splitlines() data-loss (latent in 1.8.35) ⚠️
The shipped `repair_torn_trailing_line` + `doctor._has_torn_trailing_line` used `str.splitlines()`, which also breaks on **U+2028 / U+2029 / U+0085** + C0 controls — chars Claude Code's JS `JSON.stringify` emits **raw** inside JSON strings. A *valid* last line containing one was mis-detected as torn → the repair **dropped real data on a healthy session**, silently, via the automatic guard path. Fixed by reusing the existing `_split_physical_lines()` (the `\n`-only splitter every other JSONL path already uses). Regression-tested + mutation-verified.

## 2. EXTEND — automatic recovery for silent victims
A user who hit the bug but never ran `doctor --fix` now auto-recovers just by running `cozempic current` / `diagnose` on the dead session. **Critical safety:** gated on the file being **idle ≥10s** (no live writer) — a torn line on a fresh file is usually Claude mid-append, and repairing *that* would race a live write (#106). The idle gate only ever heals a real crash artifact.

Fleet: 7 confirmed (1 HIGH = the splitlines bug, fixed; rest low/nit). Full suite **1763 passing**, ledger untouched.