### PR TITLE
fix(#158): bake absolute interpreter into hooks so the guard resolves off-PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Cozempic removes it with **18 composable strategies** across 3 prescription tier
 Pick your package manager. `uvx`/`pipx`/`npm`/`pip` are the lowest-friction (no Homebrew trust prompt — see the note below):
 
 ```bash
-# uv / uvx — no install needed, run on demand (recommended)
+# uv — persistent install, always on PATH (recommended)
+uv tool install cozempic
+
+# uvx — run once without installing (handy to try it, but the guard daemon
+# can't auto-start from an ephemeral env — use `uv tool install` for that)
 uvx cozempic --help
 
 # pipx — isolated user install, always on PATH

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1323,6 +1323,17 @@ def cmd_init(args):
         for h in hooks["skipped"]:
             print(f"    ~ {h} (current, skipped)")
 
+    # #158: if cozempic is running from a throwaway env (uvx / uv run), the path
+    # baked into the hooks won't exist next session, so the guard daemon can't
+    # auto-start. Warn loudly and point at a persistent install.
+    if hooks.get("ephemeral"):
+        print()
+        print("  ⚠ cozempic is running from an EPHEMERAL environment (e.g. `uvx`).")
+        print("    The guard daemon will NOT auto-start on the next session — the hook")
+        print("    can't find cozempic. Install persistently so it lands on PATH:")
+        print("        uv tool install cozempic")
+        print("    then re-run `cozempic init`.")
+
     print()
 
     # Report slash command

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -10,6 +10,7 @@ This module automates both so `cozempic init` is the only setup step.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sys
 from datetime import datetime
@@ -314,6 +315,50 @@ class _SettingsLock:
             pass
 
 
+def _resolve_cozempic_python() -> tuple[str, bool]:
+    """Return (abs_python, ephemeral) for baking into hook commands (#158).
+
+    abs_python is the absolute interpreter currently running cozempic
+    (``sys.executable``), used as the hook fallback so the guard daemon resolves
+    even when bare ``cozempic`` isn't on the hook's PATH and the *system*
+    ``python3`` lacks cozempic (the exact failure on a uvx/non-PATH install).
+    ``ephemeral`` is True when that interpreter lives in a throwaway env (uvx /
+    uv-run cache / temp) that won't exist next session — in which case baking it
+    can't help and the caller should warn the user to ``uv tool install``.
+    """
+    # Use sys.executable AS-IS — do NOT realpath it. A uv-tool / pipx / venv
+    # install's sys.executable is that venv's python (whose site-packages HAS
+    # cozempic); resolving the symlink to the shared base interpreter would drop
+    # cozempic from `-m cozempic` and break the very install we recommend.
+    exe = sys.executable or ""
+    ephemeral = any(m in exe for m in (
+        "/.cache/uv/", "/cache/uv/", "/environments-v", "/uv-run", "/tmp/", "/var/folders/",
+    ))
+    return exe, ephemeral
+
+
+def _bake_cozempic_path(hooks: dict, abs_python: str) -> dict:
+    """Deep-copy ``hooks`` and replace the bare ``python3 -m cozempic`` fallback in
+    every command with an absolute ``<abs_python> -m cozempic``, so the hook
+    resolves cozempic regardless of the runtime PATH/system-python (#158). The
+    primary ``cozempic`` (on-PATH) invocation is left first; this only hardens the
+    fallback. Never mutates the canonical module constant. The schema marker is
+    untouched, so cozempic-hook detection/idempotency is unaffected."""
+    import copy
+    import shlex
+    q = shlex.quote(abs_python)
+    out = copy.deepcopy(hooks)
+    for entries in out.values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            for h in entry.get("hooks", []) if isinstance(entry, dict) else []:
+                cmd = h.get("command") if isinstance(h, dict) else None
+                if isinstance(cmd, str) and "python3 -m cozempic" in cmd:
+                    h["command"] = cmd.replace("python3 -m cozempic", f"{q} -m cozempic")
+    return out
+
+
 def wire_hooks(project_dir: str) -> dict:
     """Add cozempic checkpoint hooks to .claude/settings.json.
 
@@ -355,7 +400,12 @@ def wire_hooks(project_dir: str) -> dict:
         updated: list[str] = []
         skipped: list[str] = []
 
-        for event_name, hook_entries in COZEMPIC_HOOKS.items():
+        # #158: bake the absolute interpreter into the hook fallback so the guard
+        # resolves even when bare `cozempic` isn't on the hook's PATH.
+        abs_python, ephemeral = _resolve_cozempic_python()
+        canonical_hooks = _bake_cozempic_path(COZEMPIC_HOOKS, abs_python)
+
+        for event_name, hook_entries in canonical_hooks.items():
             existing = hooks.get(event_name, [])
 
             for new_entry in hook_entries:
@@ -422,6 +472,8 @@ def wire_hooks(project_dir: str) -> dict:
         "skipped": skipped,
         "settings_path": str(path),
         "backup_path": str(backup) if backup else None,
+        "ephemeral": ephemeral,        # #158: True if cozempic runs from a throwaway env
+        "cozempic_python": abs_python,
     }
 
 

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -1,0 +1,91 @@
+"""#158: bake an absolute cozempic interpreter into the hook fallback so the
+guard daemon resolves even when bare `cozempic` isn't on the hook's PATH."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cozempic import init as cz
+
+
+class TestResolveAndBake(unittest.TestCase):
+    def test_bake_replaces_python3_fallback_with_abs(self):
+        hooks = {"SessionStart": [{"hooks": [
+            {"type": "command",
+             "command": "{ cozempic guard 2>/dev/null || python3 -m cozempic guard 2>/dev/null; } # cozempic-hook-schema=v13"},
+        ]}]}
+        out = cz._bake_cozempic_path(hooks, "/opt/uvtools/cozempic/bin/python3.12")
+        cmd = out["SessionStart"][0]["hooks"][0]["command"]
+        self.assertIn("/opt/uvtools/cozempic/bin/python3.12 -m cozempic guard", cmd)
+        self.assertNotIn("|| python3 -m cozempic", cmd)   # bare python3 fallback gone
+        self.assertIn("cozempic guard 2>/dev/null ||", cmd)  # on-PATH primary kept first
+        self.assertIn("cozempic-hook-schema=v13", cmd)       # marker untouched
+
+    def test_bake_does_not_mutate_input(self):
+        hooks = {"E": [{"hooks": [{"command": "python3 -m cozempic x"}]}]}
+        cz._bake_cozempic_path(hooks, "/abs/py")
+        self.assertEqual(hooks["E"][0]["hooks"][0]["command"], "python3 -m cozempic x")  # original intact
+
+    def test_bake_quotes_paths_with_spaces(self):
+        out = cz._bake_cozempic_path({"E": [{"hooks": [{"command": "python3 -m cozempic x"}]}]},
+                                     "/Users/a b/py")
+        self.assertIn("'/Users/a b/py' -m cozempic x", out["E"][0]["hooks"][0]["command"])
+
+    def test_bake_tolerates_malformed_entries(self):
+        # non-dict entries / missing command must not crash
+        cz._bake_cozempic_path({"E": [{"hooks": ["nope", {"x": 1}]}, "bad"]}, "/p")
+
+    def test_resolve_uses_sys_executable_unmodified(self):
+        # must NOT realpath — a uv-tool venv python must be returned as-is so its
+        # site-packages (which has cozempic) is used by `-m cozempic`.
+        p = "/Users/x/.local/share/uv/tools/cozempic/bin/python3.12"
+        with patch("cozempic.init.sys.executable", p):
+            got, _ = cz._resolve_cozempic_python()
+            self.assertEqual(got, p)
+
+    def test_resolve_flags_uvx_ephemeral(self):
+        for p in ("/Users/x/.cache/uv/environments-v2/abc/bin/python3",
+                  "/private/var/folders/xx/T/uvx-tmp/bin/python"):
+            with patch("cozempic.init.sys.executable", p):
+                _, eph = cz._resolve_cozempic_python()
+                self.assertTrue(eph, f"{p} should be ephemeral")
+
+    def test_resolve_flags_persistent_not_ephemeral(self):
+        for p in ("/Users/x/.local/share/uv/tools/cozempic/bin/python3.12",
+                  "/opt/homebrew/bin/python3", "/usr/local/bin/python3.11"):
+            with patch("cozempic.init.sys.executable", p):
+                _, eph = cz._resolve_cozempic_python()
+                self.assertFalse(eph, f"{p} should be persistent")
+
+
+class TestWireHooksBakes(unittest.TestCase):
+    def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("cozempic.init._resolve_cozempic_python",
+                       return_value=("/abs/uvtool/bin/python3.12", False)):
+                res = cz.wire_hooks(tmp)
+            self.assertFalse(res["ephemeral"])
+            self.assertEqual(res["cozempic_python"], "/abs/uvtool/bin/python3.12")
+            settings = json.loads((Path(tmp) / ".claude" / "settings.json").read_text())
+            cmds = [h["command"] for entries in settings["hooks"].values()
+                    for e in entries for h in e["hooks"]]
+            # at least one hook now carries the absolute interpreter fallback
+            self.assertTrue(any("/abs/uvtool/bin/python3.12 -m cozempic" in c for c in cmds))
+            # and none still falls back to bare python3
+            self.assertFalse(any("|| python3 -m cozempic" in c for c in cmds))
+
+    def test_wire_hooks_propagates_ephemeral_true(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("cozempic.init._resolve_cozempic_python",
+                       return_value=("/tmp/uvx/bin/python", True)):
+                res = cz.wire_hooks(tmp)
+            self.assertTrue(res["ephemeral"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #158. On a uvx / non-PATH install, the SessionStart hook ran `{ cozempic guard || python3 -m cozempic guard }` — **both fail** when bare `cozempic` isn't on the hook's PATH *and* the system `python3` lacks cozempic. The guard daemon silently never started, yet the hook still printed "Cozempic: guard active" (false-safety).

**Confirmed live** on the reporter's class of box: `command -v cozempic`=NONE, `python3 -m cozempic`=traceback.

## Fix
- `_resolve_cozempic_python()` returns `sys.executable` **as-is** (deliberately NOT realpath'd — a uv-tool/pipx/venv python must stay the venv python whose site-packages has cozempic; resolving to the shared base interpreter would drop it and break the recommended `uv tool install`).
- `_bake_cozempic_path()` rewrites every hook's `python3 -m cozempic` fallback to `<sys.executable> -m cozempic`, so the guard resolves regardless of the hook's PATH. The on-PATH `cozempic` primary is still tried first.
- `cmd_init` **warns** when cozempic runs from an ephemeral env (uvx/uv-run/temp) where the baked path won't persist — pointing at `uv tool install cozempic`.
- README now recommends `uv tool install` (persistent) over `uvx` (ephemeral).

## Proof (end-to-end, real `uv tool install`)
With PATH stripped of cozempic: baked `<tool-venv python> -m cozempic` → `cozempic 1.8.37` ✓; old `system python3 -m cozempic` → `No module named cozempic` ✗.

Fleet-reviewed (6 dimensions incl. idempotency-detection + no-realpath): **0 findings**. 9 tests; full suite 1881 passing.

Note: this closes the *resolvability* half of #158 (guard now starts). The *honest-reporting* half (the "guard active" message could still over-promise on a genuinely ephemeral install) is mitigated by the init-time warning; a hook-level daemon-up check is a possible follow-up.