### PR TITLE
fix(team): re-key shared task list by real system id (completed tasks render as pending after compaction)

### DIFF
--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -604,6 +604,13 @@ def extract_team_state(messages: list[Message]) -> TeamState:
     # discard event ordering and mark a still-working teammate "completed").
     last_send_line: dict[str, int] = {}
     seen_tasks: dict[str, TaskInfo] = {}
+    # TaskCreate's tool INPUT carries no id (the system assigns it and returns it
+    # in the tool_result: "Task #N created"). Map each TaskCreate tool_use_id to
+    # the temp key its task is parked under, so the result handler can re-key it
+    # to the REAL id. Without this, creates were keyed positionally (str(len(...)))
+    # while TaskUpdate keys by the real id → completed tasks render as pending and
+    # phantom blank tasks appear in the recovered checkpoint.
+    taskcreate_uid_to_key: dict[str, str] = {}
 
     # Track tool_use_id -> tool_name for matching results to calls
     tool_use_id_to_name: dict[str, str] = {}
@@ -809,11 +816,22 @@ def extract_team_state(messages: list[Message]) -> TeamState:
 
                 # TaskCreate (shared todo list)
                 elif name == "TaskCreate":
-                    task_id = _sfield(inp, "taskId", "id") or str(len(seen_tasks))
-                    subject = _sfield(inp, "subject", "title")
-                    seen_tasks[task_id] = TaskInfo(
-                        task_id=task_id,
-                        subject=subject,
+                    # The real task id is assigned by the system and appears ONLY
+                    # in the tool_result ("Task #N created"), never in the input.
+                    # Park the task under a temp key tied to this tool_use_id; the
+                    # tool_result handler re-keys it to the real id so a later
+                    # TaskUpdate(taskId=...) lands on the right task.
+                    real_id = _sfield(inp, "taskId", "id")
+                    if real_id:
+                        task_key = real_id
+                    elif tool_use_id:
+                        task_key = f"__pending_create_{tool_use_id}"
+                        taskcreate_uid_to_key[tool_use_id] = task_key
+                    else:
+                        task_key = str(len(seen_tasks))
+                    seen_tasks[task_key] = TaskInfo(
+                        task_id=real_id or task_key,
+                        subject=_sfield(inp, "subject", "title"),
                         status="pending",
                         owner=_sfield(inp, "owner"),
                         description=_sfield(inp, "description"),
@@ -857,6 +875,22 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                 if not isinstance(tool_use_id, str):  # dict-key use below
                     tool_use_id = ""
                 tool_name = tool_use_id_to_name.get(tool_use_id, "")
+
+                # TaskCreate result carries the system-assigned id ("Task #N
+                # created"); re-key the parked task from its temp key to the real
+                # id so TaskUpdate completions (which carry the real taskId) land
+                # on it. A reused id (task store reset) overwrites the older
+                # generation, matching the live store which holds only the latest.
+                if tool_name == "TaskCreate":
+                    _tc_temp = taskcreate_uid_to_key.pop(tool_use_id, "")
+                    if _tc_temp and _tc_temp in seen_tasks:
+                        _m_tc = re.search(r"Task\s+#?(\d+)\s+created",
+                                          _extract_block_text(block), re.I)
+                        if _m_tc:
+                            _rid = _m_tc.group(1)
+                            _info = seen_tasks.pop(_tc_temp)
+                            _info.task_id = _rid
+                            seen_tasks[_rid] = _info
 
                 # Task tool result = subagent finished, capture result
                 if tool_name == "Task" or tool_use_id in tool_use_id_to_subagent:

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -882,15 +882,38 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                 # on it. A reused id (task store reset) overwrites the older
                 # generation, matching the live store which holds only the latest.
                 if tool_name == "TaskCreate":
-                    _tc_temp = taskcreate_uid_to_key.pop(tool_use_id, "")
+                    _tc_temp = taskcreate_uid_to_key.get(tool_use_id, "")
                     if _tc_temp and _tc_temp in seen_tasks:
                         _m_tc = re.search(r"Task\s+#?(\d+)\s+created",
                                           _extract_block_text(block), re.I)
                         if _m_tc:
+                            # Consume the mapping ONLY once we've parsed a real id — a
+                            # regex miss (reworded/torn result) leaves it intact so a
+                            # later duplicate result can still recover the id.
+                            taskcreate_uid_to_key.pop(tool_use_id, None)
                             _rid = _m_tc.group(1)
                             _info = seen_tasks.pop(_tc_temp)
-                            _info.task_id = _rid
-                            seen_tasks[_rid] = _info
+                            _existing = seen_tasks.get(_rid)
+                            if _existing is None or _existing.subject:
+                                # Free id, OR a real prior-generation task holds it
+                                # (a store reset reused #N) — latest generation wins:
+                                # install the fresh create. A prior task is identified
+                                # by having a subject (only a real TaskCreate sets one).
+                                _info.task_id = _rid
+                                seen_tasks[_rid] = _info
+                            else:
+                                # The id is held by a SUBJECT-LESS entry: an out-of-order
+                                # TaskUpdate that already recorded THIS create's status
+                                # (torn/reordered transcript). Keep its authoritative
+                                # status/owner — never clobber e.g. "completed" with the
+                                # create's "pending" — and backfill the create's subject/
+                                # description so the recovered row isn't blank.
+                                _existing.task_id = _rid
+                                _existing.subject = _info.subject
+                                if not _existing.description:
+                                    _existing.description = _info.description
+                                if not _existing.owner:
+                                    _existing.owner = _info.owner
 
                 # Task tool result = subagent finished, capture result
                 if tool_name == "Task" or tool_use_id in tool_use_id_to_subagent:
@@ -1116,6 +1139,14 @@ def extract_team_state(messages: list[Message]) -> TeamState:
 
     state.teammates = list(seen_teammates.values())
     state.subagents = list(seen_subagents.values())
+    # A TaskCreate whose result was missing/torn/reworded never got re-keyed, so
+    # its task_id still holds the internal "__pending_create_<uid>" sentinel.
+    # Rewrite those to a clean positional id (matching the pre-#167 convention) so
+    # the sentinel never leaks to JSON consumers (_summary_dict / to_dict). Markdown
+    # already renders by subject+status, so this is display-invisible there.
+    for _i, _t in enumerate(seen_tasks.values()):
+        if _t.task_id.startswith("__pending_create_"):
+            _t.task_id = str(_i)
     state.tasks = list(seen_tasks.values())
     state.config_source = "jsonl" if state.message_count > 0 else ""
 

--- a/tests/test_task_list_keying.py
+++ b/tests/test_task_list_keying.py
@@ -1,0 +1,114 @@
+"""Regression tests for shared-task-list keying in extract_team_state.
+
+Bug: TaskCreate's tool *input* carries no id — the system assigns it and returns
+it only in the tool_result ("Task #N created"). The extractor used to key created
+tasks positionally (str(len(seen_tasks)) -> "0","1",...), but TaskUpdate keys by
+the real system id (taskId, 1-based). The two namespaces diverge, so:
+  - a TaskUpdate(completed) lands on the wrong slot,
+  - the first-created task (key "0") is never matched by any update,
+  - high-id updates fabricate phantom blank tasks,
+so genuinely-completed tasks render as pending in the recovered checkpoint (which
+is injected back into context post-compact).
+
+Fix: re-key each created task to its real id parsed from the "Task #N created"
+tool_result; reused ids (task-store resets) overwrite older generations.
+
+These tests fail on the positional-keying base and pass after the fix.
+"""
+
+import unittest
+from unittest.mock import patch
+
+
+def _tool_use(id_, name, inp):
+    return {"message": {"role": "assistant", "content": [
+        {"type": "tool_use", "id": id_, "name": name, "input": inp}
+    ]}}
+
+
+def _tool_result(tool_use_id, text):
+    return {"message": {"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": tool_use_id, "content": text}
+    ]}}
+
+
+def _extract(msgs):
+    """extract_team_state with config isolation (no live ~/.claude/teams/ merge)."""
+    from cozempic.team import extract_team_state
+    with patch("cozempic.team.load_team_configs", return_value=[]):
+        return extract_team_state(msgs)
+
+
+def _create(idx, uid, real_id, subject):
+    """A TaskCreate tool_use immediately followed by its 'Task #N created' result."""
+    return [
+        (idx, _tool_use(uid, "TaskCreate", {"subject": subject}), 100),
+        (idx + 1, _tool_result(uid, f"Task #{real_id} created successfully: {subject}"), 80),
+    ]
+
+
+def _update(idx, uid, real_id, status):
+    return [(idx, _tool_use(uid, "TaskUpdate", {"taskId": str(real_id), "status": status}), 80)]
+
+
+def _by_subject(state, subject):
+    return [t for t in state.tasks if (t.subject or "").strip() == subject]
+
+
+class TestTaskListKeying(unittest.TestCase):
+    def test_completed_task_not_rendered_pending(self):
+        """A created-then-completed task must read 'completed', not 'pending'."""
+        msgs = []
+        msgs += _create(0, "c5", 5, "Ship the widget")
+        msgs += _update(2, "u5", 5, "completed")
+        state = _extract(msgs)
+
+        matches = _by_subject(state, "Ship the widget")
+        self.assertEqual(len(matches), 1, "task should appear exactly once")
+        self.assertEqual(matches[0].status, "completed",
+                         "completed task must not render as pending")
+
+    def test_no_phantom_blank_task_from_update(self):
+        """The TaskUpdate must not fabricate a blank-subject phantom task."""
+        msgs = []
+        msgs += _create(0, "c1", 1, "Only task")
+        msgs += _update(2, "u1", 1, "completed")
+        state = _extract(msgs)
+        blanks = [t for t in state.tasks if not (t.subject or "").strip()]
+        self.assertEqual(blanks, [], f"no phantom blank tasks expected, got {blanks}")
+
+    def test_first_created_task_not_orphaned(self):
+        """With several tasks all completed, none should remain pending."""
+        msgs = []
+        msgs += _create(0, "c1", 1, "First")
+        msgs += _create(2, "c2", 2, "Second")
+        msgs += _create(4, "c3", 3, "Third")
+        msgs += _update(6, "u1", 1, "completed")
+        msgs += _update(7, "u2", 2, "completed")
+        msgs += _update(8, "u3", 3, "completed")
+        state = _extract(msgs)
+        pending = [t.subject for t in state.tasks
+                   if (t.status or "") not in ("completed", "deleted")
+                   and (t.subject or "").strip()]
+        self.assertEqual(pending, [], f"all tasks completed; none should be pending, got {pending}")
+
+    def test_id_reuse_latest_generation_wins(self):
+        """A task-store reset reuses id #1; the latest generation must win."""
+        msgs = []
+        msgs += _create(0, "a1", 1, "Old gen task")
+        msgs += _update(2, "ua1", 1, "completed")
+        # store reset — id 1 reused for a brand-new task
+        msgs += _create(4, "b1", 1, "New gen task")
+        msgs += _update(6, "ub1", 1, "in_progress")
+        state = _extract(msgs)
+
+        new = _by_subject(state, "New gen task")
+        self.assertEqual(len(new), 1)
+        self.assertEqual(new[0].status, "in_progress",
+                         "latest-generation task #1 must reflect its own status")
+        self.assertEqual(_by_subject(state, "Old gen task"), [],
+                         "superseded generation must not linger")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_list_keying.py
+++ b/tests/test_task_list_keying.py
@@ -110,5 +110,58 @@ class TestTaskListKeying(unittest.TestCase):
                          "superseded generation must not linger")
 
 
+class TestTaskListKeyingTornTranscripts(unittest.TestCase):
+    """Hardening for torn/reordered/reworded transcripts (#167 review nits).
+
+    The re-key depends on the create's tool_result existing AND matching
+    `Task #N created`. When ordering or text drift breaks that, the fix must
+    still not regress: never render a completed task as pending, never leak the
+    internal `__pending_create_<uid>` sentinel, and recover if a good result
+    arrives later.
+    """
+
+    def test_update_before_result_keeps_completed(self):
+        """Out-of-order: TaskUpdate(completed) precedes the create-result.
+
+        The re-key must NOT clobber the authoritative 'completed' with the
+        create's 'pending'; it must backfill the subject onto the real entry.
+        """
+        msgs = [
+            (0, _tool_use("c1", "TaskCreate", {"subject": "Build feature X"}), 100),
+            (1, _tool_use("u1", "TaskUpdate", {"taskId": "1", "status": "completed", "owner": "alice"}), 80),
+            (2, _tool_result("c1", "Task #1 created successfully: Build feature X"), 80),
+        ]
+        state = _extract(msgs)
+        matches = _by_subject(state, "Build feature X")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].status, "completed",
+                         "out-of-order completion must survive the re-key")
+        self.assertEqual(matches[0].owner, "alice", "owner from the update must survive")
+
+    def test_missing_result_no_sentinel_leak(self):
+        """A create whose result was truncated away must not leak the temp key."""
+        msgs = [(0, _tool_use("c1", "TaskCreate", {"subject": "Orphan task"}), 100)]
+        state = _extract(msgs)
+        leaked = [t for t in state.tasks if t.task_id.startswith("__pending_create_")]
+        self.assertEqual(leaked, [], f"internal sentinel must not reach output, got {leaked}")
+        self.assertEqual(_by_subject(state, "Orphan task")[0].status, "pending")
+
+    def test_regex_miss_then_duplicate_result_recovers(self):
+        """A reworded first result must not consume the mapping — a later good
+        (duplicate) result must still recover the real id."""
+        msgs = [
+            (0, _tool_use("c1", "TaskCreate", {"subject": "Retry task"}), 100),
+            (1, _tool_result("c1", "Created task 1 (reworded, no canonical phrase)"), 80),
+            (2, _tool_result("c1", "Task #1 created successfully: Retry task"), 80),
+            (3, _tool_use("u1", "TaskUpdate", {"taskId": "1", "status": "completed"}), 80),
+        ]
+        state = _extract(msgs)
+        matches = _by_subject(state, "Retry task")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].status, "completed",
+                         "duplicate good result must recover the id after a regex miss")
+        self.assertEqual(matches[0].task_id, "1")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

After a compaction, the recovered checkpoint's shared task list (`## Active Task List` / "Shared active tasks") renders tasks that were **already completed** as still `[ ]` pending, and sometimes shows phantom blank tasks. Because `cmd_post_compact` writes the checkpoint to stdout (injected as post-compact context) and `inject_team_recovery` injects team state on the prune path, this incorrect list is also fed back to the model — so the agent is told finished work is still outstanding.

## Root cause

`extract_team_state()` keys created and updated tasks in two **different namespaces**:

- `TaskCreate`'s tool **input has no id** — the system assigns it and returns it only in the tool_result (`"Task #N created"`). The extractor therefore keyed created tasks **positionally**: `task_id = _sfield(inp, "taskId", "id") or str(len(seen_tasks))` → `"0", "1", "2", …`.
- `TaskUpdate`'s input **does** carry the real system id (`{"taskId": "1", …}`, 1-based).

So a `TaskUpdate(taskId="1", status="completed")` lands on the **positional** slot `"1"` (the *second* created task), not real task #1. Consequences:

- completions are applied to the wrong task;
- the first-created task (positional key `"0"`) is **never** matched by any update, so it is stuck `pending` forever;
- an update whose id exceeds the positional range falls through to the `else` branch and **fabricates a phantom blank task**.

This is made worse when the task store resets mid-session and re-issues ids from #1 (the positional and real namespaces diverge further).

### Minimal repro

```python
msgs = [
    (0, {"message": {"role": "assistant", "content": [
        {"type": "tool_use", "id": "c1", "name": "TaskCreate", "input": {"subject": "Ship it"}}]}}, 100),
    (1, {"message": {"role": "user", "content": [
        {"type": "tool_result", "tool_use_id": "c1", "content": "Task #1 created successfully: Ship it"}]}}, 80),
    (2, {"message": {"role": "assistant", "content": [
        {"type": "tool_use", "id": "u1", "name": "TaskUpdate", "input": {"taskId": "1", "status": "completed"}}]}}, 80),
]
state = extract_team_state(msgs)
# before: task "Ship it" -> status "pending"  (+ a phantom blank "completed" task)
# after:  task "Ship it" -> status "completed"
```

## Fix

Re-key each `TaskCreate` to its **real** id, parsed from the `"Task #N created"` tool_result:

- park the created task under a temp key tied to its `tool_use_id`;
- when the matching tool_result arrives, parse the real id and re-key the task to it;
- a reused id (task-store reset) overwrites the older generation — latest-generation-wins, matching the live store which only holds the latest.

Fail-open: if a create's tool_result is missing (e.g. a truncated transcript), the task stays visible under its temp key rather than disappearing.

## Tests

`tests/test_task_list_keying.py` (4 cases) — completed-task-not-pending, no-phantom-blank, first-task-not-orphaned, id-reuse-latest-generation-wins. They **fail on the positional-keying base and pass with the fix**. The full existing team suite (`test_team_schema`, `test_guard_team_agent_spawn`, `test_post_compact`, `test_team_recovery_receipt`) stays green — 105 passed total.
