### PR TITLE
fix: 3 pre-existing nits surfaced by the C3-fallback fleet

### DIFF
--- a/src/cozempic/digest.py
+++ b/src/cozempic/digest.py
@@ -857,8 +857,10 @@ def _sanitize_for_injection(text: str, limit: int = 300) -> str:
     text = re.sub(r"[\x00-\x1f\x7f]+", " ", text)
     text = re.sub(r"\s+", " ", text).strip()
     # Defang a leading markdown-structural char so the value can't render as a
-    # header/quote/list/fence at the start of its line.
-    if text[:1] in "#>-*`|":
+    # header/quote/list/fence at the start of its line. Guard on a non-empty
+    # first char: `"" in "#>-*`|"` is True (empty str is a substring of every
+    # str), which would prepend a stray backslash to an emptied rule.
+    if text and text[0] in "#>-*`|":
         text = "\\" + text
     if len(text) > limit:
         text = text[:limit] + "…"

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -675,7 +675,13 @@ def fix_corrupted_tool_use() -> str:
                         delta = None
                     if delta is not None:
                         from .helpers import atomic_write_text
-                        atomic_write_text(path, "".join(lines) + "".join(delta))
+                        # errors="surrogateescape": the appended delta is decoded
+                        # with surrogateescape (_parse_delta_lines), so a valid
+                        # JSONL line with a raw non-UTF-8 byte carries lone
+                        # surrogates — a strict write would raise UnicodeEncodeError
+                        # and abort the run. Round-trip them like every other write.
+                        atomic_write_text(path, "".join(lines) + "".join(delta),
+                                          errors="surrogateescape")
                         total_fixed += fixed_in_session
                         sessions_fixed += 1
                 else:  # "unchanged" — safe to write our repaired buffer

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -56,9 +56,10 @@ STORM_TRIP = 5
 # The guard's back-off cap (HARD_LOOP_BACKOFF_CAP), recorded for diagnostics.
 BACKOFF_CAP_S = 300
 
-# The token-count group must tolerate the K/M/G suffix and comma grouping that
-# guard._fmt_prune_result emits ("210.0K tokens freed", "1.2M tokens freed") for
-# any prune >= 1000 tokens — WITHOUT this, every productive prune line is
+# The token-count group must tolerate the suffix guard._fmt_prune_result emits:
+# in practice only "K" (e.g. "210.0K tokens freed") or a bare integer — a 1.2M-token
+# prune renders as "1200.0K", never "1.2M". The regex stays permissive ([KMG]?,
+# commas) as a harmless superset. WITHOUT this, every productive prune line is
 # unparsed, so the futile-dominance ratio skews to ~1.0 and the watchdog
 # FALSE-FLAGS a healthy daemon as looping (and --fix would SIGTERM it). The count
 # is matched but NOT captured (the percent is the only capture group, group 1, and

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -259,6 +259,16 @@ class TestInjectionSanitization(unittest.TestCase):
         self.assertTrue(san("> quote").startswith("\\>"))
         self.assertTrue(san("```fence").startswith("\\`"))
 
+    def test_sanitizer_empty_or_control_input_is_not_backslash(self):
+        # an emptied rule (all whitespace/control) must sanitize to "" — NOT a lone
+        # backslash. `"" in "#>-*`|"` is True (empty str ⊂ every str), the trap the
+        # codebase warns about; guard on a non-empty first char.
+        from cozempic.digest import _sanitize_for_injection as san
+        self.assertEqual(san(""), "")
+        self.assertEqual(san("   "), "")
+        self.assertEqual(san("\x00\x01"), "")
+        self.assertEqual(san("\t\n  \r"), "")
+
     def test_injection_text_has_no_extra_lines_from_rule(self):
         from cozempic.digest import build_injection_text, DigestStore, DigestRule
         # A rule whose text tries to add fake markdown lines/instructions.


### PR DESCRIPTION
Small hygiene fixes the fleet found in adjacent code (digest empty-string defang, doctor append-merge surrogateescape, watchdog comment). +1 test. Full suite 1872.