### PR TITLE
Load default protect patterns from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ cozempic guard --daemon
 
 **Token thresholds auto-detect** — 200K and 1M models detected automatically. Override with `COZEMPIC_CONTEXT_WINDOW=200000` for Pro plan.
 
+**Default protected patterns** — put regexes in `~/.cozempic/config.json` so every `treat`, `reload`, and guard cycle protects matching messages without repeating CLI flags:
+
+```json
+{
+  "protect_patterns": ["SPR-", "control-file"]
+}
+```
+
 ## Behavioral Digest
 
 Cozempic extracts your corrections and persists them across compactions:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -354,14 +354,15 @@ def _compile_protect_patterns_or_exit(args):
     cli_raw = list(getattr(args, "protect_pattern", None) or [])
     compiled = []
     seen = set()
-    if cfg_raw:
+    for raw in cfg_raw:
         try:
-            for pat in compile_protect_patterns(cfg_raw):
-                if pat.pattern not in seen:
-                    compiled.append(pat)
-                    seen.add(pat.pattern)
+            pat = compile_protect_patterns([raw])[0]
         except ValueError as e:
-            print(f"  Warning: ignoring config protect_patterns: {e}", file=sys.stderr)
+            print(f"  Warning: ignoring config protect_pattern {raw!r}: {e}", file=sys.stderr)
+            continue
+        if pat.pattern not in seen:
+            compiled.append(pat)
+            seen.add(pat.pattern)
     if not cli_raw:
         return compiled or None
     try:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -345,16 +345,34 @@ def cmd_diagnose(args):
 
 
 def _compile_protect_patterns_or_exit(args):
-    """Compile --protect-pattern regexes from args, or exit(2) with a clean error.
-    Returns the compiled list, or None when the flag is unused (#122, @eggrollofchaos)."""
-    raw = getattr(args, "protect_pattern", None)
-    if not raw:
-        return None
+    """Compile configured and CLI protect-pattern regexes.
+
+    Config defaults fail soft so a stale ~/.cozempic/config.json cannot kill the
+    daemon. Explicit CLI flags still fail loud with exit(2).
+    """
+    cfg_raw = list(load_config().protect_patterns)
+    cli_raw = list(getattr(args, "protect_pattern", None) or [])
+    compiled = []
+    seen = set()
+    if cfg_raw:
+        try:
+            for pat in compile_protect_patterns(cfg_raw):
+                if pat.pattern not in seen:
+                    compiled.append(pat)
+                    seen.add(pat.pattern)
+        except ValueError as e:
+            print(f"  Warning: ignoring config protect_patterns: {e}", file=sys.stderr)
+    if not cli_raw:
+        return compiled or None
     try:
-        return compile_protect_patterns(raw)
+        for pat in compile_protect_patterns(cli_raw):
+            if pat.pattern not in seen:
+                compiled.append(pat)
+                seen.add(pat.pattern)
     except ValueError as e:
         print(f"  Error: {e}", file=sys.stderr)
         sys.exit(2)
+    return compiled or None
 
 
 _TIER_NAMES = {"gentle", "standard", "aggressive"}

--- a/src/cozempic/config.py
+++ b/src/cozempic/config.py
@@ -5,6 +5,8 @@ prune-safety defense-in-depth fix (P0-B/C/D port onto v1.8.18 terminate-first):
 
   - ``floor``: per-prune protections — max % of user/assistant messages that
     may drop, last-K turns guaranteed to survive, first-message guarantee.
+  - ``protect_patterns``: default user regexes whose matching message content
+    gets prune immunity.
 
 Precedence: environment variable > ``~/.cozempic/config.json`` > built-in default.
 
@@ -70,6 +72,7 @@ class Config:
     """Top-level cozempic runtime config."""
 
     floor: FloorConfig = field(default_factory=FloorConfig)
+    protect_patterns: tuple[str, ...] = ()
 
 
 # ── Clamping helpers ──────────────────────────────────────────────────────────
@@ -229,6 +232,18 @@ def _resolve_floor_with(file_data: dict[str, Any]) -> FloorConfig:
     )
 
 
+def _resolve_protect_patterns_with(file_data: dict[str, Any]) -> tuple[str, ...]:
+    """Resolve default protect-pattern regex strings from config file data.
+
+    Regex compilation happens at the CLI/guard boundary so explicit CLI flags
+    can still fail loud while bad config defaults fail soft.
+    """
+    raw_patterns = file_data.get("protect_patterns", ())
+    if not isinstance(raw_patterns, list):
+        return ()
+    return tuple(pat for pat in raw_patterns if isinstance(pat, str))
+
+
 def load_config() -> Config:
     """Load the active runtime config (env → file → default).
 
@@ -238,4 +253,7 @@ def load_config() -> Config:
     floor behavior between reads.
     """
     file_data = _read_config_file()
-    return Config(floor=_resolve_floor_with(file_data))
+    return Config(
+        floor=_resolve_floor_with(file_data),
+        protect_patterns=_resolve_protect_patterns_with(file_data),
+    )

--- a/tests/test_protect_pattern.py
+++ b/tests/test_protect_pattern.py
@@ -12,8 +12,11 @@ from a strategy's removal actions.
 import io
 import unittest
 from contextlib import redirect_stderr
+from argparse import Namespace
+from types import SimpleNamespace
 from unittest import mock
 
+from cozempic.cli import _compile_protect_patterns_or_exit
 from cozempic.helpers import (
     compile_protect_patterns, tag_pattern_matches, strip_pattern_tags, is_protected,
     _msg_text_matches_any, _PATTERN_PROTECTED_KEY,
@@ -55,6 +58,44 @@ class TestCompileGuards(unittest.TestCase):
     def test_none_and_empty(self):
         self.assertEqual(compile_protect_patterns(None), [])
         self.assertEqual(compile_protect_patterns([]), [])
+
+    def test_cli_uses_config_default_patterns(self):
+        with mock.patch(
+            "cozempic.cli.load_config",
+            return_value=SimpleNamespace(protect_patterns=(r"FROM_CONFIG",)),
+        ):
+            pats = _compile_protect_patterns_or_exit(Namespace(protect_pattern=None))
+        self.assertEqual([pat.pattern for pat in pats], [r"FROM_CONFIG"])
+
+    def test_cli_combines_config_default_and_flag_patterns(self):
+        with mock.patch(
+            "cozempic.cli.load_config",
+            return_value=SimpleNamespace(protect_patterns=(r"FROM_CONFIG",)),
+        ):
+            pats = _compile_protect_patterns_or_exit(
+                Namespace(protect_pattern=[r"FROM_FLAG"])
+            )
+        self.assertEqual([pat.pattern for pat in pats], [r"FROM_CONFIG", r"FROM_FLAG"])
+
+    def test_cli_dedupes_config_and_flag_patterns(self):
+        with mock.patch(
+            "cozempic.cli.load_config",
+            return_value=SimpleNamespace(protect_patterns=(r"SAME",)),
+        ):
+            pats = _compile_protect_patterns_or_exit(
+                Namespace(protect_pattern=[r"SAME"])
+            )
+        self.assertEqual([pat.pattern for pat in pats], [r"SAME"])
+
+    def test_invalid_config_pattern_does_not_block_cli_pattern(self):
+        with mock.patch(
+            "cozempic.cli.load_config",
+            return_value=SimpleNamespace(protect_patterns=(r"(unclosed",)),
+        ):
+            pats = _compile_protect_patterns_or_exit(
+                Namespace(protect_pattern=[r"FROM_FLAG"])
+            )
+        self.assertEqual([pat.pattern for pat in pats], [r"FROM_FLAG"])
 
 
 class TestMatcherSurfaces(unittest.TestCase):

--- a/tests/test_protect_pattern.py
+++ b/tests/test_protect_pattern.py
@@ -90,12 +90,17 @@ class TestCompileGuards(unittest.TestCase):
     def test_invalid_config_pattern_does_not_block_cli_pattern(self):
         with mock.patch(
             "cozempic.cli.load_config",
-            return_value=SimpleNamespace(protect_patterns=(r"(unclosed",)),
+            return_value=SimpleNamespace(
+                protect_patterns=(r"GOOD_CONFIG", r"(unclosed", r"ALSO_GOOD")
+            ),
         ):
             pats = _compile_protect_patterns_or_exit(
                 Namespace(protect_pattern=[r"FROM_FLAG"])
             )
-        self.assertEqual([pat.pattern for pat in pats], [r"FROM_FLAG"])
+        self.assertEqual(
+            [pat.pattern for pat in pats],
+            [r"GOOD_CONFIG", r"ALSO_GOOD", r"FROM_FLAG"],
+        )
 
 
 class TestMatcherSurfaces(unittest.TestCase):

--- a/tests/test_prune_safety.py
+++ b/tests/test_prune_safety.py
@@ -456,6 +456,23 @@ class TestFloorConfig:
         assert cfg.preserve_last_k_turns == 10
         assert cfg.preserve_first_message is True
 
+    def test_config_default_protect_patterns(self):
+        """Config defaults expose protect_patterns from ~/.cozempic/config.json."""
+        from cozempic.config import Config, _resolve_protect_patterns_with
+
+        result = Config(
+            protect_patterns=_resolve_protect_patterns_with(
+                {"protect_patterns": [r"SPR-", r"control-file", 12]}
+            )
+        )
+        assert result.protect_patterns == (r"SPR-", r"control-file")
+
+    def test_config_default_protect_patterns_non_list_ignored(self):
+        """Invalid config shape must fail soft, not crash guard startup."""
+        from cozempic import config as cfg_mod
+
+        assert cfg_mod._resolve_protect_patterns_with({"protect_patterns": "SPR-"}) == ()
+
     def test_env_var_max_drop_pct(self, monkeypatch):
         """COZEMPIC_FLOOR_MAX_DROP_PCT=0.3 → FloorConfig.max_user_assistant_drop_pct == 0.3."""
         from cozempic import config as cfg_mod


### PR DESCRIPTION
## Summary
- Add `protect_patterns` support to `~/.cozempic/config.json`.
- Apply config defaults alongside explicit `--protect-pattern` values for treat, reload, and guard flows.
- Ignore invalid config regex defaults with a warning while preserving hard failures for invalid CLI flags.

## Tests
- `python -m pytest tests/test_protect_pattern.py tests/test_prune_safety.py`

Follow-up to #122, which was implemented  `feat(prune): --protect-pattern` (617758d) + hardening (64d9650). 

@junaidtitan 
