### PR TITLE
chore: pre-release fleet nits (1.8.38)

### DIFF
--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -10,7 +10,6 @@ This module automates both so `cozempic init` is the only setup step.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import sys
 from datetime import datetime
@@ -330,7 +329,9 @@ def _resolve_cozempic_python() -> tuple[str, bool]:
     # install's sys.executable is that venv's python (whose site-packages HAS
     # cozempic); resolving the symlink to the shared base interpreter would drop
     # cozempic from `-m cozempic` and break the very install we recommend.
-    exe = sys.executable or ""
+    # Degrade to a real `python3` if sys.executable is empty (exotic frozen
+    # interpreters) so the baked fallback is never an empty command.
+    exe = sys.executable or shutil.which("python3") or "python3"
     ephemeral = any(m in exe for m in (
         "/.cache/uv/", "/cache/uv/", "/environments-v", "/uv-run", "/tmp/", "/var/folders/",
     ))
@@ -346,8 +347,10 @@ def _bake_cozempic_path(hooks: dict, abs_python: str) -> dict:
     untouched, so cozempic-hook detection/idempotency is unaffected."""
     import copy
     import shlex
-    q = shlex.quote(abs_python)
     out = copy.deepcopy(hooks)
+    if not abs_python:
+        return out  # never bake an empty command — keep the original fallback
+    q = shlex.quote(abs_python)
     for entries in out.values():
         if not isinstance(entries, list):
             continue

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -4,7 +4,6 @@ guard daemon resolves even when bare `cozempic` isn't on the hook's PATH."""
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -54,6 +53,19 @@ class TestResolveAndBake(unittest.TestCase):
             with patch("cozempic.init.sys.executable", p):
                 _, eph = cz._resolve_cozempic_python()
                 self.assertTrue(eph, f"{p} should be ephemeral")
+
+    def test_resolve_degrades_when_sys_executable_empty(self):
+        # exotic frozen interpreters can have an empty sys.executable — must NOT
+        # return "" (which would bake an empty `'' -m cozempic` no-op command).
+        with patch("cozempic.init.sys.executable", ""), \
+                patch("cozempic.init.shutil.which", return_value="/usr/bin/python3"):
+            got, _ = cz._resolve_cozempic_python()
+            self.assertEqual(got, "/usr/bin/python3")
+
+    def test_bake_skips_when_abs_python_empty(self):
+        hooks = {"E": [{"hooks": [{"command": "python3 -m cozempic x"}]}]}
+        out = cz._bake_cozempic_path(hooks, "")
+        self.assertEqual(out["E"][0]["hooks"][0]["command"], "python3 -m cozempic x")  # untouched
 
     def test_resolve_flags_persistent_not_ephemeral(self):
         for p in ("/Users/x/.local/share/uv/tools/cozempic/bin/python3.12",


### PR DESCRIPTION
3 nits from the integrated pre-release fleet review (0 real findings): unused imports + an empty-sys.executable guard. +2 tests. Suite 1883.