### PR TITLE
release: 1.8.39 — dash hook fix (#168) + task-list keying (#167) + pre-release fast-follow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools",
-    "version": "1.8.38",
+    "version": "1.8.39",
     "pluginRoot": "./plugin"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "cozempic",
       "source": "./plugin",
       "description": "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools",
-      "version": "1.8.38",
+      "version": "1.8.39",
       "category": "productivity",
       "tags": ["context", "pruning", "compaction", "agent-teams", "tokens", "optimization"]
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cozempic
 
-![Downloads](https://img.shields.io/badge/downloads-100k%2B-brightgreen) ![Version](https://img.shields.io/badge/version-1.8.38-blue) ![License](https://img.shields.io/badge/license-MIT-lightgrey)
+![Downloads](https://img.shields.io/badge/downloads-100k%2B-brightgreen) ![Version](https://img.shields.io/badge/version-1.8.39-blue) ![License](https://img.shields.io/badge/license-MIT-lightgrey)
 
 **100,000+ power users** trust Cozempic to keep their Claude Code sessions lean.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozempic",
-  "version": "1.8.38",
+  "version": "1.8.39",
   "description": "Context weight-loss for Claude Code — prune bloated sessions, protect Agent Teams from compaction",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cozempic",
-  "version": "1.8.38",
+  "version": "1.8.39",
   "description": "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools",
   "author": {
     "name": "Ruya AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cozempic"
-version = "1.8.38"
+version = "1.8.39"
 description = "2x the effective context with smart weight-loss for Claude Code — prune bloated sessions, protect agent teams from compaction, monitor token usage with MCP tools"
 readme = "README.md"
 license = "MIT"
@@ -40,3 +40,10 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 cozempic = ["data/*.md", "data/*.json"]
+
+[tool.pytest.ini_options]
+# Test against the working tree, not a stale installed wheel. Without this, a
+# non-editable `pip install cozempic` in the venv shadows src/ and a bare
+# `pytest` silently runs the OLD code (false green/red). Keep src/ first.
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/cozempic/__init__.py
+++ b/src/cozempic/__init__.py
@@ -1,3 +1,3 @@
 """Cozempic - Context weight-loss tool for Claude Code."""
 
-__version__ = "1.8.38"
+__version__ = "1.8.39"

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1766,7 +1766,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="cozempic",
         description="Context weight-loss tool for Claude Code — prune bloated JSONL conversation files",
     )
-    parser.add_argument("--version", action="version", version="%(prog)s 1.8.38")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.8.39")
     parser.add_argument("--context-window", type=int, default=None, help="Override context window size in tokens (e.g. 1000000 for 1M beta)")
     parser.add_argument("--system-overhead-tokens", type=int, default=None, help="Override system overhead estimate (default: 21000). Increase for heavy rules/MCP configs.")
     sub = parser.add_subparsers(dest="command")

--- a/src/cozempic/team.py
+++ b/src/cozempic/team.py
@@ -81,6 +81,11 @@ class TaskInfo:
     status: str = "pending"
     owner: str = ""
     description: str = ""
+    # True once this entry is backed by a real TaskCreate (vs. a placeholder
+    # synthesized from an out-of-order TaskUpdate). Used to classify id-reuse
+    # (real prior generation → overwrite) vs. a subject-less update fragment
+    # (→ merge, keep its authoritative status) without inferring from `subject`.
+    from_create: bool = False
 
 
 @dataclass
@@ -835,6 +840,7 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                         status="pending",
                         owner=_sfield(inp, "owner"),
                         description=_sfield(inp, "description"),
+                        from_create=True,
                     )
 
                 # TaskUpdate (shared todo list)
@@ -894,21 +900,24 @@ def extract_team_state(messages: list[Message]) -> TeamState:
                             _rid = _m_tc.group(1)
                             _info = seen_tasks.pop(_tc_temp)
                             _existing = seen_tasks.get(_rid)
-                            if _existing is None or _existing.subject:
-                                # Free id, OR a real prior-generation task holds it
-                                # (a store reset reused #N) — latest generation wins:
-                                # install the fresh create. A prior task is identified
-                                # by having a subject (only a real TaskCreate sets one).
+                            if _existing is None or _existing.from_create:
+                                # Free id, OR a real prior-generation task already holds
+                                # it (a store reset reused #N) — latest generation wins:
+                                # install the fresh create. `from_create` marks a genuine
+                                # prior TaskCreate (not inferred from `subject`, which an
+                                # out-of-order TaskUpdate can also carry).
                                 _info.task_id = _rid
                                 seen_tasks[_rid] = _info
                             else:
-                                # The id is held by a SUBJECT-LESS entry: an out-of-order
-                                # TaskUpdate that already recorded THIS create's status
-                                # (torn/reordered transcript). Keep its authoritative
-                                # status/owner — never clobber e.g. "completed" with the
-                                # create's "pending" — and backfill the create's subject/
-                                # description so the recovered row isn't blank.
+                                # The id is held by a placeholder synthesized from an
+                                # out-of-order TaskUpdate (torn/reordered transcript).
+                                # Keep its authoritative status/owner — never clobber
+                                # e.g. "completed" with the create's "pending" — and
+                                # backfill the create's subject/description so the row
+                                # isn't blank. It's now backed by a real create, so mark
+                                # it as such for any later same-id reuse.
                                 _existing.task_id = _rid
+                                _existing.from_create = True
                                 _existing.subject = _info.subject
                                 if not _existing.description:
                                     _existing.description = _info.description
@@ -1142,11 +1151,20 @@ def extract_team_state(messages: list[Message]) -> TeamState:
     # A TaskCreate whose result was missing/torn/reworded never got re-keyed, so
     # its task_id still holds the internal "__pending_create_<uid>" sentinel.
     # Rewrite those to a clean positional id (matching the pre-#167 convention) so
-    # the sentinel never leaks to JSON consumers (_summary_dict / to_dict). Markdown
-    # already renders by subject+status, so this is display-invisible there.
-    for _i, _t in enumerate(seen_tasks.values()):
+    # the sentinel never appears in internal state. Markdown renders by
+    # subject+status, so this is display-invisible; the rewrite keeps task_id sane
+    # for any future consumer. Skip ids already taken by a real re-keyed task so we
+    # never mint a duplicate task_id.
+    _used_ids = {_t.task_id for _t in seen_tasks.values()
+                 if not _t.task_id.startswith("__pending_create_")}
+    _next = 0
+    for _t in seen_tasks.values():
         if _t.task_id.startswith("__pending_create_"):
-            _t.task_id = str(_i)
+            while str(_next) in _used_ids:
+                _next += 1
+            _t.task_id = str(_next)
+            _used_ids.add(str(_next))
+            _next += 1
     state.tasks = list(seen_tasks.values())
     state.config_source = "jsonl" if state.message_count > 0 else ""
 

--- a/tests/test_task_list_keying.py
+++ b/tests/test_task_list_keying.py
@@ -162,6 +162,56 @@ class TestTaskListKeyingTornTranscripts(unittest.TestCase):
                          "duplicate good result must recover the id after a regex miss")
         self.assertEqual(matches[0].task_id, "1")
 
+    def test_ooo_update_with_subject_keeps_completed(self):
+        """F1: an out-of-order TaskUpdate that ALSO carries a subject must not be
+        misread as a prior generation — the create-result must keep 'completed',
+        not revert to the create's 'pending'. (Provenance is tracked via
+        from_create, not inferred from the presence of a subject.)"""
+        msgs = [
+            (0, _tool_use("u5", "TaskUpdate",
+                          {"taskId": "5", "status": "completed", "owner": "al", "subject": "finish auth"}), 100),
+            (1, _tool_use("c5", "TaskCreate", {"subject": "finish auth"}), 100),
+            (2, _tool_result("c5", "Task #5 created"), 80),
+        ]
+        state = _extract(msgs)
+        m = _by_subject(state, "finish auth")
+        self.assertEqual(len(m), 1)
+        self.assertEqual(m[0].status, "completed",
+                         "subject-carrying OOO completion must survive the re-key")
+        self.assertEqual(m[0].owner, "al")
+
+    def test_subjectless_create_reuse_does_not_inherit_completed(self):
+        """F2: a subject-less create that later gets completed, then the same id is
+        reused by a brand-new create, must NOT let the new task inherit the old
+        'completed' status."""
+        msgs = [
+            (0, _tool_use("c1", "TaskCreate", {}), 100),
+            (1, _tool_result("c1", "Task #3 created"), 80),
+            (2, _tool_use("u1", "TaskUpdate", {"taskId": "3", "status": "completed"}), 80),
+            (3, _tool_use("c2", "TaskCreate", {"subject": "gen2 task"}), 100),
+            (4, _tool_result("c2", "Task #3 created"), 80),
+        ]
+        state = _extract(msgs)
+        g2 = _by_subject(state, "gen2 task")
+        self.assertEqual(len(g2), 1)
+        self.assertEqual(g2[0].status, "pending",
+                         "reused-id new generation must not inherit the prior completion")
+
+    def test_sentinel_normalization_no_duplicate_ids(self):
+        """F3: normalizing stranded __pending_create_ sentinels must not mint a
+        task_id that collides with a real re-keyed numeric id."""
+        msgs = [
+            (0, _tool_use("a", "TaskCreate", {"subject": "torn one"}), 100),   # no result
+            (1, _tool_use("b", "TaskCreate", {"subject": "torn two"}), 100),   # no result
+            (2, _tool_use("c", "TaskCreate", {"subject": "real"}), 100),
+            (3, _tool_result("c", "Task #1 created"), 80),
+        ]
+        state = _extract(msgs)
+        ids = [t.task_id for t in state.tasks]
+        self.assertEqual(len(ids), len(set(ids)), f"task_ids must be unique, got {ids}")
+        self.assertNotIn("__pending_create_", "".join(ids), "no sentinel may leak")
+        self.assertEqual(_by_subject(state, "real")[0].task_id, "1", "real task keeps its parsed id")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Ships the unreleased main work since 1.8.38, plus the pre-release fleet's fast-follow findings (all fixed with regression tests).

## Included
- **#168** — POSIX-safe SessionStart hook: replace `${SESSION_ID:0:12}` bashism with `SLUG=$(printf '%.12s')` so the guard no longer dies with `Bad substitution` under dash. Hook schema **v13→v14** (re-wires installed hooks). Verified under real `/bin/dash`.
- **#167** — shared-task-list real-id re-keying so completed tasks stop rendering as pending after compaction, + torn-transcript hardening.
- **#166** — docs hygiene.

## Pre-release fleet fast-follow
The full-diff adversarial fleet returned **SHIP (zero blockers)** but surfaced 6 non-blocking findings; fixed the substantive ones before tagging:
- **F1/F2 (medium)** — `team.py` now tracks task provenance via a `from_create` flag instead of inferring generation from `subject`. Fixes: a subject-carrying out-of-order `TaskUpdate` reverting a completed task to pending (F1), and a reused id making a new task inherit the old completion (F2).
- **F3 (low)** — sentinel normalization is collision-aware (a stranded `__pending_create_` id can't be renumbered onto a real re-keyed numeric id).
- **F5 (nit)** — corrected a comment referencing non-existent JSON consumers.
- **F4** — `pyproject.toml` pins `[tool.pytest.ini_options] pythonpath=["src"]` so a bare `pytest` tests the working tree, not a stale installed wheel that shadows `src/` (the false-green risk that masked earlier runs).
- **F6** — non-issue (badge and prose already agree at 100k+).

## Verification
- Full suite **1896 passed / 5 skipped** (bare `pytest`, via the new pin).
- Wheel verified: `__version__` 1.8.39, hook schema v14 (no v13), POSIX SLUG (no bashism), provenance + collision fixes present.