### PR TITLE
docs: recommend on-PATH install so the hooks + guard daemon actually start

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ Install cozempic (any method above), then inside Claude Code:
 
 This gives you MCP tools, skills (`/cozempic:diagnose`, `/cozempic:treat`, etc.), and auto-wired hooks.
 
+> **Keep the plugin current — enable marketplace auto-update.** The `COZEMPIC_*` controls above govern the PyPI **package** (the `cozempic` CLI + guard daemon). The Claude Code **plugin** (hooks, skills, MCP server) is versioned separately, and unless auto-update is enabled for its marketplace it stays pinned at whatever version you installed until you run `/plugin` by hand. To keep it current automatically, set `autoUpdate` on the marketplace entry in `~/.claude/settings.json`:
+>
+> ```json
+> {
+>   "extraKnownMarketplaces": {
+>     "cozempic": {
+>       "source": { "source": "github", "repo": "Ruya-AI/cozempic" },
+>       "autoUpdate": true
+>     }
+>   }
+> }
+> ```
+>
+> With `autoUpdate: true`, Claude Code refreshes the marketplace **and its installed plugins** on startup.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Cozempic removes it with **18 composable strategies** across 3 prescription tier
 
 ## Install
 
-Pick your package manager. `uvx`/`pipx`/`npm`/`pip` are the lowest-friction (no Homebrew trust prompt — see the note below):
+Pick your package manager. `uv tool`/`pipx`/`npm`/`pip` are the lowest-friction (no Homebrew trust prompt — see the note below):
 
 ```bash
-# uv / uvx — no install needed, run on demand (recommended)
-uvx cozempic --help
+# uv — persistent install on PATH (recommended); powers the hooks + guard daemon
+uv tool install cozempic
 
 # pipx — isolated user install, always on PATH
 pipx install cozempic
@@ -59,6 +59,8 @@ nix profile install github:Ruya-AI/cozempic?dir=packaging/nix
 AUR (`yay -S cozempic`) and MacPorts (`port install py-cozempic`) submissions are in progress — see [`packaging/README.md`](packaging/README.md) for status and PKGBUILD/Portfile sources.
 
 That's it. Cozempic auto-initializes on first use — hooks are wired globally, guard daemon auto-starts on every Claude Code session. No manual setup needed. Opt out with `COZEMPIC_NO_GLOBAL_INIT=1`.
+
+> **`cozempic` must be on your `PATH`.** The global hooks and guard daemon work by invoking the `cozempic` command — the `SessionStart` hook runs `cozempic guard --daemon` (falling back to `python3 -m cozempic`). A run-on-demand `uvx cozempic` resolves the package in a throwaway environment and installs **no** executable, so it will **not** power the hooks or daemon: the launch fails silently and `/cozempic:doctor` reports `No guard daemon is running` even though `SessionStart` printed `Cozempic: guard active`. Install with one of the on-`PATH` methods above (`uv tool install` / `pipx` / `npm -g` / `pip`) and verify with `command -v cozempic`.
 
 ### Auto-update & how to control it
 


### PR DESCRIPTION
Fixes #158.

## Problem

The README recommends `uvx cozempic` as the primary install method:

```
# uv / uvx — no install needed, run on demand (recommended)
uvx cozempic --help
```

But `uvx` runs the package in a throwaway environment and **never installs a `cozempic` executable on `PATH`**. The `SessionStart` hook starts the guard daemon by invoking bare `cozempic` (falling back to `python3 -m cozempic`) — neither of which resolves under a `uvx`-only setup. The daemon never starts, yet the hook still prints `Cozempic: guard active` (the `echo` is unconditional), so the failure is invisible until `/cozempic:doctor` reports `No guard daemon is running`. This directly contradicts the README's own promise that the "guard daemon auto-starts on every Claude Code session."

## Change

Docs-only:

- Recommend **`uv tool install cozempic`** (persistent, on `PATH`, still the uv toolchain, and compatible with cozempic's own auto-update) instead of run-on-demand `uvx cozempic`.
- Add a callout right after the install block explaining that the hooks and guard daemon require `cozempic` to be resolvable on `PATH`, why bare `uvx` doesn't satisfy that, and how to verify (`command -v cozempic`).
- In the "As a Claude Code Plugin" section, recommend enabling marketplace **`autoUpdate`** after adding the marketplace. The plugin bundle (hooks/skills/MCP) is versioned separately from the PyPI package and otherwise stays pinned until a manual `/plugin` update — which is how an install can silently drift behind the package.

The other listed methods (`pipx`, `npm -g`, `pip`, Homebrew, Nix) already land an executable on `PATH` and are unaffected.

## Notes / possible follow-ups (out of scope here)

This PR only fixes the docs. Two code-side improvements would make this more robust, happy to open separate issues/PRs if useful:

1. Add a `uvx cozempic …` / `uv tool run cozempic …` fallback to the `SessionStart` daemon-launch chain so a uvx-only setup still works.
2. Only print `Cozempic: guard active` when the daemon actually started — a silent failure that reports success is the part that made this hard to diagnose.
