### PR TITLE
feat: cozempic uninstall (#147 FR) + CLI idle-gate test

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1147,9 +1147,68 @@ def cmd_doctor(args):
     print()
 
 
+def cmd_uninstall(args):
+    """Reverse `cozempic init` — remove hooks, the slash command, and markers.
+
+    Default scope is GLOBAL (~/.claude). Keeps the user's data (savings ledger,
+    receipts) unless --purge. Sets the auto-init opt-out so init won't re-wire.
+    """
+    from .init import preview_uninstall, run_uninstall
+
+    scope = "all" if getattr(args, "all", False) else ("project" if getattr(args, "project", False) else "global")
+    purge = getattr(args, "purge", False)
+
+    print("\n  COZEMPIC UNINSTALL")
+    print("  ═══════════════════════════════════════════════════════════════════")
+    print(f"  Scope: {scope}" + ("  (+ purge data)" if purge else ""))
+
+    if getattr(args, "dry_run", False):
+        prev = preview_uninstall(scope, purge)
+        print("  Dry run — nothing will be changed.\n")
+        print(f"    Hooks would be removed from: {prev['hooks_in'] or '(none)'}")
+        print(f"    Slash command (~/.claude/commands/cozempic.md): "
+              f"{'remove' if prev['slash_command'] else '(not present / not ours)'}")
+        print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
+        if purge:
+            print(f"    Purge data: {prev['purge_data'] or '(none)'}")
+        print()
+        return
+
+    if purge:
+        print("  --purge will DELETE your savings ledger + receipts (~/.cozempic). This is irreversible.")
+        try:
+            if input("  Continue? [y/N] ").strip().lower() != "y":
+                print("  Aborted.\n")
+                return
+        except EOFError:
+            print("  Aborted (no confirmation).\n")
+            return
+
+    result = run_uninstall(scope, purge)
+    n_hooks = sum(len(h.get("removed", [])) for h in result["hooks"])
+    print(f"  Removed {n_hooks} hook(s) across {len(result['hooks'])} settings file(s).")
+    for h in result["hooks"]:
+        if h.get("removed"):
+            print(f"    - {h['settings_path']}: {', '.join(h['removed'])}"
+                  + (f"  (backup: {h['backup_path']})" if h.get("backup_path") else ""))
+    sc = result.get("slash_command")
+    if sc and sc.get("removed"):
+        print(f"  Removed slash command: {sc['path']}"
+              + (f"  (backup: {sc['backup_path']})" if sc.get("backup_path") else ""))
+    elif sc and sc.get("skipped_foreign"):
+        print(f"  Left {sc['path']} in place (not a cozempic command).")
+    if result.get("purged"):
+        print(f"  Purged data: {', '.join(result['purged'])}")
+    if result.get("opt_out_set"):
+        print("  Auto-init disabled. Re-run `cozempic init` to reinstall.")
+    print()
+
+
 def cmd_init(args):
     """Wire cozempic hooks and slash command into the current project (or globally)."""
     if getattr(args, "uninstall_global", False):
+        # Deprecated alias → `cozempic uninstall --global`.
+        print("  Note: `init --uninstall-global` is deprecated; use `cozempic uninstall`.", file=sys.stderr)
         from .init import uninstall_hooks
         result = uninstall_hooks(str(Path.home()))
         print("\n  COZEMPIC INIT — UNINSTALL GLOBAL")
@@ -1732,7 +1791,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--cwd", help="Project directory (default: current)")
     p_init.add_argument("--no-slash-command", action="store_true", help="Skip installing /cozempic slash command")
     p_init.add_argument("--global", dest="global_install", action="store_true", help="Wire hooks into ~/.claude/settings.json so every Claude Code session in every project is protected")
-    p_init.add_argument("--uninstall-global", action="store_true", help="Remove cozempic hooks from ~/.claude/settings.json")
+    p_init.add_argument("--uninstall-global", action="store_true", help="(deprecated) use `cozempic uninstall`")
+
+    p_uninstall = sub.add_parser("uninstall", help="Reverse `cozempic init` — remove hooks, slash command, markers (global by default)")
+    p_uninstall.add_argument("--project", action="store_true", help="Uninstall from THIS project's .claude/settings.json (default is global ~/.claude)")
+    p_uninstall.add_argument("--all", action="store_true", help="Uninstall from both global and project")
+    p_uninstall.add_argument("--purge", action="store_true", help="ALSO delete ~/.cozempic data + savings ledger (irreversible; prompts)")
+    p_uninstall.add_argument("--dry-run", action="store_true", help="Show what would be removed without changing anything")
 
     # doctor
     p_doctor = sub.add_parser("doctor", help="Check for known Claude Code issues and fix them")
@@ -1783,7 +1848,7 @@ def build_parser() -> argparse.ArgumentParser:
 _SUBCOMMANDS = {
     "list", "current", "diagnose", "treat", "strategy", "reload",
     "checkpoint", "post-compact", "guard", "init", "doctor", "formulary", "completions",
-    "digest", "self-update", "remind", "guard-watchdog", "dashboard",
+    "digest", "self-update", "remind", "guard-watchdog", "dashboard", "uninstall",
 }
 
 
@@ -1872,6 +1937,7 @@ _AUTO_INIT_SKIP_CMDS = frozenset({
     "doctor",        # diagnostic-only; doctor surfaces missing init via its own check
     "nudge",         # Stop-hook protocol command; never mutate state as a side effect
     "guard-watchdog",  # read-only log scan; never mutate project state
+    "uninstall",     # the whole point is to REMOVE wiring — must never auto-init
     "dashboard",     # report-only; reads/writes only ~/.cozempic, never project state
 })
 
@@ -2288,6 +2354,7 @@ def main():
         "post-compact": cmd_post_compact,
         "guard": cmd_guard,
         "init": cmd_init,
+        "uninstall": cmd_uninstall,
         "doctor": cmd_doctor,
         "guard-watchdog": cmd_guard_watchdog,
         "formulary": cmd_formulary,

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -477,6 +477,151 @@ def run_init(project_dir: str, skip_slash: bool = False) -> dict:
     }
 
 
+# ── Uninstall (reverse of init) ───────────────────────────────────────────────
+
+# Stable content signature of cozempic's /cozempic slash command, used to avoid
+# clobbering an unrelated user-authored ~/.claude/commands/cozempic.md.
+_SLASH_SIGNATURE = "prune bloated Claude Code context"
+_GLOBAL_INIT_MARKER = Path.home() / ".cozempic_global_initialized"
+_REMIND_COUNTER = Path.home() / ".cozempic_remind_counter"
+
+
+def _global_slash_path() -> Path:
+    from .session import get_claude_dir
+    return get_claude_dir() / "commands" / "cozempic.md"
+
+
+def _slash_is_ours(content: str) -> bool:
+    """True if this cozempic.md is cozempic's (vs a user's unrelated command)."""
+    return _SLASH_SIGNATURE in content or content.lower().count("cozempic") >= 5
+
+
+def uninstall_slash_command() -> dict:
+    """Remove the GLOBAL /cozempic slash command (~/.claude/commands/cozempic.md),
+    but only when it is cozempic's (content signature) so a user's unrelated
+    cozempic.md is never deleted. Backs it up (.md.bak) first. Idempotent;
+    never raises destructively.
+
+    Returns: {removed: bool, path: str|None, backup_path: str|None, skipped_foreign: bool}
+    """
+    target = _global_slash_path()
+    out = {"removed": False, "path": str(target), "backup_path": None, "skipped_foreign": False}
+    if not target.exists():
+        out["path"] = None
+        return out
+    try:
+        content = target.read_text(encoding="utf-8", errors="surrogateescape")
+    except OSError:
+        return out
+    if not _slash_is_ours(content):
+        out["skipped_foreign"] = True
+        return out
+    try:
+        backup = target.with_suffix(".md.bak")
+        shutil.copy2(target, backup)
+        out["backup_path"] = str(backup)
+    except OSError:
+        pass
+    try:
+        target.unlink()
+        out["removed"] = True
+    except OSError:
+        pass
+    return out
+
+
+def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
+    """Read-only: report what `run_uninstall(scope, purge)` WOULD remove. No writes."""
+    scopes = {"global": [str(Path.home())], "project": ["."],
+              "all": [str(Path.home()), "."]}.get(scope, [str(Path.home())])
+    hook_targets = []
+    for d in scopes:
+        p = _settings_path(d)
+        if p.exists() and _settings_has_cozempic_hooks(p):
+            hook_targets.append(str(p))
+    slash = _global_slash_path()
+    slash_present = False
+    if scope in ("global", "all") and slash.exists():
+        try:
+            slash_present = _slash_is_ours(slash.read_text(encoding="utf-8", errors="surrogateescape"))
+        except OSError:
+            slash_present = False
+    data = []
+    if purge:
+        for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
+            if p.exists():
+                data.append(str(p))
+    return {"hooks_in": hook_targets, "slash_command": slash_present,
+            "remind_counter": _REMIND_COUNTER.exists(), "purge_data": data}
+
+
+def _settings_has_cozempic_hooks(path: Path) -> bool:
+    try:
+        settings = _load_settings(path)
+    except (OSError, json.JSONDecodeError):
+        return False
+    hooks = settings.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return False
+    for entries in hooks.values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                for h in entry.get("hooks", []) or []:
+                    if isinstance(h, dict) and _is_cozempic_command(h.get("command", "")):
+                        return True
+    return False
+
+
+def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
+    """Reverse cozempic init. scope: 'global' | 'project' | 'all'.
+
+    Removes hooks (per scope), the global slash command (global/all), the remind
+    counter, and — with purge — the ~/.cozempic data dir + savings ledger. ALWAYS
+    leaves the global-init marker in place as the auto-init opt-out, so init does
+    not silently re-wire on the next run (explicit `cozempic init` still works).
+    """
+    dirs = {"global": [str(Path.home())], "project": ["."],
+            "all": [str(Path.home()), "."]}.get(scope, [str(Path.home())])
+    result: dict = {"scope": scope, "hooks": [], "slash_command": None,
+                    "remind_counter_removed": False, "purged": [], "opt_out_set": False}
+
+    for d in dirs:
+        result["hooks"].append(uninstall_hooks(d))
+
+    if scope in ("global", "all"):
+        result["slash_command"] = uninstall_slash_command()
+
+    # Cleanup the nudge counter (cosmetic, safe).
+    try:
+        if _REMIND_COUNTER.exists():
+            _REMIND_COUNTER.unlink()
+            result["remind_counter_removed"] = True
+    except OSError:
+        pass
+
+    # Opt-out: keep auto-init from re-wiring after uninstall.
+    try:
+        _GLOBAL_INIT_MARKER.touch()
+        result["opt_out_set"] = True
+    except OSError:
+        pass
+
+    if purge:
+        import shutil as _sh
+        for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
+            try:
+                if p.is_dir():
+                    _sh.rmtree(p); result["purged"].append(str(p))
+                elif p.exists():
+                    p.unlink(); result["purged"].append(str(p))
+            except OSError:
+                pass
+
+    return result
+
+
 def uninstall_hooks(project_dir: str) -> dict:
     """Remove cozempic-installed hooks from a settings.json. Idempotent.
 

--- a/tests/test_resume_torn_line.py
+++ b/tests/test_resume_torn_line.py
@@ -174,6 +174,27 @@ class TestCliAutoHeal(unittest.TestCase):
             json.loads(l)  # file is now resumable
         self.assertTrue((self.tmp / "sess.jsonl.torn.bak").exists())
 
+    def test_cmd_diagnose_does_NOT_heal_FRESH_torn_session(self):
+        # safety property through the REAL cli wrapper: a torn line on a fresh
+        # (mtime=now) file may be a live mid-write — cmd_diagnose must NOT touch it.
+        from cozempic import cli
+        from types import SimpleNamespace
+
+        p = self.tmp / "live.jsonl"
+        _write(p, [_valid("a"), _valid("b", "a")])
+        with open(p, "a") as f:
+            f.write('{"torn')  # mtime is now -> looks live
+        before = p.read_bytes()
+        with patch("cozempic.cli.resolve_session", return_value=p), \
+                patch("cozempic.cli.load_config"), \
+                patch("cozempic.cli.print_diagnosis"), patch("cozempic.cli.diagnose_session", return_value={}):
+            try:
+                cli.cmd_diagnose(SimpleNamespace(session="x", project=None))
+            except Exception:
+                pass
+        self.assertEqual(p.read_bytes(), before)  # untouched — live write never raced
+        self.assertFalse((self.tmp / "live.jsonl.torn.bak").exists())
+
 
 class TestDoctorUnresumable(unittest.TestCase):
     def setUp(self):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,154 @@
+"""cozempic uninstall — reverse of init (issue #147 FR)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cozempic import init as cz_init
+
+# A realistic cozempic hook command (carries the schema marker + canonical wrapper
+# shape that _is_cozempic_command recognizes — a bare "cozempic ..." is NOT matched
+# by design, so user inline calls are never eaten).
+COZ_CMD = ("export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || "
+           "python3 -m cozempic checkpoint; }  # cozempic-hook-schema=2")
+
+
+def _settings_with(hooks):
+    return {"hooks": hooks}
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="cz_uninstall_"))
+        # redirect HOME and the module-level markers into the temp home
+        self._patches = [
+            patch.dict(os.environ, {"HOME": str(self.home)}),
+            patch.object(cz_init, "_GLOBAL_INIT_MARKER", self.home / ".cozempic_global_initialized"),
+            patch.object(cz_init, "_REMIND_COUNTER", self.home / ".cozempic_remind_counter"),
+            patch("cozempic.session.get_claude_dir", return_value=self.home / ".claude"),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        import shutil
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def _write_global_settings(self, settings):
+        p = self.home / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(settings))
+        return p
+
+    def _write_slash(self, content):
+        p = self.home / ".claude" / "commands" / "cozempic.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        return p
+
+
+class TestRunUninstall(_Base):
+    def test_removes_global_hooks_and_slash(self):
+        self._write_global_settings(_settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        }))
+        slash = self._write_slash("# cozempic\nDiagnose and prune bloated Claude Code context\ncozempic treat")
+        res = cz_init.run_uninstall("global")
+        self.assertTrue(any(h.get("removed") for h in res["hooks"]))
+        self.assertTrue(res["slash_command"]["removed"])
+        self.assertFalse(slash.exists())
+        self.assertTrue((self.home / ".claude" / "commands" / "cozempic.md.bak").exists())
+        self.assertTrue(res["opt_out_set"])
+        self.assertTrue((self.home / ".cozempic_global_initialized").exists())  # opt-out marker
+
+    def test_preserves_user_hooks_in_mixed_entry(self):
+        self._write_global_settings(_settings_with({
+            "SessionStart": [{"hooks": [
+                {"type": "command", "command": COZ_CMD},
+                {"type": "command", "command": "my-own-tool --do-thing"},
+            ]}]
+        }))
+        cz_init.run_uninstall("global")
+        s = json.loads((self.home / ".claude" / "settings.json").read_text())
+        cmds = [h["command"] for e in s["hooks"]["SessionStart"] for h in e["hooks"]]
+        self.assertIn("my-own-tool --do-thing", cmds)  # user hook kept
+        self.assertNotIn(COZ_CMD, cmds)  # cozempic hook gone
+
+    def test_leaves_foreign_slash_untouched(self):
+        slash = self._write_slash("# My own command named cozempic\nnothing to do with the tool")
+        res = cz_init.run_uninstall("global")
+        self.assertTrue(slash.exists())  # not ours -> not removed
+        self.assertTrue(res["slash_command"]["skipped_foreign"])
+
+    def test_purge_removes_data_with_marker_kept(self):
+        (self.home / ".cozempic").mkdir()
+        (self.home / ".cozempic" / "receipts").mkdir()
+        (self.home / ".cozempic_savings.json").write_text("{}")
+        res = cz_init.run_uninstall("global", purge=True)
+        self.assertFalse((self.home / ".cozempic").exists())
+        self.assertFalse((self.home / ".cozempic_savings.json").exists())
+        self.assertIn(str(self.home / ".cozempic"), res["purged"])
+        # opt-out marker still set even on purge (so auto-init doesn't re-fire)
+        self.assertTrue((self.home / ".cozempic_global_initialized").exists())
+
+    def test_no_purge_keeps_data(self):
+        (self.home / ".cozempic").mkdir()
+        (self.home / ".cozempic_savings.json").write_text("{}")
+        cz_init.run_uninstall("global", purge=False)
+        self.assertTrue((self.home / ".cozempic").exists())
+        self.assertTrue((self.home / ".cozempic_savings.json").exists())
+
+    def test_idempotent_second_run(self):
+        self._write_global_settings(_settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        }))
+        cz_init.run_uninstall("global")
+        res2 = cz_init.run_uninstall("global")  # nothing left
+        self.assertFalse(any(h.get("removed") for h in res2["hooks"]))
+
+    def test_removes_remind_counter(self):
+        (self.home / ".cozempic_remind_counter").write_text("3")
+        res = cz_init.run_uninstall("global")
+        self.assertTrue(res["remind_counter_removed"])
+        self.assertFalse((self.home / ".cozempic_remind_counter").exists())
+
+
+class TestPreviewAndDryRun(_Base):
+    def test_preview_reports_without_mutating(self):
+        sp = self._write_global_settings(_settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        }))
+        before = sp.read_text()
+        prev = cz_init.preview_uninstall("global")
+        self.assertIn(str(sp), prev["hooks_in"])
+        self.assertEqual(sp.read_text(), before)  # untouched
+
+    def test_cmd_dry_run_changes_nothing(self):
+        from cozempic import cli
+
+        sp = self._write_global_settings(_settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        }))
+        before = sp.read_text()
+        cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=True))
+        self.assertEqual(sp.read_text(), before)
+        self.assertFalse((self.home / ".cozempic_global_initialized").exists())  # no opt-out write either
+
+
+class TestOptOutHolds(_Base):
+    def test_opt_out_marker_blocks_refire(self):
+        # after uninstall, the global-init marker exists -> auto-init must skip
+        cz_init.run_uninstall("global")
+        self.assertTrue(cz_init._GLOBAL_INIT_MARKER.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `cozempic uninstall` — the reverse of `init` (the other half of #147). Default scope global; keeps user data unless `--purge`; sets the auto-init opt-out; `--dry-run`. Reuses the surgical `uninstall_hooks`; new signature-gated slash removal. Fleet-reviewed: 0 findings on uninstall itself; applied the 1 low (CLI idle-gate safety test). 1773+ tests green.