### PR TITLE
fix(#168): POSIX-safe SessionStart hook — replace ${SESSION_ID:0:12} bashism (Bad substitution on dash)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       },
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       },
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -82,7 +82,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -102,7 +102,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -122,7 +122,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v14"
           }
         ]
       }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v14"
           }
         ]
       }

--- a/src/cozempic/data/hooks.json
+++ b/src/cozempic/data/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SESSION_ID:0:12}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SESSION_ID:0:12}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v14"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v13"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v14"
           }
         ]
       }

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -39,7 +39,11 @@ def _c(args: str) -> str:
 # at the end of every canonical hook command (e.g. "# cozempic-hook-schema=v2")
 # is what `_is_current_cozempic_hook` looks for — old hooks without the current
 # marker are treated as stale and get refreshed on next init.
-HOOK_SCHEMA_VERSION = "v13"
+# v14: replace the bash-only `${SESSION_ID:0:12}` substring expansion with a
+# POSIX-safe `SLUG=$(printf '%.12s' "$SESSION_ID")` so the SessionStart hook no
+# longer aborts with "Bad substitution" under dash (/bin/sh on Debian/Ubuntu),
+# which silently killed the guard-daemon spawn on those systems (#168).
+HOOK_SCHEMA_VERSION = "v14"
 HOOK_SCHEMA_MARKER = f"cozempic-hook-schema={HOOK_SCHEMA_VERSION}"
 
 

--- a/tests/test_atomic_writes_wave1.py
+++ b/tests/test_atomic_writes_wave1.py
@@ -335,20 +335,21 @@ class TestHookSchemaV9(unittest.TestCase):
         daemon spawn runs inside a flock on a dedicated `*.startup-lock`
         file (distinct from the existing hook-level `*.lock`). The two locks
         MUST be distinct files so the daemon-spawn lock doesn't serialize
-        unrelated hook work. Slug source is ``${SESSION_ID:0:12}`` — the
-        bash side uses the permissive ``re.sub`` sanitiser, the same
-        12-char prefix Python now produces via the relaxed regex."""
+        unrelated hook work. Slug source is ``${SLUG}`` (POSIX
+        ``printf '%.12s' "$SESSION_ID"`` — #168) — the bash side uses the
+        permissive ``re.sub`` sanitiser, the same 12-char prefix Python now
+        produces via the relaxed regex."""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
         self.assertIn("GUARD_STARTUP_LOCK=", ss_cmd,
             "Expected a dedicated GUARD_STARTUP_LOCK variable for the "
             "second-layer flock guarding the daemon spawn")
-        self.assertIn("/tmp/cozempic_guard_${SESSION_ID:0:12}.startup-lock", ss_cmd,
-            "GUARD_STARTUP_LOCK path must use ${SESSION_ID:0:12} — first 12 chars "
-            "of the bash-sanitised lowercased session_id. Convergence (C2/Option B) "
-            "is achieved by Python relaxing its regex to match this character set, "
-            "not by bash tightening to match a stricter Python regex.")
+        self.assertIn("/tmp/cozempic_guard_${SLUG}.startup-lock", ss_cmd,
+            "GUARD_STARTUP_LOCK path must use ${SLUG} — the POSIX-safe first 12 "
+            "chars of the bash-sanitised lowercased session_id (#168). Convergence "
+            "(C2/Option B) is achieved by Python relaxing its regex to match this "
+            "character set, not by bash tightening to match a stricter Python regex.")
         # The startup-lock must use a DIFFERENT fd than the outer hook lock
         # (fd 9) — otherwise the inner flock acquire would race the outer.
         self.assertIn("flock -n 8", ss_cmd,
@@ -360,9 +361,9 @@ class TestHookSchemaV9(unittest.TestCase):
         """v8 keeps v7's fast-path invariant: the SessionStart hook must wrap
         the guard --daemon spawn in a `kill -0 $(cat GUARD_PID_FILE)` fast-path
         so a healthy daemon for the current session is NOT respawned. The
-        GUARD_PID_FILE path uses ``${SESSION_ID:0:12}`` (bash-sanitised
-        lowercased session_id, first 12 chars) — Python's relaxed regex
-        produces the same slug for the same input."""
+        GUARD_PID_FILE path uses ``${SLUG}`` (POSIX ``printf '%.12s'`` of the
+        bash-sanitised lowercased session_id, first 12 chars — #168) — Python's
+        relaxed regex produces the same slug for the same input."""
         hooks_path = Path(__file__).parent.parent / "src" / "cozempic" / "data" / "hooks.json"
         hooks = json.loads(hooks_path.read_text())
         ss_cmd = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
@@ -373,10 +374,10 @@ class TestHookSchemaV9(unittest.TestCase):
         # Path must match Python's `_pid_file_for_session` convention
         # (/tmp/cozempic_guard_<slug>.pid where <slug> = first 12 chars of
         # the lowercased+sanitised session_id; Python validates same charset).
-        self.assertIn("/tmp/cozempic_guard_${SESSION_ID:0:12}.pid", ss_cmd,
-            "Fast-path PID file path must use ${SESSION_ID:0:12} — first 12 chars "
-            "of the bash-sanitised lowercased session_id, which (post-C2 Option B) "
-            "matches the slug Python computes via the relaxed _SESSION_ID_RE.")
+        self.assertIn("/tmp/cozempic_guard_${SLUG}.pid", ss_cmd,
+            "Fast-path PID file path must use ${SLUG} — the POSIX-safe first 12 "
+            "chars of the bash-sanitised lowercased session_id (#168), which "
+            "(post-C2 Option B) matches the slug Python computes via _SESSION_ID_RE.")
 
     def test_session_id_lowercased(self):
         """The hook MUST lowercase the session_id before sanitising — Python's

--- a/tests/test_hook_posix_dash.py
+++ b/tests/test_hook_posix_dash.py
@@ -1,0 +1,70 @@
+"""#168: the SessionStart hook must be POSIX-sh clean.
+
+Claude Code invokes hooks with `/bin/sh`. On Debian/Ubuntu that is dash, which
+does NOT support bash's `${var:offset:length}` substring expansion — the hook
+used `${SESSION_ID:0:12}` and aborted with "Bad substitution", silently killing
+the guard-daemon spawn on those systems. The fix computes the slug once with the
+POSIX-safe `SLUG=$(printf '%.12s' "$SESSION_ID")`.
+
+These tests pin: (1) no bash-only substring expansion survives in any shipped
+hook, (2) the POSIX slug is defined and used, and (3) the construct runs clean
+under a strict POSIX shell (dash if present) producing the same 12-char slug.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SHIPPED_HOOKS = [
+    ROOT / "src" / "cozempic" / "data" / "hooks.json",
+    ROOT / "plugin" / "hooks" / "hooks.json",
+]
+
+# bash-only ${var:offset[:length]} substring expansion — a colon FOLLOWED BY A
+# DIGIT. Deliberately does NOT match the POSIX forms ${var:-default},
+# ${var:+alt}, ${var:=default} (colon followed by -, +, =).
+_BASH_SUBSTRING = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*:[0-9]")
+
+
+class TestSessionStartHookIsPosix(unittest.TestCase):
+    def _ss_cmd(self, path: Path) -> str:
+        data = json.loads(path.read_text())
+        return data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+    def test_no_bash_only_substring_expansion(self):
+        for f in SHIPPED_HOOKS:
+            cmd = self._ss_cmd(f)
+            m = _BASH_SUBSTRING.search(cmd)
+            self.assertIsNone(
+                m, f"{f.name}: bash-only substring expansion "
+                f"{m.group(0) if m else ''!r} breaks under dash (#168)")
+
+    def test_defines_and_uses_posix_slug(self):
+        for f in SHIPPED_HOOKS:
+            cmd = self._ss_cmd(f)
+            self.assertIn(
+                "SLUG=$(printf '%.12s' \"$SESSION_ID\")", cmd,
+                f"{f.name}: must define the slug via POSIX printf (#168)")
+            self.assertIn(
+                "${SLUG}", cmd,
+                f"{f.name}: tmp paths must reference the portable ${{SLUG}}")
+
+    def test_slug_runs_clean_under_posix_sh(self):
+        """The POSIX slug construct yields the same 12-char prefix as bash's
+        ${SESSION_ID:0:12} under a strict POSIX shell, with no error."""
+        sh = shutil.which("dash") or "/bin/sh"
+        snippet = ('SESSION_ID=5d53e013-32d9-4e72-9a3a-deadbeefcafe; '
+                   'SLUG=$(printf "%.12s" "$SESSION_ID"); printf %s "$SLUG"')
+        out = subprocess.run([sh, "-c", snippet], capture_output=True, text=True)
+        self.assertEqual(out.returncode, 0, f"{sh}: {out.stderr}")
+        self.assertNotIn("Bad substitution", out.stderr)
+        self.assertEqual(out.stdout, "5d53e013-32d",
+                         "POSIX slug must equal bash ${SESSION_ID:0:12}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_id_parity.py
+++ b/tests/test_session_id_parity.py
@@ -51,7 +51,8 @@ def _bash_slug(session_id: str) -> str:
             s = json.load(sys.stdin).get('session_id','').lower()
             print(re.sub(r'[^a-z0-9_-]', '_', s))
         ")
-        GUARD_PID_FILE="/tmp/cozempic_guard_${SESSION_ID:0:12}.pid"
+        SLUG=$(printf '%.12s' "$SESSION_ID")      # POSIX-safe, #168
+        GUARD_PID_FILE="/tmp/cozempic_guard_${SLUG}.pid"
 
     So the bash slug is: ``re.sub(r'[^a-z0-9_-]', '_', s.lower())[:12]``.
     """

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -669,8 +669,9 @@ class TestC2_SlugConvergence(unittest.TestCase):
             s = json.load(sys.stdin).get('session_id','').lower()
             print(re.sub(r'[^a-z0-9_-]', '_', s))
 
-        Then the shell takes ``${SESSION_ID:0:12}`` as the slug. So the
-        composite contract is: lowercase → sub non-``[a-z0-9_-]`` with
+        Then the shell takes ``SLUG=$(printf '%.12s' "$SESSION_ID")`` as the
+        slug (POSIX-safe, #168). So the composite contract is unchanged:
+        lowercase → sub non-``[a-z0-9_-]`` with
         ``_`` → take first 12 chars. Always returns a string (possibly
         empty if input is empty); the shell's ``[ -n "$SESSION_ID" ]``
         gate is what skips the spawn for empty inputs.


### PR DESCRIPTION
Fixes #168.

## Problem
Claude Code invokes hooks with `/bin/sh`. On Debian/Ubuntu that is **dash**, which does not support bash's `${var:offset:length}` substring expansion. The `SessionStart` hook used `${SESSION_ID:0:12}` in five places, so on dash systems it aborted with `Bad substitution` — and everything downstream of the first one died:
- the auto-update block,
- `cozempic guard --reload-self`,
- the `cozempic guard --daemon` spawn (its lock/pid/sentinel paths are all built from the slug).

Net effect: **the guard daemon was silently never spawned from `SessionStart` on dash systems**, and the user saw a hook error at the top of every session. (Not seen on macOS, where `/bin/sh` is bash.)

## Fix
Compute the 12-char slug once with the POSIX-safe form the reporter suggested:
```sh
SLUG=$(printf '%.12s' "$SESSION_ID")
```
and reference `${SLUG}` for every tmp path. `printf '%.12s'` is POSIX and byte-identical to `${SESSION_ID:0:12}` on bash, so the **shell↔Python slug parity** (`test_session_id_parity`, `test_spawn_lock`) is preserved unchanged.

Bumped the hook schema **v13 → v14** across all canonical hooks so already-installed v13 hooks are detected as stale and **re-wired with the fix** on next init / auto-init.

## Verification (real `/bin/dash`)
- Old form: `dash -c '...${SESSION_ID:0:12}...'` → `Bad substitution`.
- New form and the **full patched SessionStart command** → run clean, reach `guard active`.
- New regression test `tests/test_hook_posix_dash.py` pins: (1) no bash-only `${var:N...}` substring expansion in any shipped hook, (2) the POSIX slug is defined + used, (3) the construct runs clean under dash with the same 12-char output.
- Full suite **1892 passed** (1 unrelated known watcher flake deselected).

Thanks to the reporter for the precise root-cause and the correct POSIX fix.