### PR TITLE
release: 1.8.38

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools",
-    "version": "1.8.37",
+    "version": "1.8.38",
     "pluginRoot": "./plugin"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "cozempic",
       "source": "./plugin",
       "description": "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools",
-      "version": "1.8.37",
+      "version": "1.8.38",
       "category": "productivity",
       "tags": ["context", "pruning", "compaction", "agent-teams", "tokens", "optimization"]
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cozempic
 
-![Downloads](https://img.shields.io/badge/downloads-150k%2B-brightgreen) ![Version](https://img.shields.io/badge/version-1.8.37-blue) ![License](https://img.shields.io/badge/license-MIT-lightgrey)
+![Downloads](https://img.shields.io/badge/downloads-150k%2B-brightgreen) ![Version](https://img.shields.io/badge/version-1.8.38-blue) ![License](https://img.shields.io/badge/license-MIT-lightgrey)
 
 **50,000+ power users** trust Cozempic to keep their Claude Code sessions lean.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozempic",
-  "version": "1.8.37",
+  "version": "1.8.38",
   "description": "Context weight-loss for Claude Code — prune bloated sessions, protect Agent Teams from compaction",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cozempic",
-  "version": "1.8.37",
+  "version": "1.8.38",
   "description": "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools",
   "author": {
     "name": "Ruya AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cozempic"
-version = "1.8.37"
+version = "1.8.38"
 description = "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools"
 readme = "README.md"
 license = "MIT"

--- a/src/cozempic/__init__.py
+++ b/src/cozempic/__init__.py
@@ -1,3 +1,3 @@
 """Cozempic - Context weight-loss tool for Claude Code."""
 
-__version__ = "1.8.37"
+__version__ = "1.8.38"

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1766,7 +1766,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="cozempic",
         description="Context weight-loss tool for Claude Code — prune bloated JSONL conversation files",
     )
-    parser.add_argument("--version", action="version", version="%(prog)s 1.8.37")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.8.38")
     parser.add_argument("--context-window", type=int, default=None, help="Override context window size in tokens (e.g. 1000000 for 1M beta)")
     parser.add_argument("--system-overhead-tokens", type=int, default=None, help="Override system overhead estimate (default: 21000). Increase for heavy rules/MCP configs.")
     sub = parser.add_subparsers(dest="command")


### PR DESCRIPTION
C3 graceful fallback + #158 guard-on-PATH + L1 dashboard hardening (#146). Integrated pre-release fleet: 0 real findings. 1883 tests passing.