### PR TITLE
fix(init): refresh stale global hooks after upgrades

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1204,7 +1204,7 @@ def cmd_doctor(args):
 def cmd_uninstall(args):
     """Reverse `cozempic init` — remove hooks, the slash command, and markers.
 
-    Default scope is GLOBAL (~/.claude). Keeps the user's data (savings ledger,
+    Default scope is Claude's configured global directory. Keeps the user's data (savings ledger,
     receipts) unless --purge. Sets the auto-init opt-out so init won't re-wire.
     """
     from .init import preview_uninstall, run_uninstall
@@ -1223,6 +1223,8 @@ def cmd_uninstall(args):
         print(f"    Slash command (~/.claude/commands/cozempic.md): "
               f"{'remove' if prev['slash_command'] else '(not present / not ours)'}")
         print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
+        for error in prev.get("errors", []):
+            print(f"    Hooks: ERROR — {error}")
         if purge:
             print(f"    Purge data: {prev['purge_data'] or '(none)'}")
         print()
@@ -1240,11 +1242,14 @@ def cmd_uninstall(args):
 
     result = run_uninstall(scope, purge)
     n_hooks = sum(len(h.get("removed", [])) for h in result["hooks"])
-    print(f"  Removed {n_hooks} hook(s) across {len(result['hooks'])} settings file(s).")
+    successful_settings = [h for h in result["hooks"] if not h.get("error")]
+    print(f"  Removed {n_hooks} hook(s) across {len(successful_settings)} settings file(s).")
     for h in result["hooks"]:
         if h.get("removed"):
             print(f"    - {h['settings_path']}: {', '.join(h['removed'])}"
                   + (f"  (backup: {h['backup_path']})" if h.get("backup_path") else ""))
+        elif h.get("error"):
+            print(f"    - ERROR: {h['error']}")
     sc = result.get("slash_command")
     if sc and sc.get("removed"):
         print(f"  Removed slash command: {sc['path']}"
@@ -1264,10 +1269,13 @@ def cmd_init(args):
         # Deprecated alias → `cozempic uninstall --global`.
         print("  Note: `init --uninstall-global` is deprecated; use `cozempic uninstall`.", file=sys.stderr)
         from .init import uninstall_hooks
-        result = uninstall_hooks(str(Path.home()))
+        global_settings = _global_claude_dir() / "settings.json"
+        result = uninstall_hooks(str(Path.home()), settings_path=global_settings)
         print("\n  COZEMPIC INIT — UNINSTALL GLOBAL")
         print("  ═══════════════════════════════════════════════════════════════════")
-        if result.get("removed"):
+        if result.get("error"):
+            print(f"  Hooks: ERROR — {result['error']}")
+        elif result.get("removed"):
             print(f"  Removed {len(result['removed'])} hook(s) from {result['settings_path']}")
             for h in result["removed"]:
                 print(f"    - {h}")
@@ -1275,17 +1283,19 @@ def cmd_init(args):
                 print(f"  Backup: {result['backup_path']}")
         else:
             print("  No cozempic hooks found in ~/.claude/settings.json — nothing to remove.")
-        # Mark as opted-out so global auto-init doesn't re-fire
-        try:
-            _GLOBAL_INIT_MARKER.touch()
-        except OSError:
-            pass
+        if not result.get("error"):
+            # Mark as opted-out so global auto-init doesn't re-fire.
+            try:
+                _GLOBAL_INIT_MARKER.touch()
+            except OSError:
+                pass
         print()
         return
 
     if getattr(args, "global_install", False):
         project_dir = str(Path.home())
-        scope_label = "GLOBAL (~/.claude/)"
+        global_settings = _global_claude_dir() / "settings.json"
+        scope_label = f"GLOBAL ({global_settings.parent}/)"
     else:
         project_dir = args.cwd or os.getcwd()
         scope_label = f"Project: {project_dir}"
@@ -1295,13 +1305,11 @@ def cmd_init(args):
     print(f"  {scope_label}")
     print()
 
-    result = run_init(project_dir, skip_slash=args.no_slash_command)
-    if getattr(args, "global_install", False):
-        # Mark as initialized so global auto-init doesn't re-fire
-        try:
-            _GLOBAL_INIT_MARKER.touch()
-        except OSError:
-            pass
+    result = run_init(
+        project_dir,
+        skip_slash=args.no_slash_command,
+        settings_path=global_settings if getattr(args, "global_install", False) else None,
+    )
 
     # Report hooks
     hooks = result["hooks"]
@@ -1322,6 +1330,13 @@ def cmd_init(args):
     if hooks["skipped"]:
         for h in hooks["skipped"]:
             print(f"    ~ {h} (current, skipped)")
+
+    if getattr(args, "global_install", False) and not hooks.get("error"):
+        # A failed install must remain retryable instead of looking like a decline.
+        try:
+            _GLOBAL_INIT_MARKER.touch()
+        except OSError:
+            pass
 
     # #158: if cozempic is running from a throwaway env (uvx / uv run), the path
     # baked into the hooks won't exist next session, so the guard daemon can't
@@ -2057,16 +2072,16 @@ def _prompt_with_timeout(msg: str, timeout: int = 30, default: str = "n") -> str
 
 
 def _maybe_global_init(argv: list[str]) -> None:
-    """Wire cozempic into ~/.claude/settings.json on first cozempic invocation
+    """Wire cozempic into Claude's configured global settings on first invocation
     on this machine — guarantees protection for every Claude Code session in
     every project, including projects the user has never run cozempic in.
 
     Bail-outs (in order):
       1. COZEMPIC_NO_GLOBAL_INIT=1 in env (also set by --no-global-init)
       2. Subcommand is in _AUTO_INIT_SKIP_CMDS
-      3. ~/.claude/ doesn't exist (Claude Code not installed yet)
+      3. Claude's configured global directory doesn't exist yet
       4. Marker exists and no Cozempic hooks are present (the user declined)
-      5. Cozempic hooks are already current in ~/.claude/settings.json (e.g. plugin
+      5. Cozempic hooks are already current in Claude's global settings (e.g. plugin
          marketplace install)
 
     Otherwise: writes hooks (skip slash command — project-level only) and
@@ -2091,7 +2106,7 @@ def _maybe_global_init(argv: list[str]) -> None:
     if cmd is None and not is_version_check:
         return
 
-    home_claude = Path.home() / ".claude"
+    home_claude = _global_claude_dir()
     if not home_claude.exists():
         return  # Claude Code not yet installed — defer until it is
 
@@ -2100,7 +2115,7 @@ def _maybe_global_init(argv: list[str]) -> None:
     if hook_state.error:
         print(
             f"  Cozempic: global init FAILED — {hook_state.error}. "
-            "Fix ~/.claude/settings.json, then run `cozempic init --global`.",
+            f"Fix {home_claude / 'settings.json'}, then run `cozempic init --global`.",
             file=sys.stderr,
         )
         return
@@ -2137,7 +2152,7 @@ def _maybe_global_init(argv: list[str]) -> None:
                 file=sys.stderr,
             )
             print(
-                "  Wires hooks into ~/.claude/settings.json. Reverse any time with "
+                "  Wires hooks into Claude's global settings. Reverse any time with "
                 "`cozempic init --uninstall-global`.",
                 file=sys.stderr,
             )
@@ -2159,7 +2174,11 @@ def _maybe_global_init(argv: list[str]) -> None:
             return
 
     try:
-        result = run_init(str(Path.home()), skip_slash=True)
+        result = run_init(
+            str(Path.home()),
+            skip_slash=True,
+            settings_path=home_claude / "settings.json",
+        )
     except Exception as exc:
         print(
             f"  Cozempic: global init failed ({exc}). Run `cozempic init --global` manually "
@@ -2236,6 +2255,11 @@ def _managed_cozempic_hook_state(claude_dir: Path):
     return cozempic_hook_schema_state(claude_dir / "settings.json")
 
 
+def _global_claude_dir() -> Path:
+    from .session import get_claude_dir
+    return get_claude_dir()
+
+
 def _project_cozempic_hook_state(claude_dir: Path):
     """Return combined state for the project's effective Claude settings files."""
     from .init import cozempic_hook_schema_state_for_paths
@@ -2272,13 +2296,13 @@ def _maybe_auto_init(argv: list[str]) -> None:
     # Skip local init when global hooks are already current (avoids double-firing).
     # Guard: if cwd IS the home dir, home_claude == claude_dir -- fall through
     # to the normal local check instead.
-    home_claude = Path.home() / ".claude"
+    home_claude = _global_claude_dir()
     if home_claude != claude_dir:
         global_state = _managed_cozempic_hook_state(home_claude)
         if global_state.error:
             print(
                 f"  Cozempic: auto-init skipped ({global_state.error}). "
-                "Fix ~/.claude/settings.json, then run `cozempic init --global`.",
+                f"Fix {home_claude / 'settings.json'}, then run `cozempic init --global`.",
                 file=sys.stderr,
             )
             return
@@ -2293,7 +2317,15 @@ def _maybe_auto_init(argv: list[str]) -> None:
                 )
             return
 
-    if _project_is_cozempic_current(claude_dir):
+    project_state = _project_cozempic_hook_state(claude_dir)
+    if project_state.error:
+        print(
+            f"  Cozempic: auto-init skipped ({project_state.error}). "
+            "Fix the project settings, then run `cozempic init`.",
+            file=sys.stderr,
+        )
+        return
+    if project_state.found and project_state.current:
         return  # already initialized
 
     try:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2063,10 +2063,10 @@ def _maybe_global_init(argv: list[str]) -> None:
 
     Bail-outs (in order):
       1. COZEMPIC_NO_GLOBAL_INIT=1 in env (also set by --no-global-init)
-      2. Marker file exists (already done once)
-      3. Subcommand is in _AUTO_INIT_SKIP_CMDS
-      4. ~/.claude/ doesn't exist (Claude Code not installed yet)
-      5. Cozempic hooks are already in ~/.claude/settings.json (e.g. plugin
+      2. Subcommand is in _AUTO_INIT_SKIP_CMDS
+      3. ~/.claude/ doesn't exist (Claude Code not installed yet)
+      4. Marker exists and no Cozempic hooks are present (the user declined)
+      5. Cozempic hooks are already current in ~/.claude/settings.json (e.g. plugin
          marketplace install)
 
     Otherwise: writes hooks (skip slash command — project-level only) and
@@ -2074,8 +2074,6 @@ def _maybe_global_init(argv: list[str]) -> None:
     we never ask again on this machine.
     """
     if os.environ.get("COZEMPIC_NO_GLOBAL_INIT"):
-        return
-    if _GLOBAL_INIT_MARKER.exists():
         return
 
     # --help / -h are pure-info, never trigger init
@@ -2097,6 +2095,7 @@ def _maybe_global_init(argv: list[str]) -> None:
     if not home_claude.exists():
         return  # Claude Code not yet installed — defer until it is
 
+    marker_exists = _GLOBAL_INIT_MARKER.exists()
     if _project_is_cozempic_current(home_claude):
         # Already wired (probably via plugin marketplace install). Mark as done.
         try:
@@ -2105,10 +2104,17 @@ def _maybe_global_init(argv: list[str]) -> None:
             pass
         return
 
+    if marker_exists and not _project_has_cozempic_hooks(home_claude):
+        # A marker without hooks records a prior explicit decline. Do not turn a
+        # future package upgrade into an unsolicited first install.
+        return
+
     # Ask the user interactively when both stdin and stderr are TTYs (real terminal).
     # Fall back to silent auto-install for non-interactive contexts (CI, pipelines,
     # Claude Code subprocess invocations) so we never hang waiting for input.
-    interactive = sys.stdin.isatty() and sys.stderr.isatty()
+    # Existing but stale hooks already establish consent; refresh them without
+    # prompting so an automatic package update also advances the hook schema.
+    interactive = not marker_exists and sys.stdin.isatty() and sys.stderr.isatty()
 
     if interactive:
         try:
@@ -2215,10 +2221,23 @@ def _project_is_cozempic_current(claude_dir: Path) -> bool:
     query. If one file is current and another has stale cozempic hooks, we
     return False so wire_hooks is called and refreshes the stale one.
     """
+    found, current = _project_cozempic_hook_state(claude_dir)
+    return found and current
+
+
+def _project_has_cozempic_hooks(claude_dir: Path) -> bool:
+    """Return whether either global settings file contains Cozempic hooks."""
+    found, _ = _project_cozempic_hook_state(claude_dir)
+    return found
+
+
+def _project_cozempic_hook_state(claude_dir: Path) -> tuple[bool, bool]:
+    """Return ``(has_cozempic_hooks, all_cozempic_hooks_are_current)``."""
     import json as _json
     from .init import _is_cozempic_command, HOOK_SCHEMA_MARKER
 
     any_cozempic_found = False
+    any_stale_cozempic_found = False
     for name in ("settings.json", "settings.local.json"):
         p = claude_dir / name
         if not p.exists():
@@ -2248,9 +2267,9 @@ def _project_is_cozempic_current(claude_dir: Path) -> bool:
                     # Any non-current cozempic hook (missing or stale marker)
                     # means a refresh is due.
                     if HOOK_SCHEMA_MARKER not in cmd:
-                        return False
+                        any_stale_cozempic_found = True
 
-    return any_cozempic_found
+    return any_cozempic_found, not any_stale_cozempic_found
 
 
 def _maybe_auto_init(argv: list[str]) -> None:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1259,10 +1259,18 @@ def cmd_uninstall(args):
               + (f"  (backup: {sc['backup_path']})" if sc.get("backup_path") else ""))
     elif sc and sc.get("skipped_foreign"):
         print(f"  Left {sc['path']} in place (not a cozempic command).")
+    elif sc and sc.get("error"):
+        print(f"  Slash command: ERROR — {sc['error']}")
     if result.get("purged"):
         print(f"  Purged data: {', '.join(result['purged'])}")
+    reported_hook_errors = {h.get("error") for h in result["hooks"] if h.get("error")}
+    for error in result.get("errors", []):
+        if error not in reported_hook_errors:
+            print(f"  ERROR: {error}")
     if result.get("opt_out_set"):
         print("  Auto-init disabled. Re-run `cozempic init` to reinstall.")
+    if result.get("project_opt_out_set"):
+        print("  Project auto-init disabled. Re-run `cozempic init` to reinstall.")
     print()
 
 
@@ -1288,10 +1296,7 @@ def cmd_init(args):
             print("  No cozempic hooks found in ~/.claude/settings.json — nothing to remove.")
         if not result.get("error"):
             # Mark as opted-out so global auto-init doesn't re-fire.
-            try:
-                _global_init_marker().touch()
-            except OSError:
-                pass
+            _persist_global_init_marker()
         print()
         return
 
@@ -1335,6 +1340,8 @@ def cmd_init(args):
     if hooks["skipped"]:
         for h in hooks["skipped"]:
             print(f"    ~ {h} (current, skipped)")
+    for warning in hooks.get("warnings", []):
+        print(f"  Hooks: WARNING — {warning}")
 
     local_cleanup = result.get("local_cleanup")
     if local_cleanup:
@@ -1348,10 +1355,7 @@ def cmd_init(args):
 
     if getattr(args, "global_install", False) and not hooks.get("error"):
         # A failed install must remain retryable instead of looking like a decline.
-        try:
-            _global_init_marker().touch()
-        except OSError:
-            pass
+        _persist_global_init_marker()
 
     # #158: if cozempic is running from a throwaway env (uvx / uv run), the path
     # baked into the hooks won't exist next session, so the guard daemon can't

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1319,12 +1319,14 @@ def cmd_init(args):
     updated = hooks.get("updated") or []
     if hooks.get("error"):
         print(f"  Hooks: ERROR — {hooks['error']}")
-    elif hooks["added"] or updated:
+    elif hooks["added"] or updated or hooks.get("repaired"):
         print(f"  Hooks wired in {hooks['settings_path']}:")
         for h in hooks["added"]:
             print(f"    + {h} (added)")
         for h in updated:
             print(f"    → {h} (refreshed from stale schema)")
+        if hooks.get("repaired"):
+            print("    → malformed hook entries removed")
         if hooks["backup_path"]:
             print(f"  Backup: {hooks['backup_path']}")
     else:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1154,6 +1154,7 @@ def cmd_doctor(args):
         "warning": "⚠",
         "issue": "✗",
         "fixed": "→",
+        "error": "!",
     }
     STATUS_COLORS = {
         "ok": "",
@@ -1171,6 +1172,7 @@ def cmd_doctor(args):
     issues = 0
     warnings = 0
     fixed = 0
+    errors = 0
 
     for r in results:
         icon = STATUS_ICONS.get(r.status, "?")
@@ -1188,12 +1190,14 @@ def cmd_doctor(args):
             warnings += 1
         elif r.status == "fixed":
             fixed += 1
+        elif r.status == "error":
+            errors += 1
 
     # Summary
     if fixed:
         print(f"  Summary: {fixed} issue(s) fixed")
-    elif issues or warnings:
-        print(f"  Summary: {issues} issue(s), {warnings} warning(s)")
+    elif issues or warnings or errors:
+        print(f"  Summary: {issues} issue(s), {warnings} warning(s), {errors} check(s) failed")
         if not args.fix:
             print("  Run 'cozempic doctor --fix' to auto-fix where possible.")
     else:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1257,7 +1257,7 @@ def cmd_uninstall(args):
             purge = False
         elif _prompt_with_timeout("  Continue? [y/N] ", timeout=30, default="n") != "y":
             print("  Aborted.\n")
-            return
+            raise SystemExit(1)
 
     result = run_uninstall(scope, purge)
     n_hooks = sum(len(h.get("removed", [])) for h in result["hooks"])

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1222,7 +1222,7 @@ def cmd_uninstall(args):
 
     if purge and scope == "project":
         print("  ERROR: --purge only applies to global data; omit --project or use --all.\n")
-        return
+        raise SystemExit(2)
 
     if getattr(args, "dry_run", False):
         prev = preview_uninstall(scope, purge)
@@ -1243,6 +1243,8 @@ def cmd_uninstall(args):
         if purge:
             print(f"    Purge data: {', '.join(prev['purge_data']) or '(none)'}")
         print()
+        if prev["hook_errors"] or prev.get("slash_error"):
+            raise SystemExit(1)
         return
 
     if purge:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1254,7 +1254,7 @@ def cmd_uninstall(args):
             print(f"    - {h['settings_path']}: {', '.join(h['removed'])}"
                   + (f"  (backup: {h['backup_path']})" if h.get("backup_path") else ""))
         elif h.get("error"):
-            print(f"    - ERROR: {h['error']}")
+            print(f"    - {h.get('settings_path') or '(unknown)'}: ERROR — {h['error']}")
     sc = result.get("slash_command")
     if sc and sc.get("removed"):
         print(f"  Removed slash command: {sc['path']}"
@@ -1265,9 +1265,11 @@ def cmd_uninstall(args):
         print(f"  Slash command: ERROR — {sc['error']}")
     if result.get("purged"):
         print(f"  Purged data: {', '.join(result['purged'])}")
-    reported_hook_errors = {h.get("error") for h in result["hooks"] if h.get("error")}
+    reported_errors = {h.get("error") for h in result["hooks"] if h.get("error")}
+    if sc and sc.get("error"):
+        reported_errors.add(sc["error"])
     for error in result.get("errors", []):
-        if error not in reported_hook_errors:
+        if error not in reported_errors:
             print(f"  ERROR: {error}")
     if result.get("opt_out_set"):
         print("  Auto-init disabled. Re-run `cozempic init` to reinstall.")

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1235,7 +1235,7 @@ def cmd_uninstall(args):
         )
         print(f"    Slash command (~/.claude/commands/cozempic.md): {slash_status}")
         print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
-        for error in prev.get("hook_errors", prev.get("errors", [])):
+        for error in prev["hook_errors"]:
             print(f"    Hooks: ERROR — {error}")
         if prev.get("slash_error"):
             print(f"    Slash command: ERROR — {prev['slash_error']}")
@@ -2341,9 +2341,6 @@ def _maybe_auto_init(argv: list[str]) -> None:
     claude_dir = Path.cwd() / ".claude"
     if not claude_dir.exists():
         return  # not a Claude project — never modify foreign directories
-    if project_uninstall_marker(str(Path.cwd())).exists():
-        return  # explicit project uninstall is an opt-out until `cozempic init`
-
     cmd = next((tok for tok in argv if tok in _SUBCOMMANDS), None)
     if cmd is None or cmd in _AUTO_INIT_SKIP_CMDS:
         return
@@ -2384,6 +2381,8 @@ def _maybe_auto_init(argv: list[str]) -> None:
         return
     if project_state.found and project_state.current:
         return  # already initialized
+    if project_uninstall_marker(str(Path.cwd())).exists() and not project_state.found:
+        return  # explicit project uninstall remains an opt-out for first install
 
     try:
         result = run_init(str(Path.cwd()))

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2213,63 +2213,29 @@ def _maybe_global_init(argv: list[str]) -> None:
 def _project_is_cozempic_current(claude_dir: Path) -> bool:
     """Predicate: "should we leave this settings dir alone?"
 
-    Returns True iff the settings files (settings.json + settings.local.json)
-    already have cozempic hooks AT THE CURRENT SCHEMA VERSION and none are
-    stale. Returns False when refresh OR initial install is needed.
+    Returns True iff ``settings.json`` has Cozempic hooks at the current schema
+    version and none are stale. It intentionally excludes settings.local.json:
+    global init and uninstall mutate settings.json only, so local settings must
+    not override an explicit global decline or uninstall.
 
-    NOTE: This is a "do nothing" predicate, not a "has any cozempic config"
-    query. If one file is current and another has stale cozempic hooks, we
-    return False so wire_hooks is called and refreshes the stale one.
+    NOTE: This is a "do nothing" predicate, not a "has any Cozempic config"
+    query. A stale managed hook returns False so wire_hooks refreshes it.
     """
     found, current = _project_cozempic_hook_state(claude_dir)
     return found and current
 
 
 def _project_has_cozempic_hooks(claude_dir: Path) -> bool:
-    """Return whether either global settings file contains Cozempic hooks."""
+    """Return whether the managed settings.json contains Cozempic hooks."""
     found, _ = _project_cozempic_hook_state(claude_dir)
     return found
 
 
 def _project_cozempic_hook_state(claude_dir: Path) -> tuple[bool, bool]:
-    """Return ``(has_cozempic_hooks, all_cozempic_hooks_are_current)``."""
-    import json as _json
-    from .init import _is_cozempic_command, HOOK_SCHEMA_MARKER
+    """Return managed settings.json's ``(has_hooks, all_current)`` state."""
+    from .init import cozempic_hook_schema_state
 
-    any_cozempic_found = False
-    any_stale_cozempic_found = False
-    for name in ("settings.json", "settings.local.json"):
-        p = claude_dir / name
-        if not p.exists():
-            continue
-        try:
-            data = _json.loads(p.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-
-        hooks = data.get("hooks", {}) or {}
-        if not isinstance(hooks, dict):
-            continue
-
-        for entries in hooks.values():
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                for h in entry.get("hooks", []) or []:
-                    if not isinstance(h, dict):
-                        continue
-                    cmd = str(h.get("command", ""))
-                    if not _is_cozempic_command(cmd):
-                        continue
-                    any_cozempic_found = True
-                    # Any non-current cozempic hook (missing or stale marker)
-                    # means a refresh is due.
-                    if HOOK_SCHEMA_MARKER not in cmd:
-                        any_stale_cozempic_found = True
-
-    return any_cozempic_found, not any_stale_cozempic_found
+    return cozempic_hook_schema_state(claude_dir / "settings.json")
 
 
 def _maybe_auto_init(argv: list[str]) -> None:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2295,6 +2295,8 @@ def _maybe_auto_init(argv: list[str]) -> None:
     claude_dir = Path.cwd() / ".claude"
     if not claude_dir.exists():
         return  # not a Claude project — never modify foreign directories
+    if (claude_dir / ".cozempic_uninstalled").exists():
+        return  # explicit project uninstall is an opt-out until `cozempic init`
 
     cmd = next((tok for tok in argv if tok in _SUBCOMMANDS), None)
     if cmd is None or cmd in _AUTO_INIT_SKIP_CMDS:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -19,7 +19,7 @@ from .helpers import (
     is_ssh_session, shell_quote,
     compile_protect_patterns, tag_pattern_matches, strip_pattern_tags,
 )
-from .init import global_init_marker_path, run_init
+from .init import global_init_marker_path, project_uninstall_marker, run_init
 from .recap import save_recap
 from .registry import PRESCRIPTIONS, STRATEGIES
 from .safety import PruneValidationError
@@ -1228,8 +1228,12 @@ def cmd_uninstall(args):
         prev = preview_uninstall(scope, purge)
         print("  Dry run — nothing will be changed.\n")
         print(f"    Hooks would be removed from: {', '.join(prev['hooks_in']) or '(none)'}")
-        print(f"    Slash command (~/.claude/commands/cozempic.md): "
-              f"{'remove' if prev['slash_command'] else '(not present / not ours)'}")
+        slash_status = (
+            "remove" if prev["slash_command"]
+            else "(could not determine)" if prev.get("slash_error")
+            else "(not present / not ours)"
+        )
+        print(f"    Slash command (~/.claude/commands/cozempic.md): {slash_status}")
         print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
         for error in prev.get("hook_errors", prev.get("errors", [])):
             print(f"    Hooks: ERROR — {error}")
@@ -2300,7 +2304,7 @@ def _project_is_cozempic_current(claude_dir: Path) -> bool:
 
 
 def _managed_cozempic_hook_state(claude_dir: Path):
-    """Return state for the settings.json that global init and uninstall manage."""
+    """Return state for the settings.json that global init writes to."""
     from .init import _global_settings_paths, cozempic_hook_schema_state
 
     return cozempic_hook_schema_state(_global_settings_paths()[0])
@@ -2337,7 +2341,7 @@ def _maybe_auto_init(argv: list[str]) -> None:
     claude_dir = Path.cwd() / ".claude"
     if not claude_dir.exists():
         return  # not a Claude project — never modify foreign directories
-    if (claude_dir / ".cozempic_uninstalled").exists():
+    if project_uninstall_marker(str(Path.cwd())).exists():
         return  # explicit project uninstall is an opt-out until `cozempic init`
 
     cmd = next((tok for tok in argv if tok in _SUBCOMMANDS), None)

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1232,6 +1232,9 @@ def cmd_uninstall(args):
 
     if purge:
         print("  --purge will DELETE your savings ledger + receipts (~/.cozempic). This is irreversible.")
+        if not sys.stdin.isatty():
+            print("  Aborted (no interactive confirmation).\n")
+            return
         if _prompt_with_timeout("  Continue? [y/N] ", timeout=30, default="n") != "y":
             print("  Aborted.\n")
             return

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1277,6 +1277,8 @@ def cmd_uninstall(args):
         print(f"  Slash command: ERROR — {sc['error']}")
     if result.get("purged"):
         print(f"  Purged data: {', '.join(result['purged'])}")
+    elif result.get("purge_skipped"):
+        print("  Purge skipped due to a hook/settings error above; fix it, then re-run with --purge.")
     reported_errors = {h.get("error") for h in result["hooks"] if h.get("error")}
     if sc and sc.get("error"):
         reported_errors.add(sc["error"])

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1245,8 +1245,8 @@ def cmd_uninstall(args):
 
     result = run_uninstall(scope, purge)
     n_hooks = sum(len(h.get("removed", [])) for h in result["hooks"])
-    successful_settings = [h for h in result["hooks"] if not h.get("error")]
-    print(f"  Removed {n_hooks} hook(s) across {len(successful_settings)} settings file(s).")
+    changed_settings = [h for h in result["hooks"] if h.get("removed")]
+    print(f"  Removed {n_hooks} hook(s) across {len(changed_settings)} settings file(s).")
     for h in result["hooks"]:
         if h.get("removed"):
             print(f"    - {h['settings_path']}: {', '.join(h['removed'])}"
@@ -2051,6 +2051,17 @@ def _global_init_marker() -> Path:
     return _GLOBAL_INIT_MARKER or global_init_marker_path()
 
 
+def _persist_global_init_marker() -> None:
+    try:
+        _global_init_marker().touch()
+    except OSError as exc:
+        print(
+            f"  Cozempic: could not save your global init preference ({exc}). "
+            "Set COZEMPIC_NO_GLOBAL_INIT=1 to prevent automatic setup.",
+            file=sys.stderr,
+        )
+
+
 def _prompt_with_timeout(msg: str, timeout: int = 30, default: str = "n") -> str:
     """input() wrapped with a hard timeout so we never hang a cozempic invocation.
 
@@ -2147,10 +2158,7 @@ def _maybe_global_init(argv: list[str]) -> None:
 
     if hook_state.found and hook_state.current:
         # Already wired (probably via plugin marketplace install). Mark as done.
-        try:
-            _global_init_marker().touch()
-        except OSError:
-            pass
+        _persist_global_init_marker()
         return
 
     if marker_exists and not hook_state.found:
@@ -2188,10 +2196,7 @@ def _maybe_global_init(argv: list[str]) -> None:
         # Accept common "cancel" synonyms so users who press q/quit/cancel
         # don't accidentally opt IN.
         if response in ("n", "no", "q", "quit", "cancel", "exit", "x"):
-            try:
-                _global_init_marker().touch()
-            except OSError:
-                pass
+            _persist_global_init_marker()
             print(
                 "  Skipped. Run `cozempic init --global` later if you change your mind.\n",
                 file=sys.stderr,
@@ -2226,10 +2231,7 @@ def _maybe_global_init(argv: list[str]) -> None:
         )
         return
 
-    try:
-        _global_init_marker().touch()
-    except OSError:
-        pass
+    _persist_global_init_marker()
 
     repaired = hooks_result.get("repaired")
     if not (added or updated or repaired):

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1253,8 +1253,7 @@ def cmd_uninstall(args):
     n_hooks = sum(len(h.get("removed", [])) for h in result["hooks"])
     changed_settings = [h for h in result["hooks"] if h.get("removed")]
     error_count = len(result.get("errors", []))
-    error_suffix = f" ({error_count} error(s))" if error_count else ""
-    print(f"  Removed {n_hooks} hook(s) across {len(changed_settings)} settings file(s).{error_suffix}")
+    print(f"  Removed {n_hooks} hook(s) across {len(changed_settings)} settings file(s).")
     for h in result["hooks"]:
         if h.get("removed"):
             print(f"    - {h['settings_path']}: {', '.join(h['removed'])}"
@@ -1277,6 +1276,8 @@ def cmd_uninstall(args):
     for error in result.get("errors", []):
         if error not in reported_errors:
             print(f"  ERROR: {error}")
+    if error_count:
+        print(f"  Uninstall completed with {error_count} error(s).")
     if result.get("opt_out_set"):
         print("  Auto-init disabled. Re-run `cozempic init` to reinstall.")
     if result.get("project_opt_out_set"):
@@ -1390,12 +1391,14 @@ def cmd_init(args):
         print(f"  Use /cozempic in any Claude Code session to diagnose and treat.")
     elif slash["already_existed"]:
         print(f"  Slash command: up-to-date at {slash['path']}")
+    elif slash.get("error"):
+        print(f"  Slash command: ERROR — {slash['error']}")
     elif not args.no_slash_command:
         print(f"  Slash command: source not found (install from git repo to get it)")
 
     print()
 
-    if hooks.get("error") or (local_cleanup or {}).get("error"):
+    if hooks.get("error") or (local_cleanup or {}).get("error") or slash.get("error"):
         print("  Setup incomplete — fix the error above and re-run `cozempic init`.")
     else:
         # Summary: what to do next
@@ -1909,8 +1912,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--uninstall-global", action="store_true", help="(deprecated) use `cozempic uninstall`")
 
     p_uninstall = sub.add_parser("uninstall", help="Reverse `cozempic init` — remove hooks, slash command, markers (global by default)")
-    p_uninstall.add_argument("--project", action="store_true", help="Uninstall from THIS project's .claude/settings.json (default is global ~/.claude)")
-    p_uninstall.add_argument("--all", action="store_true", help="Uninstall from both global and project")
+    uninstall_scope = p_uninstall.add_mutually_exclusive_group()
+    uninstall_scope.add_argument("--project", action="store_true", help="Uninstall from THIS project's .claude/settings.json (default is global ~/.claude)")
+    uninstall_scope.add_argument("--all", action="store_true", help="Uninstall from both global and project")
     p_uninstall.add_argument("--purge", action="store_true", help="ALSO delete ~/.cozempic data + savings ledger (irreversible; prompts)")
     p_uninstall.add_argument("--dry-run", action="store_true", help="Show what would be removed without changing anything")
 
@@ -2067,7 +2071,9 @@ def _global_init_marker() -> Path:
 
 def _persist_global_init_marker() -> None:
     try:
-        _global_init_marker().touch()
+        marker = _global_init_marker()
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
     except OSError as exc:
         print(
             f"  Cozempic: could not save your global init preference ({exc}). "

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1304,25 +1304,7 @@ def cmd_init(args):
     if getattr(args, "uninstall_global", False):
         # Deprecated alias → `cozempic uninstall --global`.
         print("  Note: `init --uninstall-global` is deprecated; use `cozempic uninstall`.", file=sys.stderr)
-        from .init import uninstall_hooks
-        global_settings = _global_claude_dir() / "settings.json"
-        result = uninstall_hooks(str(Path.home()), settings_path=global_settings)
-        print("\n  COZEMPIC INIT — UNINSTALL GLOBAL")
-        print("  ═══════════════════════════════════════════════════════════════════")
-        if result.get("error"):
-            print(f"  Hooks: ERROR — {result['error']}")
-        elif result.get("removed"):
-            print(f"  Removed {len(result['removed'])} hook(s) from {result['settings_path']}")
-            for h in result["removed"]:
-                print(f"    - {h}")
-            if result.get("backup_path"):
-                print(f"  Backup: {result['backup_path']}")
-        else:
-            print("  No cozempic hooks found in ~/.claude/settings.json — nothing to remove.")
-        if not result.get("error"):
-            # Mark as opted-out so global auto-init doesn't re-fire.
-            _persist_global_init_marker()
-        print()
+        cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=False))
         return
 
     if getattr(args, "global_install", False):

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1236,7 +1236,7 @@ def cmd_uninstall(args):
 
     if purge:
         print("  --purge will DELETE your savings ledger + receipts (~/.cozempic). This is irreversible.")
-        if not sys.stdin.isatty():
+        if not (sys.stdin.isatty() and sys.stderr.isatty()):
             print("  Aborted (no interactive confirmation).\n")
             return
         if _prompt_with_timeout("  Continue? [y/N] ", timeout=30, default="n") != "y":
@@ -1335,6 +1335,16 @@ def cmd_init(args):
     if hooks["skipped"]:
         for h in hooks["skipped"]:
             print(f"    ~ {h} (current, skipped)")
+
+    local_cleanup = result.get("local_cleanup")
+    if local_cleanup:
+        if local_cleanup.get("error"):
+            print(f"  Local settings cleanup: ERROR — {local_cleanup['error']}")
+        elif local_cleanup.get("removed"):
+            print(
+                f"  Local settings cleanup: removed {len(local_cleanup['removed'])} stale hook(s) "
+                f"from {local_cleanup['settings_path']}"
+            )
 
     if getattr(args, "global_install", False) and not hooks.get("error"):
         # A failed install must remain retryable instead of looking like a decline.
@@ -2218,7 +2228,8 @@ def _maybe_global_init(argv: list[str]) -> None:
     except OSError:
         pass
 
-    if not (added or updated):
+    repaired = hooks_result.get("repaired")
+    if not (added or updated or repaired):
         return
 
     count_desc = []
@@ -2226,11 +2237,14 @@ def _maybe_global_init(argv: list[str]) -> None:
         count_desc.append(f"{len(added)} new")
     if updated:
         count_desc.append(f"{len(updated)} refreshed")
+    if repaired:
+        count_desc.append("malformed hook entries removed")
     summary = ", ".join(count_desc)
+    outcome = f"{summary} hook(s) wired" if added or updated else summary
 
     if interactive:
         print(
-            f"  Cozempic enabled — {summary} hook(s) wired into ~/.claude/settings.json.",
+            f"  Cozempic enabled — {outcome} in ~/.claude/settings.json.",
             file=sys.stderr,
         )
         print(
@@ -2241,7 +2255,7 @@ def _maybe_global_init(argv: list[str]) -> None:
     else:
         print(
             f"  Cozempic: protecting every Claude Code session globally "
-            f"({summary} hook(s) wired into ~/.claude/settings.json). "
+            f"({outcome} in ~/.claude/settings.json). "
             "Disable with `cozempic init --uninstall-global` or COZEMPIC_NO_GLOBAL_INIT=1.",
             file=sys.stderr,
         )
@@ -2364,17 +2378,33 @@ def _maybe_auto_init(argv: list[str]) -> None:
 
     added = hooks_result.get("added", []) or []
     updated = hooks_result.get("updated", []) or []
-    if added or updated:
+    repaired = hooks_result.get("repaired")
+    if added or updated or repaired:
         parts = []
         if added:
             parts.append(f"{len(added)} hook(s) wired")
         if updated:
             parts.append(f"{len(updated)} refreshed from stale schema")
+        if repaired:
+            parts.append("malformed hook entries removed")
         print(
             f"  Cozempic: auto-initialized this project ({', '.join(parts)}). "
             "Disable with --no-auto-init or COZEMPIC_NO_AUTO_INIT=1.",
             file=sys.stderr,
         )
+
+    local_cleanup = result.get("local_cleanup")
+    if local_cleanup:
+        if local_cleanup.get("error"):
+            print(
+                f"  Cozempic: local settings cleanup FAILED — {local_cleanup['error']}",
+                file=sys.stderr,
+            )
+        elif local_cleanup.get("removed"):
+            print(
+                "  Cozempic: removed stale hooks from project settings.local.json.",
+                file=sys.stderr,
+            )
 
 
 def cmd_dashboard(args):

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1246,7 +1246,9 @@ def cmd_uninstall(args):
     result = run_uninstall(scope, purge)
     n_hooks = sum(len(h.get("removed", [])) for h in result["hooks"])
     changed_settings = [h for h in result["hooks"] if h.get("removed")]
-    print(f"  Removed {n_hooks} hook(s) across {len(changed_settings)} settings file(s).")
+    error_count = len(result.get("errors", []))
+    error_suffix = f" ({error_count} error(s))" if error_count else ""
+    print(f"  Removed {n_hooks} hook(s) across {len(changed_settings)} settings file(s).{error_suffix}")
     for h in result["hooks"]:
         if h.get("removed"):
             print(f"    - {h['settings_path']}: {', '.join(h['removed'])}"

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1237,9 +1237,9 @@ def cmd_uninstall(args):
     if purge:
         print("  --purge will DELETE your savings ledger + receipts (~/.cozempic). This is irreversible.")
         if not (sys.stdin.isatty() and sys.stderr.isatty()):
-            print("  Aborted (no interactive confirmation).\n")
-            return
-        if _prompt_with_timeout("  Continue? [y/N] ", timeout=30, default="n") != "y":
+            print("  Purge skipped (no interactive confirmation); continuing uninstall.\n")
+            purge = False
+        elif _prompt_with_timeout("  Continue? [y/N] ", timeout=30, default="n") != "y":
             print("  Aborted.\n")
             return
 

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1241,7 +1241,10 @@ def cmd_uninstall(args):
         if prev.get("slash_error"):
             print(f"    Slash command: ERROR — {prev['slash_error']}")
         if purge:
-            print(f"    Purge data: {', '.join(prev['purge_data']) or '(none)'}")
+            if prev.get("purge_skipped"):
+                print("    Purge data: skipped due to a hook/settings error above")
+            else:
+                print(f"    Purge data: {', '.join(prev['purge_data']) or '(none)'}")
         print()
         if prev["hook_errors"] or prev.get("slash_error"):
             raise SystemExit(1)

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2175,7 +2175,7 @@ def _maybe_global_init(argv: list[str]) -> None:
             )
             print(
                 "  Wires hooks into Claude's global settings. Reverse any time with "
-                "`cozempic init --uninstall-global`.",
+                "`cozempic uninstall`.",
                 file=sys.stderr,
             )
             response = _prompt_with_timeout("  Enable? [Y/n] ", timeout=30, default="n")
@@ -2248,7 +2248,7 @@ def _maybe_global_init(argv: list[str]) -> None:
             file=sys.stderr,
         )
         print(
-            "  Disable any time with `cozempic init --uninstall-global` "
+            "  Disable any time with `cozempic uninstall` "
             "or COZEMPIC_NO_GLOBAL_INIT=1.\n",
             file=sys.stderr,
         )
@@ -2256,7 +2256,7 @@ def _maybe_global_init(argv: list[str]) -> None:
         print(
             f"  Cozempic: protecting every Claude Code session globally "
             f"({outcome} in ~/.claude/settings.json). "
-            "Disable with `cozempic init --uninstall-global` or COZEMPIC_NO_GLOBAL_INIT=1.",
+            "Disable with `cozempic uninstall` or COZEMPIC_NO_GLOBAL_INIT=1.",
             file=sys.stderr,
         )
 

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1232,12 +1232,8 @@ def cmd_uninstall(args):
 
     if purge:
         print("  --purge will DELETE your savings ledger + receipts (~/.cozempic). This is irreversible.")
-        try:
-            if input("  Continue? [y/N] ").strip().lower() != "y":
-                print("  Aborted.\n")
-                return
-        except EOFError:
-            print("  Aborted (no confirmation).\n")
+        if _prompt_with_timeout("  Continue? [y/N] ", timeout=30, default="n") != "y":
+            print("  Aborted.\n")
             return
 
     result = run_uninstall(scope, purge)
@@ -2315,6 +2311,8 @@ def _maybe_auto_init(argv: list[str]) -> None:
                 file=sys.stderr,
             )
             return
+        if _global_init_marker().exists() and not global_state.found:
+            return  # explicit global uninstall remains an opt-out for local auto-init
         if global_state.found and global_state.current:
             # Warn if redundant local hooks are also present.
             if _project_is_cozempic_current(claude_dir):

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1381,15 +1381,18 @@ def cmd_init(args):
 
     print()
 
-    # Summary: what to do next
-    print(f"  Setup complete. Protection is fully automatic:")
-    print(f"    - Guard daemon auto-starts on every session (SessionStart hook)")
-    print(f"    - Team state checkpointed on every agent event (PostToolUse hooks)")
-    print(f"    - Emergency checkpoint before compaction (PreCompact hook)")
-    print(f"    - Recovery context after compaction (PostCompact hook)")
-    print(f"    - Final checkpoint on session end (Stop hook)")
-    print()
-    print(f"  Just start Claude Code normally. No second terminal needed.")
+    if hooks.get("error"):
+        print("  Setup incomplete — fix the error above and re-run `cozempic init`.")
+    else:
+        # Summary: what to do next
+        print(f"  Setup complete. Protection is fully automatic:")
+        print(f"    - Guard daemon auto-starts on every session (SessionStart hook)")
+        print(f"    - Team state checkpointed on every agent event (PostToolUse hooks)")
+        print(f"    - Emergency checkpoint before compaction (PreCompact hook)")
+        print(f"    - Recovery context after compaction (PostCompact hook)")
+        print(f"    - Final checkpoint on session end (Stop hook)")
+        print()
+        print(f"  Just start Claude Code normally. No second terminal needed.")
     print()
 
 
@@ -2276,9 +2279,9 @@ def _project_is_cozempic_current(claude_dir: Path) -> bool:
 
 def _managed_cozempic_hook_state(claude_dir: Path):
     """Return state for the settings.json that global init and uninstall manage."""
-    from .init import cozempic_hook_schema_state
+    from .init import _global_settings_paths, cozempic_hook_schema_state
 
-    return cozempic_hook_schema_state(claude_dir / "settings.json")
+    return cozempic_hook_schema_state(_global_settings_paths()[0])
 
 
 def _global_claude_dir() -> Path:
@@ -2288,11 +2291,9 @@ def _global_claude_dir() -> Path:
 
 def _project_cozempic_hook_state(claude_dir: Path):
     """Return combined state for the project's effective Claude settings files."""
-    from .init import cozempic_hook_schema_state_for_paths
+    from .init import _project_settings_paths, cozempic_hook_schema_state_for_paths
 
-    return cozempic_hook_schema_state_for_paths(
-        (claude_dir / "settings.json", claude_dir / "settings.local.json")
-    )
+    return cozempic_hook_schema_state_for_paths(tuple(_project_settings_paths(str(claude_dir.parent))))
 
 
 def _maybe_auto_init(argv: list[str]) -> None:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1302,7 +1302,7 @@ def cmd_uninstall(args):
 def cmd_init(args):
     """Wire cozempic hooks and slash command into the current project (or globally)."""
     if getattr(args, "uninstall_global", False):
-        # Deprecated alias → `cozempic uninstall --global`.
+        # Deprecated alias → `cozempic uninstall` (global is the default scope).
         print("  Note: `init --uninstall-global` is deprecated; use `cozempic uninstall`.", file=sys.stderr)
         cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=False))
         return

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2161,17 +2161,9 @@ def _maybe_global_init(argv: list[str]) -> None:
     try:
         result = run_init(str(Path.home()), skip_slash=True)
     except Exception as exc:
-        # Touch the marker even on failure — prevents a DoS loop where every
-        # single cozempic invocation re-attempts a failing run_init and spams
-        # stderr. User can `rm ~/.cozempic_global_initialized` to retry after
-        # addressing the underlying problem (read-only file, permissions, etc).
-        try:
-            _GLOBAL_INIT_MARKER.touch()
-        except OSError:
-            pass
         print(
             f"  Cozempic: global init failed ({exc}). Run `cozempic init --global` manually "
-            "after fixing; `rm ~/.cozempic_global_initialized` to re-ask on next invocation.",
+            "after fixing.",
             file=sys.stderr,
         )
         return
@@ -2281,16 +2273,25 @@ def _maybe_auto_init(argv: list[str]) -> None:
     # Guard: if cwd IS the home dir, home_claude == claude_dir -- fall through
     # to the normal local check instead.
     home_claude = Path.home() / ".claude"
-    if home_claude != claude_dir and _project_is_cozempic_current(home_claude):
-        # Warn if redundant local hooks are also present.
-        if _project_is_cozempic_current(claude_dir):
+    if home_claude != claude_dir:
+        global_state = _managed_cozempic_hook_state(home_claude)
+        if global_state.error:
             print(
-                "  Cozempic: local hooks redundant (global hooks active) — "
-                "they are harmless but can be removed from this project's "
-                ".claude/settings.json.",
+                f"  Cozempic: auto-init skipped ({global_state.error}). "
+                "Fix ~/.claude/settings.json, then run `cozempic init --global`.",
                 file=sys.stderr,
             )
-        return
+            return
+        if global_state.found and global_state.current:
+            # Warn if redundant local hooks are also present.
+            if _project_is_cozempic_current(claude_dir):
+                print(
+                    "  Cozempic: local hooks redundant (global hooks active) — "
+                    "they are harmless but can be removed from this project's "
+                    ".claude/settings.json.",
+                    file=sys.stderr,
+                )
+            return
 
     if _project_is_cozempic_current(claude_dir):
         return  # already initialized

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1220,6 +1220,10 @@ def cmd_uninstall(args):
     print("  ═══════════════════════════════════════════════════════════════════")
     print(f"  Scope: {scope}" + ("  (+ purge data)" if purge else ""))
 
+    if purge and scope == "project":
+        print("  ERROR: --purge only applies to global data; choose --global or --all.\n")
+        return
+
     if getattr(args, "dry_run", False):
         prev = preview_uninstall(scope, purge)
         print("  Dry run — nothing will be changed.\n")

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2420,6 +2420,9 @@ def _maybe_auto_init(argv: list[str]) -> None:
             file=sys.stderr,
         )
 
+    for warning in hooks_result.get("warnings", []) or []:
+        print(f"  Cozempic: {warning}", file=sys.stderr)
+
     local_cleanup = result.get("local_cleanup")
     if local_cleanup:
         if local_cleanup.get("error"):

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -19,7 +19,7 @@ from .helpers import (
     is_ssh_session, shell_quote,
     compile_protect_patterns, tag_pattern_matches, strip_pattern_tags,
 )
-from .init import run_init
+from .init import global_init_marker_path, run_init
 from .recap import save_recap
 from .registry import PRESCRIPTIONS, STRATEGIES
 from .safety import PruneValidationError
@@ -1286,7 +1286,7 @@ def cmd_init(args):
         if not result.get("error"):
             # Mark as opted-out so global auto-init doesn't re-fire.
             try:
-                _GLOBAL_INIT_MARKER.touch()
+                _global_init_marker().touch()
             except OSError:
                 pass
         print()
@@ -1334,7 +1334,7 @@ def cmd_init(args):
     if getattr(args, "global_install", False) and not hooks.get("error"):
         # A failed install must remain retryable instead of looking like a decline.
         try:
-            _GLOBAL_INIT_MARKER.touch()
+            _global_init_marker().touch()
         except OSError:
             pass
 
@@ -1494,7 +1494,8 @@ def cmd_nudge(args):
     # Once-per-tier latch with re-arm: drop tiers we've fallen BELOW (so they
     # re-fire on a later re-cross), persist that drop in EVERY path, then fire the
     # current tier only if not already latched.
-    state_file = Path.home() / ".claude" / "cozempic-metrics" / "nudge-state.json"
+    from .session import get_claude_dir
+    state_file = get_claude_dir() / "cozempic-metrics" / "nudge-state.json"
     try:
         state = _json.loads(state_file.read_text()) if state_file.exists() else {}
     except Exception:
@@ -2023,7 +2024,13 @@ _AUTO_INIT_SKIP_CMDS = frozenset({
     "dashboard",     # report-only; reads/writes only ~/.cozempic, never project state
 })
 
-_GLOBAL_INIT_MARKER = Path.home() / ".cozempic_global_initialized"
+# Compatibility seam for callers that patch this in tests. Production resolves
+# dynamically so each CLAUDE_CONFIG_DIR profile gets its own decision.
+_GLOBAL_INIT_MARKER: Path | None = None
+
+
+def _global_init_marker() -> Path:
+    return _GLOBAL_INIT_MARKER or global_init_marker_path()
 
 
 def _prompt_with_timeout(msg: str, timeout: int = 30, default: str = "n") -> str:
@@ -2110,7 +2117,7 @@ def _maybe_global_init(argv: list[str]) -> None:
     if not home_claude.exists():
         return  # Claude Code not yet installed — defer until it is
 
-    marker_exists = _GLOBAL_INIT_MARKER.exists()
+    marker_exists = _global_init_marker().exists()
     hook_state = _managed_cozempic_hook_state(home_claude)
     if hook_state.error:
         print(
@@ -2123,7 +2130,7 @@ def _maybe_global_init(argv: list[str]) -> None:
     if hook_state.found and hook_state.current:
         # Already wired (probably via plugin marketplace install). Mark as done.
         try:
-            _GLOBAL_INIT_MARKER.touch()
+            _global_init_marker().touch()
         except OSError:
             pass
         return
@@ -2164,7 +2171,7 @@ def _maybe_global_init(argv: list[str]) -> None:
         # don't accidentally opt IN.
         if response in ("n", "no", "q", "quit", "cancel", "exit", "x"):
             try:
-                _GLOBAL_INIT_MARKER.touch()
+                _global_init_marker().touch()
             except OSError:
                 pass
             print(
@@ -2202,7 +2209,7 @@ def _maybe_global_init(argv: list[str]) -> None:
         return
 
     try:
-        _GLOBAL_INIT_MARKER.touch()
+        _global_init_marker().touch()
     except OSError:
         pass
 

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -2096,7 +2096,16 @@ def _maybe_global_init(argv: list[str]) -> None:
         return  # Claude Code not yet installed — defer until it is
 
     marker_exists = _GLOBAL_INIT_MARKER.exists()
-    if _project_is_cozempic_current(home_claude):
+    hook_state = _managed_cozempic_hook_state(home_claude)
+    if hook_state.error:
+        print(
+            f"  Cozempic: global init FAILED — {hook_state.error}. "
+            "Fix ~/.claude/settings.json, then run `cozempic init --global`.",
+            file=sys.stderr,
+        )
+        return
+
+    if hook_state.found and hook_state.current:
         # Already wired (probably via plugin marketplace install). Mark as done.
         try:
             _GLOBAL_INIT_MARKER.touch()
@@ -2104,7 +2113,7 @@ def _maybe_global_init(argv: list[str]) -> None:
             pass
         return
 
-    if marker_exists and not _project_has_cozempic_hooks(home_claude):
+    if marker_exists and not hook_state.found:
         # A marker without hooks records a prior explicit decline. Do not turn a
         # future package upgrade into an unsolicited first install.
         return
@@ -2114,7 +2123,12 @@ def _maybe_global_init(argv: list[str]) -> None:
     # Claude Code subprocess invocations) so we never hang waiting for input.
     # Existing but stale hooks already establish consent; refresh them without
     # prompting so an automatic package update also advances the hook schema.
-    interactive = not marker_exists and sys.stdin.isatty() and sys.stderr.isatty()
+    interactive = (
+        not marker_exists
+        and not hook_state.found
+        and sys.stdin.isatty()
+        and sys.stderr.isatty()
+    )
 
     if interactive:
         try:
@@ -2213,29 +2227,30 @@ def _maybe_global_init(argv: list[str]) -> None:
 def _project_is_cozempic_current(claude_dir: Path) -> bool:
     """Predicate: "should we leave this settings dir alone?"
 
-    Returns True iff ``settings.json`` has Cozempic hooks at the current schema
-    version and none are stale. It intentionally excludes settings.local.json:
-    global init and uninstall mutate settings.json only, so local settings must
-    not override an explicit global decline or uninstall.
+    Returns True iff the project's effective settings files have Cozempic hooks
+    at the current schema version and none are stale.
 
     NOTE: This is a "do nothing" predicate, not a "has any Cozempic config"
     query. A stale managed hook returns False so wire_hooks refreshes it.
     """
-    found, current = _project_cozempic_hook_state(claude_dir)
-    return found and current
+    state = _project_cozempic_hook_state(claude_dir)
+    return state.found and state.current
 
 
-def _project_has_cozempic_hooks(claude_dir: Path) -> bool:
-    """Return whether the managed settings.json contains Cozempic hooks."""
-    found, _ = _project_cozempic_hook_state(claude_dir)
-    return found
-
-
-def _project_cozempic_hook_state(claude_dir: Path) -> tuple[bool, bool]:
-    """Return managed settings.json's ``(has_hooks, all_current)`` state."""
+def _managed_cozempic_hook_state(claude_dir: Path):
+    """Return state for the settings.json that global init and uninstall manage."""
     from .init import cozempic_hook_schema_state
 
     return cozempic_hook_schema_state(claude_dir / "settings.json")
+
+
+def _project_cozempic_hook_state(claude_dir: Path):
+    """Return combined state for the project's effective Claude settings files."""
+    from .init import cozempic_hook_schema_state_for_paths
+
+    return cozempic_hook_schema_state_for_paths(
+        (claude_dir / "settings.json", claude_dir / "settings.local.json")
+    )
 
 
 def _maybe_auto_init(argv: list[str]) -> None:

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1221,20 +1221,21 @@ def cmd_uninstall(args):
     print(f"  Scope: {scope}" + ("  (+ purge data)" if purge else ""))
 
     if purge and scope == "project":
-        print("  ERROR: --purge only applies to global data; choose --global or --all.\n")
+        print("  ERROR: --purge only applies to global data; omit --project or use --all.\n")
         return
 
     if getattr(args, "dry_run", False):
         prev = preview_uninstall(scope, purge)
         print("  Dry run — nothing will be changed.\n")
         print(f"    Hooks would be removed from: {', '.join(prev['hooks_in']) or '(none)'}")
-        slash_status = (
-            "remove" if prev["slash_command"]
-            else "(could not determine)" if prev.get("slash_error")
-            else "(not present / not ours)"
-        )
-        print(f"    Slash command (~/.claude/commands/cozempic.md): {slash_status}")
-        print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
+        if scope in ("global", "all"):
+            slash_status = (
+                "remove" if prev["slash_command"]
+                else "(could not determine)" if prev.get("slash_error")
+                else "(not present / not ours)"
+            )
+            print(f"    Slash command (~/.claude/commands/cozempic.md): {slash_status}")
+            print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
         for error in prev["hook_errors"]:
             print(f"    Hooks: ERROR — {error}")
         if prev.get("slash_error"):
@@ -1287,6 +1288,8 @@ def cmd_uninstall(args):
     if result.get("project_opt_out_set"):
         print("  Project auto-init disabled. Re-run `cozempic init` to reinstall.")
     print()
+    if error_count:
+        raise SystemExit(1)
 
 
 def cmd_init(args):
@@ -1404,6 +1407,7 @@ def cmd_init(args):
 
     if hooks.get("error") or (local_cleanup or {}).get("error") or slash.get("error"):
         print("  Setup incomplete — fix the error above and re-run `cozempic init`.")
+        raise SystemExit(1)
     else:
         # Summary: what to do next
         print(f"  Setup complete. Protection is fully automatic:")

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1227,14 +1227,16 @@ def cmd_uninstall(args):
     if getattr(args, "dry_run", False):
         prev = preview_uninstall(scope, purge)
         print("  Dry run — nothing will be changed.\n")
-        print(f"    Hooks would be removed from: {prev['hooks_in'] or '(none)'}")
+        print(f"    Hooks would be removed from: {', '.join(prev['hooks_in']) or '(none)'}")
         print(f"    Slash command (~/.claude/commands/cozempic.md): "
               f"{'remove' if prev['slash_command'] else '(not present / not ours)'}")
         print(f"    Remind counter: {'remove' if prev['remind_counter'] else '(none)'}")
-        for error in prev.get("errors", []):
+        for error in prev.get("hook_errors", prev.get("errors", [])):
             print(f"    Hooks: ERROR — {error}")
+        if prev.get("slash_error"):
+            print(f"    Slash command: ERROR — {prev['slash_error']}")
         if purge:
-            print(f"    Purge data: {prev['purge_data'] or '(none)'}")
+            print(f"    Purge data: {', '.join(prev['purge_data']) or '(none)'}")
         print()
         return
 
@@ -1393,7 +1395,7 @@ def cmd_init(args):
 
     print()
 
-    if hooks.get("error"):
+    if hooks.get("error") or (local_cleanup or {}).get("error"):
         print("  Setup incomplete — fix the error above and re-run `cozempic init`.")
     else:
         # Summary: what to do next

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1194,37 +1194,18 @@ def check_cozempic_project_init() -> CheckResult:
             message="Not a Claude project (no .claude/ in cwd) — skipping",
         )
 
-    found = False
-    from .init import _hooks_list, _is_cozempic_command
-    for name in ("settings.json", "settings.local.json"):
-        p = claude_dir / name
-        if not p.exists():
-            continue
-        try:
-            data = json.loads(p.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(data, dict):
-            return CheckResult(
-                name="cozempic-project-init",
-                status="warning",
-                message=f"Could not read {p.name}: settings must be a JSON object",
-            )
-        hooks = data.get("hooks", {}) or {}
-        if not isinstance(hooks, dict):
-            hooks = {}
-        for entries in hooks.values():
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                for h in _hooks_list(entry):
-                    if isinstance(h, dict) and _is_cozempic_command(h.get("command", "")):
-                        found = True
-                        break
+    from .init import cozempic_hook_schema_state_for_paths
+    state = cozempic_hook_schema_state_for_paths(
+        (claude_dir / "settings.json", claude_dir / "settings.local.json")
+    )
+    if state.error:
+        return CheckResult(
+            name="cozempic-project-init",
+            status="warning",
+            message=state.error,
+        )
 
-    if found:
+    if state.found:
         return CheckResult(
             name="cozempic-project-init",
             status="ok",
@@ -1246,9 +1227,9 @@ def check_cozempic_hooks() -> CheckResult:
     means team state isn't re-injected after native compaction.
     """
     claude_dir = get_claude_dir()
-    settings_path = claude_dir / "settings.json"
-
-    if not settings_path.exists():
+    settings_paths = (claude_dir / "settings.json", claude_dir / "settings.local.json")
+    existing_paths = [path for path in settings_paths if path.exists()]
+    if not existing_paths:
         return CheckResult(
             name="cozempic-hooks",
             status="warning",
@@ -1256,41 +1237,39 @@ def check_cozempic_hooks() -> CheckResult:
             fix_description="Run: cozempic init",
         )
 
-    try:
-        settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as e:
-        return CheckResult(
-            name="cozempic-hooks",
-            status="warning",
-            message=f"Could not read settings.json: {e}",
-        )
-
-    if not isinstance(settings, dict):
-        return CheckResult(
-            name="cozempic-hooks",
-            status="warning",
-            message="Could not read settings.json: settings must be a JSON object",
-        )
-
-    hooks = settings.get("hooks", {}) or {}
-    if not isinstance(hooks, dict):
-        hooks = {}
     expected = {"SessionStart", "PreCompact", "PostCompact", "Stop"}
-    missing = []
-
-    for event in expected:
-        entries = hooks.get(event, [])
-        if not isinstance(entries, list):
-            entries = []
-        from .init import _hooks_list, _is_cozempic_command
-        has_cozempic = any(
-            _is_cozempic_command(h.get("command", ""))
-            for entry in entries if isinstance(entry, dict)
-            for h in _hooks_list(entry)
-            if isinstance(h, dict)
-        )
-        if not has_cozempic:
-            missing.append(event)
+    present = set()
+    from .init import _hooks_list, _is_cozempic_command
+    for settings_path in existing_paths:
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            return CheckResult(
+                name="cozempic-hooks",
+                status="warning",
+                message=f"Could not read {settings_path.name}: {e}",
+            )
+        if not isinstance(settings, dict):
+            return CheckResult(
+                name="cozempic-hooks",
+                status="warning",
+                message=f"Could not read {settings_path.name}: settings must be a JSON object",
+            )
+        hooks = settings.get("hooks", {}) or {}
+        if not isinstance(hooks, dict):
+            continue
+        for event in expected:
+            entries = hooks.get(event, [])
+            if not isinstance(entries, list):
+                continue
+            if any(
+                _is_cozempic_command(h.get("command", ""))
+                for entry in entries if isinstance(entry, dict)
+                for h in _hooks_list(entry)
+                if isinstance(h, dict)
+            ):
+                present.add(event)
+    missing = sorted(expected - present)
 
     if not missing:
         return CheckResult(

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1195,6 +1195,7 @@ def check_cozempic_project_init() -> CheckResult:
         )
 
     found = False
+    from .init import _hooks_list, _is_cozempic_command
     for name in ("settings.json", "settings.local.json"):
         p = claude_dir / name
         if not p.exists():
@@ -1216,8 +1217,7 @@ def check_cozempic_project_init() -> CheckResult:
             for entry in entries:
                 if not isinstance(entry, dict):
                     continue
-                for h in entry.get("hooks", []) or []:
-                    from .init import _is_cozempic_command
+                for h in _hooks_list(entry):
                     if isinstance(h, dict) and _is_cozempic_command(str(h.get("command", ""))):
                         found = True
                         break
@@ -1280,11 +1280,11 @@ def check_cozempic_hooks() -> CheckResult:
         entries = hooks.get(event, [])
         if not isinstance(entries, list):
             entries = []
-        from .init import _is_cozempic_command
+        from .init import _hooks_list, _is_cozempic_command
         has_cozempic = any(
             _is_cozempic_command(h.get("command", ""))
             for entry in entries if isinstance(entry, dict)
-            for h in entry.get("hooks", []) or []
+            for h in _hooks_list(entry)
             if isinstance(h, dict)
         )
         if not has_cozempic:

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1218,7 +1218,7 @@ def check_cozempic_project_init() -> CheckResult:
                     continue
                 for h in entry.get("hooks", []) or []:
                     from .init import _is_cozempic_command
-                    if _is_cozempic_command(str(h.get("command", ""))):
+                    if isinstance(h, dict) and _is_cozempic_command(str(h.get("command", ""))):
                         found = True
                         break
 
@@ -1284,7 +1284,8 @@ def check_cozempic_hooks() -> CheckResult:
         has_cozempic = any(
             _is_cozempic_command(h.get("command", ""))
             for entry in entries if isinstance(entry, dict)
-            for h in entry.get("hooks", [])
+            for h in entry.get("hooks", []) or []
+            if isinstance(h, dict)
         )
         if not has_cozempic:
             missing.append(event)

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1270,16 +1270,20 @@ def check_cozempic_hooks() -> CheckResult:
             message="Could not read settings.json: settings must be a JSON object",
         )
 
-    hooks = settings.get("hooks", {})
+    hooks = settings.get("hooks", {}) or {}
+    if not isinstance(hooks, dict):
+        hooks = {}
     expected = {"SessionStart", "PreCompact", "PostCompact", "Stop"}
     missing = []
 
     for event in expected:
         entries = hooks.get(event, [])
+        if not isinstance(entries, list):
+            entries = []
         from .init import _is_cozempic_command
         has_cozempic = any(
             _is_cozempic_command(h.get("command", ""))
-            for entry in entries
+            for entry in entries if isinstance(entry, dict)
             for h in entry.get("hooks", [])
         )
         if not has_cozempic:

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1211,6 +1211,8 @@ def check_cozempic_project_init() -> CheckResult:
                 message=f"Could not read {p.name}: settings must be a JSON object",
             )
         hooks = data.get("hooks", {}) or {}
+        if not isinstance(hooks, dict):
+            hooks = {}
         for entries in hooks.values():
             if not isinstance(entries, list):
                 continue
@@ -1218,7 +1220,7 @@ def check_cozempic_project_init() -> CheckResult:
                 if not isinstance(entry, dict):
                     continue
                 for h in _hooks_list(entry):
-                    if isinstance(h, dict) and _is_cozempic_command(str(h.get("command", ""))):
+                    if isinstance(h, dict) and _is_cozempic_command(h.get("command", "")):
                         found = True
                         break
 

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1203,6 +1203,12 @@ def check_cozempic_project_init() -> CheckResult:
             data = json.loads(p.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
+        if not isinstance(data, dict):
+            return CheckResult(
+                name="cozempic-project-init",
+                status="warning",
+                message=f"Could not read {p.name}: settings must be a JSON object",
+            )
         hooks = data.get("hooks", {}) or {}
         for entries in hooks.values():
             if not isinstance(entries, list):
@@ -1255,6 +1261,13 @@ def check_cozempic_hooks() -> CheckResult:
             name="cozempic-hooks",
             status="warning",
             message=f"Could not read settings.json: {e}",
+        )
+
+    if not isinstance(settings, dict):
+        return CheckResult(
+            name="cozempic-hooks",
+            status="warning",
+            message="Could not read settings.json: settings must be a JSON object",
         )
 
     hooks = settings.get("hooks", {})

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -237,6 +237,11 @@ def _settings_path(project_dir: str) -> Path:
     return Path(project_dir) / ".claude" / "settings.json"
 
 
+def _project_settings_paths(project_dir: str) -> list[Path]:
+    settings = _settings_path(project_dir)
+    return [settings, settings.with_name("settings.local.json")]
+
+
 def project_uninstall_marker(project_dir: str) -> Path:
     return Path(project_dir) / ".claude" / ".cozempic_uninstalled"
 
@@ -745,8 +750,8 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """Read-only: report what `run_uninstall(scope, purge)` WOULD remove. No writes."""
     scopes = {
         "global": [_global_settings_path()],
-        "project": [_settings_path(".")],
-        "all": [_global_settings_path(), _settings_path(".")],
+        "project": _project_settings_paths("."),
+        "all": [_global_settings_path(), *_project_settings_paths(".")],
     }.get(scope, [_global_settings_path()])
     hook_targets = []
     errors = []
@@ -787,8 +792,9 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """
     targets = {
         "global": [(str(Path.home()), _global_settings_path())],
-        "project": [(".", None)],
-        "all": [(str(Path.home()), _global_settings_path()), (".", None)],
+        "project": [(".", path) for path in _project_settings_paths(".")],
+        "all": [(str(Path.home()), _global_settings_path())]
+        + [(".", path) for path in _project_settings_paths(".")],
     }.get(scope, [(str(Path.home()), _global_settings_path())])
     result: dict = {"scope": scope, "hooks": [], "slash_command": None,
                     "remind_counter_removed": False, "purged": [], "opt_out_set": False,

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -67,7 +67,10 @@ def _load_canonical_hooks() -> dict:
             data = files("cozempic").joinpath("data/hooks.json").read_text(encoding="utf-8")
         except Exception:
             data = (Path(__file__).parent / "data" / "hooks.json").read_text(encoding="utf-8")
-        return json.loads(data).get("hooks", {})
+        hooks = json.loads(data).get("hooks", {})
+        if not isinstance(hooks, dict):
+            raise ValueError("bundled hooks must be a JSON object")
+        return hooks
     except Exception as exc:
         _LOAD_ERROR = (
             f"could not load bundled hook definitions ({exc}). "
@@ -100,7 +103,7 @@ def _is_cozempic_hook(hook_entry: object) -> bool:
     return False
 
 
-def _is_cozempic_command(command: str) -> bool:
+def _is_cozempic_command(command: object) -> bool:
     """Return True if this single hook command was installed by cozempic.
 
     Detection order:
@@ -120,6 +123,8 @@ def _is_cozempic_command(command: str) -> bool:
     are left alone; only commands produced by our `_c()` template / canonical
     hooks.json entries are recognized as ours.
     """
+    if not isinstance(command, str):
+        return False
     if "cozempic-hook-schema=" in command:
         return True
     has_wrapper_open = "{ cozempic " in command
@@ -129,10 +134,10 @@ def _is_cozempic_command(command: str) -> bool:
     return has_wrapper_open and has_python_fallback
 
 
-def _is_current_cozempic_command(command: str) -> bool:
+def _is_current_cozempic_command(command: object) -> bool:
     """Return True if this command is at the CURRENT schema version (fresh).
     Used by auto-init to decide whether to refresh stale hooks."""
-    return HOOK_SCHEMA_MARKER in command
+    return isinstance(command, str) and HOOK_SCHEMA_MARKER in command
 
 
 def _entry_has_current_cozempic_hook(hook_entry: object) -> bool:
@@ -800,12 +805,13 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     except OSError:
         pass
 
-    # Opt-out: keep auto-init from re-wiring after uninstall.
-    try:
-        _global_init_marker().touch()
-        result["opt_out_set"] = True
-    except OSError:
-        pass
+    if scope in ("global", "all"):
+        # Opt-out: keep global auto-init from re-wiring after global uninstall.
+        try:
+            _global_init_marker().touch()
+            result["opt_out_set"] = True
+        except OSError:
+            pass
 
     if purge:
         import shutil as _sh

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -916,7 +916,7 @@ def uninstall_hooks(project_dir: str, settings_path: Path | None = None) -> dict
                 "removed": [],
                 "settings_path": str(path),
                 "backup_path": None,
-                "error": f"could not parse settings.json: {exc}",
+                "error": f"could not parse {path}: {exc}",
             }
 
         hooks = settings.get("hooks", {})

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -816,12 +816,12 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     scopes = scopes_by_name[scope]
     hook_targets = []
     hook_errors = []
-    global_cleanup_failed = False
+    cleanup_failed = False
     for p in scopes:
         state = cozempic_hook_schema_state(p)
         if state.error:
             hook_errors.append(state.error)
-            global_cleanup_failed = global_cleanup_failed or p in global_paths
+            cleanup_failed = True
         elif state.found:
             hook_targets.append(str(p))
     slash = _global_slash_path()
@@ -833,9 +833,9 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
         except OSError as exc:
             slash_error = f"Could not read slash command: {exc}"
             slash_present = False
-            global_cleanup_failed = True
+            cleanup_failed = True
     data = []
-    purge_skipped = purge and scope in ("global", "all") and global_cleanup_failed
+    purge_skipped = purge and scope in ("global", "all") and cleanup_failed
     if purge and scope in ("global", "all") and not purge_skipped:
         for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
             if p.exists():
@@ -895,6 +895,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
             result["project_opt_out_set"] = True
         except OSError as exc:
             result["errors"].append(f"Could not persist project uninstall opt-out: {exc}")
+            project_cleanup_failed = True
 
     if scope in ("global", "all"):
         result["slash_command"] = uninstall_slash_command()
@@ -922,7 +923,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
             result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
             global_cleanup_failed = True
 
-    if purge and scope in ("global", "all") and global_cleanup_failed:
+    if purge and scope in ("global", "all") and (global_cleanup_failed or project_cleanup_failed):
         result["purge_skipped"] = True
     elif purge and scope in ("global", "all"):
         import shutil as _sh

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -354,8 +354,8 @@ class _SettingsLock:
                 # __exit__ rewinds to byte 0 before LK_UNLCK, so without
                 # this matching seek(0) before LK_LOCK the two operations
                 # would target different byte ranges and silently fail to
-                # serialize. Mirrors the _HostFileLock pattern in helpers.py
-                # (which has the same defense-in-depth gap — separate fix).
+                # serialize. Mirrors the same seek-before-lock safeguard in
+                # helpers.py's _HostFileLock.
                 import msvcrt
                 self._fh.seek(0)
                 msvcrt.locking(self._fh.fileno(), msvcrt.LK_LOCK, 1)

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -833,6 +833,7 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
         except OSError as exc:
             slash_error = f"Could not read slash command: {exc}"
             slash_present = False
+            global_cleanup_failed = True
     data = []
     purge_skipped = purge and scope in ("global", "all") and global_cleanup_failed
     if purge and scope in ("global", "all") and not purge_skipped:
@@ -899,6 +900,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         result["slash_command"] = uninstall_slash_command()
         if result["slash_command"].get("error"):
             result["errors"].append(result["slash_command"]["error"])
+            global_cleanup_failed = True
 
     # Cleanup the nudge counter (cosmetic, safe).
     if scope in ("global", "all"):

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -684,7 +684,12 @@ def run_init(
         local_settings = _settings_path(project_dir).with_name("settings.local.json")
         if local_settings.exists():
             local_cleanup = uninstall_hooks(project_dir, settings_path=local_settings)
-        project_uninstall_marker(project_dir).unlink(missing_ok=True)
+        try:
+            project_uninstall_marker(project_dir).unlink(missing_ok=True)
+        except OSError as exc:
+            hook_result.setdefault("warnings", []).append(
+                f"Could not clear project uninstall marker: {exc}"
+            )
     slash_result = {"installed": False, "path": None, "already_existed": False}
 
     if not skip_slash:
@@ -745,16 +750,24 @@ def uninstall_slash_command() -> dict:
     cozempic.md is never deleted. Backs it up (.md.bak) first. Idempotent;
     never raises destructively.
 
-    Returns: {removed: bool, path: str|None, backup_path: str|None, skipped_foreign: bool}
+    Returns: {removed: bool, path: str|None, backup_path: str|None,
+              skipped_foreign: bool, error: str|None}
     """
     target = _global_slash_path()
-    out = {"removed": False, "path": str(target), "backup_path": None, "skipped_foreign": False}
+    out = {
+        "removed": False,
+        "path": str(target),
+        "backup_path": None,
+        "skipped_foreign": False,
+        "error": None,
+    }
     if not target.exists():
         out["path"] = None
         return out
     try:
         content = target.read_text(encoding="utf-8", errors="surrogateescape")
-    except OSError:
+    except OSError as exc:
+        out["error"] = f"Could not read slash command: {exc}"
         return out
     if not _slash_is_ours(content):
         out["skipped_foreign"] = True
@@ -763,13 +776,14 @@ def uninstall_slash_command() -> dict:
         backup = target.with_suffix(".md.bak")
         shutil.copy2(target, backup)
         out["backup_path"] = str(backup)
-    except OSError:
-        pass
+    except OSError as exc:
+        out["error"] = f"Could not back up slash command: {exc}"
+        return out
     try:
         target.unlink()
         out["removed"] = True
-    except OSError:
-        pass
+    except OSError as exc:
+        out["error"] = f"Could not remove slash command: {exc}"
     return out
 
 
@@ -821,6 +835,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     }.get(scope, [(str(Path.home()), _global_settings_path())])
     result: dict = {"scope": scope, "hooks": [], "slash_command": None,
                     "remind_counter_removed": False, "purged": [], "opt_out_set": False,
+                    "project_opt_out_set": False,
                     "errors": []}
 
     global_cleanup_failed = False
@@ -838,6 +853,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     if has_project_target and not project_cleanup_failed:
         try:
             project_uninstall_marker(".").touch()
+            result["project_opt_out_set"] = True
         except OSError as exc:
             result["errors"].append(f"Could not persist project uninstall opt-out: {exc}")
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -242,6 +242,11 @@ def _project_settings_paths(project_dir: str) -> list[Path]:
     return [settings, settings.with_name("settings.local.json")]
 
 
+def _global_settings_paths() -> list[Path]:
+    settings = _global_settings_path()
+    return [settings, settings.with_name("settings.local.json")]
+
+
 def project_uninstall_marker(project_dir: str) -> Path:
     return Path(project_dir) / ".claude" / ".cozempic_uninstalled"
 
@@ -514,15 +519,20 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
             if not isinstance(existing, list):
                 existing = []
                 repaired = True
-            valid_existing = [
-                entry
-                for entry in existing
-                if isinstance(entry, dict)
-                and ("hooks" not in entry or isinstance(entry["hooks"], list))
-            ]
-            if len(valid_existing) != len(existing):
-                existing = valid_existing
-                repaired = True
+            valid_existing = []
+            for entry in existing:
+                if not isinstance(entry, dict) or (
+                    "hooks" in entry and not isinstance(entry["hooks"], list)
+                ):
+                    repaired = True
+                    continue
+                if "hooks" in entry:
+                    hooks_list = [hook for hook in entry["hooks"] if isinstance(hook, dict)]
+                    if len(hooks_list) != len(entry["hooks"]):
+                        entry = {**entry, "hooks": hooks_list}
+                        repaired = True
+                valid_existing.append(entry)
+            existing = valid_existing
 
             for new_entry in hook_entries:
                 matcher = new_entry.get("matcher", "")
@@ -757,9 +767,9 @@ def uninstall_slash_command() -> dict:
 def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """Read-only: report what `run_uninstall(scope, purge)` WOULD remove. No writes."""
     scopes = {
-        "global": [_global_settings_path()],
+        "global": _global_settings_paths(),
         "project": _project_settings_paths("."),
-        "all": [_global_settings_path(), *_project_settings_paths(".")],
+        "all": [*_global_settings_paths(), *_project_settings_paths(".")],
     }.get(scope, [_global_settings_path()])
     hook_targets = []
     errors = []
@@ -799,9 +809,9 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     not silently re-wire on the next run (explicit `cozempic init` still works).
     """
     targets = {
-        "global": [(str(Path.home()), _global_settings_path())],
+        "global": [(str(Path.home()), path) for path in _global_settings_paths()],
         "project": [(".", path) for path in _project_settings_paths(".")],
-        "all": [(str(Path.home()), _global_settings_path())]
+        "all": [(str(Path.home()), path) for path in _global_settings_paths()]
         + [(".", path) for path in _project_settings_paths(".")],
     }.get(scope, [(str(Path.home()), _global_settings_path())])
     result: dict = {"scope": scope, "hooks": [], "slash_command": None,

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -619,6 +619,13 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
         if added or updated or repaired:
             try:
                 backup = _backup_settings(path)
+            except OSError as exc:
+                return {
+                    "added": [], "updated": [], "skipped": [],
+                    "settings_path": str(path), "backup_path": None,
+                    "error": f"could not back up {path}: {exc}",
+                }
+            try:
                 _save_settings(path, settings)
             except OSError as exc:
                 return {
@@ -662,15 +669,15 @@ def install_slash_command(project_dir: str) -> dict:
     if not source.exists():
         return {"installed": False, "path": None, "already_existed": False, "updated": False}
 
-    already_existed = target.exists()
-
-    # Check if content differs
-    if already_existed:
-        if source.read_text(encoding="utf-8") == target.read_text(encoding="utf-8"):
+    try:
+        already_existed = target.exists()
+        if already_existed and source.read_text(encoding="utf-8") == target.read_text(encoding="utf-8"):
             return {"installed": False, "path": str(target), "already_existed": True, "updated": False}
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(source, target)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    except (OSError, UnicodeDecodeError) as exc:
+        return {"installed": False, "path": str(target), "already_existed": False,
+                "updated": False, "error": f"Could not install slash command: {exc}"}
 
     return {"installed": True, "path": str(target), "already_existed": already_existed, "updated": already_existed}
 
@@ -698,7 +705,7 @@ def run_init(
             hook_result.setdefault("warnings", []).append(
                 f"Could not clear project uninstall marker: {exc}"
             )
-    slash_result = {"installed": False, "path": None, "already_existed": False}
+    slash_result = {"installed": False, "path": None, "already_existed": False, "updated": False}
 
     if not skip_slash:
         slash_result = install_slash_command(project_dir)
@@ -869,7 +876,9 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
 
     if has_project_target and not project_cleanup_failed:
         try:
-            project_uninstall_marker(".").touch()
+            marker = project_uninstall_marker(".")
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch()
             result["project_opt_out_set"] = True
         except OSError as exc:
             result["errors"].append(f"Could not persist project uninstall opt-out: {exc}")
@@ -891,7 +900,9 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     if scope in ("global", "all") and not global_cleanup_failed:
         # Opt-out: keep global auto-init from re-wiring after global uninstall.
         try:
-            _global_init_marker().touch()
+            marker = _global_init_marker()
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch()
             result["opt_out_set"] = True
         except OSError as exc:
             result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
@@ -989,6 +1000,12 @@ def uninstall_hooks(project_dir: str, settings_path: Path | None = None) -> dict
             settings.pop("hooks", None)
         try:
             backup = _backup_settings(path)
+        except OSError as exc:
+            return {
+                "removed": [], "settings_path": str(path), "backup_path": None,
+                "error": f"could not back up {path}: {exc}",
+            }
+        try:
             _save_settings(path, settings)
         except OSError as exc:
             return {

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -849,10 +849,12 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     opt-out; successful project/all cleanup similarly leaves the project opt-out.
     Explicit `cozempic init` still works in either case.
     """
+    global_paths = _global_settings_paths()
+    managed_global_path = global_paths[0]
     targets_by_scope = {
-        "global": [(str(Path.home()), path) for path in _global_settings_paths()],
+        "global": [(str(Path.home()), path) for path in global_paths],
         "project": [(".", path) for path in _project_settings_paths(".")],
-        "all": [(str(Path.home()), path) for path in _global_settings_paths()]
+        "all": [(str(Path.home()), path) for path in global_paths]
         + [(".", path) for path in _project_settings_paths(".")],
     }
     if scope not in targets_by_scope:
@@ -865,6 +867,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
                     "errors": []}
 
     global_cleanup_failed = False
+    managed_global_cleanup_failed = False
     project_cleanup_failed = False
     has_project_target = False
     for directory, settings_path in targets:
@@ -874,6 +877,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         if hook_result.get("error"):
             result["errors"].append(hook_result["error"])
             global_cleanup_failed = global_cleanup_failed or directory != "."
+            managed_global_cleanup_failed = managed_global_cleanup_failed or settings_path == managed_global_path
             project_cleanup_failed = project_cleanup_failed or directory == "."
 
     if has_project_target and not project_cleanup_failed:
@@ -899,7 +903,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         except OSError as exc:
             result["errors"].append(f"Could not remove remind counter: {exc}")
 
-    if scope in ("global", "all") and not global_cleanup_failed:
+    if scope in ("global", "all") and not managed_global_cleanup_failed:
         # Opt-out: keep global auto-init from re-wiring after global uninstall.
         try:
             marker = _global_init_marker()

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -676,14 +676,12 @@ def run_init(
 
     Returns combined result dict.
     """
+    hook_result = wire_hooks(project_dir, settings_path=settings_path)
     local_cleanup = None
-    if settings_path is None:
+    if settings_path is None and not hook_result.get("error"):
         local_settings = _settings_path(project_dir).with_name("settings.local.json")
         if local_settings.exists():
             local_cleanup = uninstall_hooks(project_dir, settings_path=local_settings)
-
-    hook_result = wire_hooks(project_dir, settings_path=settings_path)
-    if settings_path is None and not hook_result.get("error"):
         project_uninstall_marker(project_dir).unlink(missing_ok=True)
     slash_result = {"installed": False, "path": None, "already_existed": False}
 
@@ -816,16 +814,21 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
                     "remind_counter_removed": False, "purged": [], "opt_out_set": False,
                     "errors": []}
 
+    project_cleanup_failed = False
+    has_project_target = False
     for directory, settings_path in targets:
         hook_result = uninstall_hooks(directory, settings_path=settings_path)
         result["hooks"].append(hook_result)
+        has_project_target = has_project_target or directory == "."
         if hook_result.get("error"):
             result["errors"].append(hook_result["error"])
-        elif directory == ".":
-            try:
-                project_uninstall_marker(directory).touch()
-            except OSError:
-                pass
+            project_cleanup_failed = project_cleanup_failed or directory == "."
+
+    if has_project_target and not project_cleanup_failed:
+        try:
+            project_uninstall_marker(".").touch()
+        except OSError:
+            pass
 
     if scope in ("global", "all"):
         result["slash_command"] = uninstall_slash_command()

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -726,7 +726,7 @@ def global_init_marker_path() -> Path:
         try:
             marker.touch(exist_ok=True)
         except OSError:
-            pass
+            return legacy_marker
     return marker
 
 
@@ -838,8 +838,8 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     if has_project_target and not project_cleanup_failed:
         try:
             project_uninstall_marker(".").touch()
-        except OSError:
-            pass
+        except OSError as exc:
+            result["errors"].append(f"Could not persist project uninstall opt-out: {exc}")
 
     if scope in ("global", "all"):
         result["slash_command"] = uninstall_slash_command()
@@ -857,8 +857,8 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         try:
             _global_init_marker().touch()
             result["opt_out_set"] = True
-        except OSError:
-            pass
+        except OSError as exc:
+            result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
 
     if purge:
         import shutil as _sh
@@ -868,8 +868,8 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
                     _sh.rmtree(p); result["purged"].append(str(p))
                 elif p.exists():
                     p.unlink(); result["purged"].append(str(p))
-            except OSError:
-                pass
+            except OSError as exc:
+                result["errors"].append(f"Purge failed for {p}: {exc}")
 
     return result
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -81,13 +81,15 @@ COZEMPIC_HOOKS = _load_canonical_hooks()
 
 # ─── Core logic ──────────────────────────────────────────────────────────────
 
-def _is_cozempic_hook(hook_entry: dict) -> bool:
+def _is_cozempic_hook(hook_entry: object) -> bool:
     """Return True if this entry contains AT LEAST ONE cozempic-installed
     command. See `_is_cozempic_command` for per-command granularity used by
     uninstall (which must preserve user-authored commands in mixed entries).
     """
-    for h in hook_entry.get("hooks", []):
-        if _is_cozempic_command(h.get("command", "")):
+    if not isinstance(hook_entry, dict):
+        return False
+    for h in hook_entry.get("hooks", []) or []:
+        if isinstance(h, dict) and _is_cozempic_command(h.get("command", "")):
             return True
     return False
 
@@ -127,12 +129,14 @@ def _is_current_cozempic_command(command: str) -> bool:
     return HOOK_SCHEMA_MARKER in command
 
 
-def _entry_has_current_cozempic_hook(hook_entry: dict) -> bool:
+def _entry_has_current_cozempic_hook(hook_entry: object) -> bool:
     """Return True if at least one command in this entry matches the current
     schema. Used by `_maybe_auto_init` and `_maybe_global_init` to decide
     whether the project/user needs a refresh."""
-    for h in hook_entry.get("hooks", []):
-        if _is_current_cozempic_command(h.get("command", "")):
+    if not isinstance(hook_entry, dict):
+        return False
+    for h in hook_entry.get("hooks", []) or []:
+        if isinstance(h, dict) and _is_current_cozempic_command(h.get("command", "")):
             return True
     return False
 
@@ -436,7 +440,7 @@ def _bake_cozempic_path(hooks: dict, abs_python: str) -> dict:
         if not isinstance(entries, list):
             continue
         for entry in entries:
-            for h in entry.get("hooks", []) if isinstance(entry, dict) else []:
+            for h in (entry.get("hooks", []) or []) if isinstance(entry, dict) else []:
                 cmd = h.get("command") if isinstance(h, dict) else None
                 if isinstance(cmd, str) and "python3 -m cozempic" in cmd:
                     h["command"] = cmd.replace("python3 -m cozempic", f"{q} -m cozempic")
@@ -507,6 +511,8 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
                 # user commands in every matching entry.
                 our_entry_idxs = []
                 for idx, existing_entry in enumerate(existing):
+                    if not isinstance(existing_entry, dict):
+                        continue
                     if existing_entry.get("matcher", "") != matcher:
                         continue
                     if _is_cozempic_hook(existing_entry):

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -920,6 +920,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
             result["opt_out_set"] = True
         except OSError as exc:
             result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
+            global_cleanup_failed = True
 
     if purge and scope in ("global", "all") and global_cleanup_failed:
         result["purge_skipped"] = True

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -610,6 +610,7 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
         "added": added,
         "updated": updated,
         "skipped": skipped,
+        "repaired": repaired,
         "settings_path": str(path),
         "backup_path": str(backup) if backup else None,
         "ephemeral": ephemeral,        # #158: True if cozempic runs from a throwaway env

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -268,7 +268,11 @@ def _backup_settings(path: Path) -> Path | None:
     if not path.exists():
         return None
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    backup = path.with_suffix(f".{ts}.bak")
+    backup = path.with_name(f"{path.name}.{ts}.bak")
+    suffix = 1
+    while backup.exists():
+        backup = path.with_name(f"{path.name}.{ts}.{suffix}.bak")
+        suffix += 1
     shutil.copy2(path, backup)
     return backup
 
@@ -903,7 +907,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
             result["errors"].append(result["slash_command"]["error"])
             global_cleanup_failed = True
 
-    # Cleanup the nudge counter (cosmetic, safe).
+    # Remove the global nudge counter before a purge.
     if scope in ("global", "all"):
         try:
             if _REMIND_COUNTER.exists():
@@ -911,6 +915,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
                 result["remind_counter_removed"] = True
         except OSError as exc:
             result["errors"].append(f"Could not remove remind counter: {exc}")
+            global_cleanup_failed = True
 
     if scope in ("global", "all") and not managed_global_cleanup_failed:
         # Opt-out: keep global auto-init from re-wiring after global uninstall.

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -859,7 +859,8 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         raise ValueError(f"Unknown uninstall scope: {scope}")
     targets = targets_by_scope[scope]
     result: dict = {"scope": scope, "hooks": [], "slash_command": None,
-                    "remind_counter_removed": False, "purged": [], "opt_out_set": False,
+                    "remind_counter_removed": False, "purged": [], "purge_skipped": False,
+                    "opt_out_set": False,
                     "project_opt_out_set": False,
                     "errors": []}
 
@@ -908,7 +909,9 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         except OSError as exc:
             result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
 
-    if purge and scope in ("global", "all") and not global_cleanup_failed:
+    if purge and scope in ("global", "all") and global_cleanup_failed:
+        result["purge_skipped"] = True
+    elif purge and scope in ("global", "all"):
         import shutil as _sh
         for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
             try:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -10,6 +10,7 @@ This module automates both so `cozempic init` is the only setup step.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -499,15 +500,16 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
                 "backup_path": None,
                 "error": f"could not parse {path}: {exc}. Back up + fix the file, then rerun.",
             }
+        repaired = False
         hooks = settings.get("hooks")
         if not isinstance(hooks, dict):
             hooks = {}
             settings["hooks"] = hooks
+            repaired = True
 
         added: list[str] = []
         updated: list[str] = []
         skipped: list[str] = []
-        repaired = False
 
         # #158: bake the absolute interpreter into the hook fallback so the guard
         # resolves even when bare `cozempic` isn't on the hook's PATH.
@@ -718,7 +720,14 @@ def _global_settings_path() -> Path:
 
 def global_init_marker_path() -> Path:
     from .session import get_claude_dir
-    return get_claude_dir() / ".cozempic_global_initialized"
+    marker = get_claude_dir() / ".cozempic_global_initialized"
+    legacy_marker = Path.home() / ".cozempic_global_initialized"
+    if not os.environ.get("CLAUDE_CONFIG_DIR") and legacy_marker != marker and legacy_marker.exists():
+        try:
+            marker.touch(exist_ok=True)
+        except OSError:
+            pass
+    return marker
 
 
 def _global_init_marker() -> Path:
@@ -814,6 +823,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
                     "remind_counter_removed": False, "purged": [], "opt_out_set": False,
                     "errors": []}
 
+    global_cleanup_failed = False
     project_cleanup_failed = False
     has_project_target = False
     for directory, settings_path in targets:
@@ -822,6 +832,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         has_project_target = has_project_target or directory == "."
         if hook_result.get("error"):
             result["errors"].append(hook_result["error"])
+            global_cleanup_failed = global_cleanup_failed or directory != "."
             project_cleanup_failed = project_cleanup_failed or directory == "."
 
     if has_project_target and not project_cleanup_failed:
@@ -841,7 +852,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     except OSError:
         pass
 
-    if scope in ("global", "all"):
+    if scope in ("global", "all") and not global_cleanup_failed:
         # Opt-out: keep global auto-init from re-wiring after global uninstall.
         try:
             _global_init_marker().touch()

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -797,26 +797,30 @@ def uninstall_slash_command() -> dict:
 
 def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """Read-only: report what `run_uninstall(scope, purge)` WOULD remove. No writes."""
-    scopes = {
+    scopes_by_name = {
         "global": _global_settings_paths(),
         "project": _project_settings_paths("."),
         "all": [*_global_settings_paths(), *_project_settings_paths(".")],
-    }.get(scope, [_global_settings_path()])
+    }
+    if scope not in scopes_by_name:
+        raise ValueError(f"Unknown uninstall scope: {scope}")
+    scopes = scopes_by_name[scope]
     hook_targets = []
-    errors = []
+    hook_errors = []
     for p in scopes:
         state = cozempic_hook_schema_state(p)
         if state.error:
-            errors.append(state.error)
+            hook_errors.append(state.error)
         elif state.found:
             hook_targets.append(str(p))
     slash = _global_slash_path()
     slash_present = False
+    slash_error = None
     if scope in ("global", "all") and slash.exists():
         try:
             slash_present = _slash_is_ours(slash.read_text(encoding="utf-8", errors="surrogateescape"))
         except OSError as exc:
-            errors.append(f"Could not read slash command: {exc}")
+            slash_error = f"Could not read slash command: {exc}"
             slash_present = False
     data = []
     if purge and scope in ("global", "all"):
@@ -825,7 +829,8 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
                 data.append(str(p))
     return {"hooks_in": hook_targets, "slash_command": slash_present,
             "remind_counter": scope in ("global", "all") and _REMIND_COUNTER.exists(), "purge_data": data,
-            "errors": errors}
+            "hook_errors": hook_errors, "slash_error": slash_error,
+            "errors": [*hook_errors, *([slash_error] if slash_error else [])]}
 
 
 def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
@@ -836,12 +841,15 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     On successful global/all cleanup, leaves the global-init marker as the auto-init
     opt-out so init does not silently re-wire (explicit `cozempic init` still works).
     """
-    targets = {
+    targets_by_scope = {
         "global": [(str(Path.home()), path) for path in _global_settings_paths()],
         "project": [(".", path) for path in _project_settings_paths(".")],
         "all": [(str(Path.home()), path) for path in _global_settings_paths()]
         + [(".", path) for path in _project_settings_paths(".")],
-    }.get(scope, [(str(Path.home()), _global_settings_path())])
+    }
+    if scope not in targets_by_scope:
+        raise ValueError(f"Unknown uninstall scope: {scope}")
+    targets = targets_by_scope[scope]
     result: dict = {"scope": scope, "hooks": [], "slash_command": None,
                     "remind_counter_removed": False, "purged": [], "opt_out_set": False,
                     "project_opt_out_set": False,

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -663,6 +663,12 @@ def run_init(
 
     Returns combined result dict.
     """
+    local_cleanup = None
+    if settings_path is None:
+        local_settings = _settings_path(project_dir).with_name("settings.local.json")
+        if local_settings.exists():
+            local_cleanup = uninstall_hooks(project_dir, settings_path=local_settings)
+
     hook_result = wire_hooks(project_dir, settings_path=settings_path)
     if settings_path is None and not hook_result.get("error"):
         project_uninstall_marker(project_dir).unlink(missing_ok=True)
@@ -673,6 +679,7 @@ def run_init(
 
     return {
         "hooks": hook_result,
+        "local_cleanup": local_cleanup,
         "slash_command": slash_result,
     }
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -617,8 +617,16 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
         # Only write if something changed
         backup = None
         if added or updated or repaired:
-            backup = _backup_settings(path)
-            _save_settings(path, settings)
+            try:
+                backup = _backup_settings(path)
+                _save_settings(path, settings)
+            except OSError as exc:
+                return {
+                    "added": [], "updated": [], "skipped": [],
+                    "settings_path": str(path),
+                    "backup_path": str(backup) if backup else None,
+                    "error": f"could not write {path}: {exc}",
+                }
 
     return {
         "added": added,
@@ -966,12 +974,21 @@ def uninstall_hooks(project_dir: str, settings_path: Path | None = None) -> dict
         if not changed:
             return {"removed": [], "settings_path": str(path), "backup_path": None}
 
-        backup = _backup_settings(path)
+        backup = None
         if hooks:
             settings["hooks"] = hooks
         else:
             settings.pop("hooks", None)
-        _save_settings(path, settings)
+        try:
+            backup = _backup_settings(path)
+            _save_settings(path, settings)
+        except OSError as exc:
+            return {
+                "removed": [],
+                "settings_path": str(path),
+                "backup_path": str(backup) if backup else None,
+                "error": f"could not write {path}: {exc}",
+            }
 
     return {
         "removed": removed,

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -81,14 +81,20 @@ COZEMPIC_HOOKS = _load_canonical_hooks()
 
 # ─── Core logic ──────────────────────────────────────────────────────────────
 
+def _hooks_list(entry: object) -> list:
+    """Return a hook entry's commands only when its container is a list."""
+    if not isinstance(entry, dict):
+        return []
+    hooks = entry.get("hooks", [])
+    return hooks if isinstance(hooks, list) else []
+
+
 def _is_cozempic_hook(hook_entry: object) -> bool:
     """Return True if this entry contains AT LEAST ONE cozempic-installed
     command. See `_is_cozempic_command` for per-command granularity used by
     uninstall (which must preserve user-authored commands in mixed entries).
     """
-    if not isinstance(hook_entry, dict):
-        return False
-    for h in hook_entry.get("hooks", []) or []:
+    for h in _hooks_list(hook_entry):
         if isinstance(h, dict) and _is_cozempic_command(h.get("command", "")):
             return True
     return False
@@ -133,9 +139,7 @@ def _entry_has_current_cozempic_hook(hook_entry: object) -> bool:
     """Return True if at least one command in this entry matches the current
     schema. Used by `_maybe_auto_init` and `_maybe_global_init` to decide
     whether the project/user needs a refresh."""
-    if not isinstance(hook_entry, dict):
-        return False
-    for h in hook_entry.get("hooks", []) or []:
+    for h in _hooks_list(hook_entry):
         if isinstance(h, dict) and _is_current_cozempic_command(h.get("command", "")):
             return True
     return False
@@ -151,9 +155,7 @@ class CozempicHookSchemaState:
 
 
 def _iter_entry_hook_commands(entry: object):
-    if not isinstance(entry, dict):
-        return
-    for hook in entry.get("hooks", []) or []:
+    for hook in _hooks_list(entry):
         if isinstance(hook, dict):
             command = hook.get("command")
             if isinstance(command, str):
@@ -440,7 +442,7 @@ def _bake_cozempic_path(hooks: dict, abs_python: str) -> dict:
         if not isinstance(entries, list):
             continue
         for entry in entries:
-            for h in (entry.get("hooks", []) or []) if isinstance(entry, dict) else []:
+            for h in _hooks_list(entry):
                 cmd = h.get("command") if isinstance(h, dict) else None
                 if isinstance(cmd, str) and "python3 -m cozempic" in cmd:
                     h["command"] = cmd.replace("python3 -m cozempic", f"{q} -m cozempic")
@@ -528,7 +530,7 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
                 # user-authored commands retain their original order.
                 primary_idx = our_entry_idxs[0]
                 primary = existing[primary_idx]
-                primary_hooks = primary.get("hooks", []) or []
+                primary_hooks = _hooks_list(primary)
                 primary_current = all(
                     _is_current_cozempic_command(h.get("command", ""))
                     for h in primary_hooks
@@ -559,7 +561,7 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
                     duplicate = existing[duplicate_idx]
                     kept_hooks = [
                         hook
-                        for hook in duplicate.get("hooks", []) or []
+                        for hook in _hooks_list(duplicate)
                         if not (
                             isinstance(hook, dict)
                             and _is_cozempic_command(hook.get("command", ""))
@@ -862,7 +864,7 @@ def uninstall_hooks(project_dir: str, settings_path: Path | None = None) -> dict
                     new_entries.append(entry)
                     continue
 
-                old_inner = entry.get("hooks", []) or []
+                old_inner = _hooks_list(entry)
                 kept_inner = [
                     h for h in old_inner
                     if not (isinstance(h, dict) and _is_cozempic_command(h.get("command", "")))

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -824,9 +824,9 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """Reverse cozempic init. scope: 'global' | 'project' | 'all'.
 
     Removes hooks (per scope), the global slash command (global/all), the remind
-    counter, and — with purge — the ~/.cozempic data dir + savings ledger. ALWAYS
-    leaves the global-init marker in place as the auto-init opt-out, so init does
-    not silently re-wire on the next run (explicit `cozempic init` still works).
+    counter, and — with global/all purge — the ~/.cozempic data dir + savings ledger.
+    On successful global/all cleanup, leaves the global-init marker as the auto-init
+    opt-out so init does not silently re-wire (explicit `cozempic init` still works).
     """
     targets = {
         "global": [(str(Path.home()), path) for path in _global_settings_paths()],
@@ -880,7 +880,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         except OSError as exc:
             result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
 
-    if purge:
+    if purge and scope in ("global", "all"):
         import shutil as _sh
         for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
             try:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -181,7 +181,7 @@ def cozempic_hook_schema_state(settings_path: Path) -> CozempicHookSchemaState:
     """Return managed-hook state for ``settings_path`` without masking errors."""
     try:
         settings = _load_settings(settings_path)
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, ValueError) as exc:
         return CozempicHookSchemaState(
             found=False,
             current=False,
@@ -230,7 +230,10 @@ def _load_settings(path: Path) -> dict:
     """Load settings.json, returning empty dict if missing."""
     if path.exists():
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            settings = json.load(f)
+        if not isinstance(settings, dict):
+            raise ValueError(f"settings.json must be a JSON object, got {type(settings).__name__}")
+        return settings
     return {}
 
 
@@ -462,7 +465,7 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
     with _SettingsLock(path):
         try:
             settings = _load_settings(path)
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, ValueError) as exc:
             # Malformed or unreadable settings.json — don't crash cmd_init with
             # a raw traceback. Surface via the `error` field like uninstall does.
             return {
@@ -639,7 +642,9 @@ def run_init(
 # Stable content signature of cozempic's /cozempic slash command, used to avoid
 # clobbering an unrelated user-authored ~/.claude/commands/cozempic.md.
 _SLASH_SIGNATURE = "prune bloated Claude Code context"
-_GLOBAL_INIT_MARKER = Path.home() / ".cozempic_global_initialized"
+# Compatibility seam for callers that patch this in tests. Production resolves
+# dynamically so each CLAUDE_CONFIG_DIR profile gets its own decision.
+_GLOBAL_INIT_MARKER: Path | None = None
 _REMIND_COUNTER = Path.home() / ".cozempic_remind_counter"
 
 
@@ -651,6 +656,15 @@ def _global_slash_path() -> Path:
 def _global_settings_path() -> Path:
     from .session import get_claude_dir
     return get_claude_dir() / "settings.json"
+
+
+def global_init_marker_path() -> Path:
+    from .session import get_claude_dir
+    return get_claude_dir() / ".cozempic_global_initialized"
+
+
+def _global_init_marker() -> Path:
+    return _GLOBAL_INIT_MARKER or global_init_marker_path()
 
 
 def _slash_is_ours(content: str) -> bool:
@@ -764,7 +778,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
 
     # Opt-out: keep auto-init from re-wiring after uninstall.
     try:
-        _GLOBAL_INIT_MARKER.touch()
+        _global_init_marker().touch()
         result["opt_out_set"] = True
     except OSError:
         pass
@@ -799,7 +813,7 @@ def uninstall_hooks(project_dir: str, settings_path: Path | None = None) -> dict
     with _SettingsLock(path):
         try:
             settings = _load_settings(path)
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, ValueError) as exc:
             # Malformed settings.json — don't crash, just report and bail.
             return {
                 "removed": [],

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -136,6 +136,38 @@ def _entry_has_current_cozempic_hook(hook_entry: dict) -> bool:
     return False
 
 
+def cozempic_hook_schema_state(settings_path: Path) -> tuple[bool, bool]:
+    """Return whether ``settings_path`` has Cozempic hooks and all are current."""
+    try:
+        settings = _load_settings(settings_path)
+    except (OSError, json.JSONDecodeError):
+        return False, True
+
+    hooks = settings.get("hooks", {}) or {}
+    if not isinstance(hooks, dict):
+        return False, True
+
+    found = False
+    stale = False
+    for entries in hooks.values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            for hook in entry.get("hooks", []) or []:
+                if not isinstance(hook, dict):
+                    continue
+                command = str(hook.get("command", ""))
+                if not _is_cozempic_command(command):
+                    continue
+                found = True
+                if not _is_current_cozempic_command(command):
+                    stale = True
+
+    return found, not stale
+
+
 def has_current_schema(settings: dict) -> bool:
     """Return True if the settings dict has at least one current-schema
     cozempic hook across any event. Used by cli auto-init to avoid refresh
@@ -419,51 +451,73 @@ def wire_hooks(project_dir: str) -> dict:
                 matcher = new_entry.get("matcher", "")
                 display = new_entry.get("matcher", "(all)")
 
-                # Find the cozempic-installed entry with the same matcher (if any).
-                # Mixed entries (cozempic + user command in the same hooks-list)
-                # are preserved — we only replace the cozempic commands within.
-                our_entry_idx = None
+                # Find every Cozempic entry with this matcher. Canonical hooks
+                # have one entry per matcher, but older installs can contain
+                # duplicates. Keep one canonical command set while preserving
+                # user commands in every matching entry.
+                our_entry_idxs = []
                 for idx, existing_entry in enumerate(existing):
                     if existing_entry.get("matcher", "") != matcher:
                         continue
                     if _is_cozempic_hook(existing_entry):
-                        our_entry_idx = idx
-                        break
+                        our_entry_idxs.append(idx)
 
-                if our_entry_idx is None:
+                if not our_entry_idxs:
                     existing.append(new_entry)
                     added.append(f"{event_name}[{display}]")
                     continue
 
-                # Check if existing is at current schema
-                our_entry = existing[our_entry_idx]
-                if _entry_has_current_cozempic_hook(our_entry):
-                    skipped.append(f"{event_name}[{display}]")
-                    continue
-
-                # STALE — refresh. Replace cozempic commands IN PLACE (preserve
-                # original position of user-authored commands in the list).
-                old_hooks = our_entry.get("hooks", []) or []
+                # Refresh the first matching entry unless every one of its
+                # Cozempic commands is current. Replace commands in place so
+                # user-authored commands retain their original order.
+                primary_idx = our_entry_idxs[0]
+                primary = existing[primary_idx]
+                primary_hooks = primary.get("hooks", []) or []
+                primary_current = all(
+                    _is_current_cozempic_command(h.get("command", ""))
+                    for h in primary_hooks
+                    if isinstance(h, dict)
+                    and _is_cozempic_command(h.get("command", ""))
+                )
                 canonical_new = list(new_entry.get("hooks", []))
-                new_hooks: list = []
-                canonical_inserted = False
-                for h in old_hooks:
-                    if _is_cozempic_command(h.get("command", "")):
-                        # Splice in the new canonical commands at the position
-                        # of the FIRST stale cozempic command; drop the rest.
-                        if not canonical_inserted:
-                            new_hooks.extend(canonical_new)
-                            canonical_inserted = True
-                        # else: this stale cozempic command is skipped
+                changed = len(our_entry_idxs) > 1
+                if not primary_current:
+                    new_hooks: list = []
+                    canonical_inserted = False
+                    for hook in primary_hooks:
+                        if isinstance(hook, dict) and _is_cozempic_command(
+                            hook.get("command", "")
+                        ):
+                            if not canonical_inserted:
+                                new_hooks.extend(canonical_new)
+                                canonical_inserted = True
+                        else:
+                            new_hooks.append(hook)
+                    primary["hooks"] = new_hooks
+                    changed = True
+
+                # Strip duplicate Cozempic commands from later entries. Work
+                # backwards so dropping an empty entry cannot shift an index we
+                # have yet to process.
+                for duplicate_idx in reversed(our_entry_idxs[1:]):
+                    duplicate = existing[duplicate_idx]
+                    kept_hooks = [
+                        hook
+                        for hook in duplicate.get("hooks", []) or []
+                        if not (
+                            isinstance(hook, dict)
+                            and _is_cozempic_command(hook.get("command", ""))
+                        )
+                    ]
+                    if kept_hooks:
+                        duplicate["hooks"] = kept_hooks
                     else:
-                        new_hooks.append(h)
-                if not canonical_inserted:
-                    # Defensive: shouldn't happen (we only entered refresh path
-                    # because a stale cozempic command exists), but fall back
-                    # to appending.
-                    new_hooks.extend(canonical_new)
-                our_entry["hooks"] = new_hooks
-                updated.append(f"{event_name}[{display}]")
+                        del existing[duplicate_idx]
+
+                if changed:
+                    updated.append(f"{event_name}[{display}]")
+                else:
+                    skipped.append(f"{event_name}[{display}]")
 
             hooks[event_name] = existing
 
@@ -615,22 +669,8 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
 
 
 def _settings_has_cozempic_hooks(path: Path) -> bool:
-    try:
-        settings = _load_settings(path)
-    except (OSError, json.JSONDecodeError):
-        return False
-    hooks = settings.get("hooks", {})
-    if not isinstance(hooks, dict):
-        return False
-    for entries in hooks.values():
-        if not isinstance(entries, list):
-            continue
-        for entry in entries:
-            if isinstance(entry, dict):
-                for h in entry.get("hooks", []) or []:
-                    if isinstance(h, dict) and _is_cozempic_command(h.get("command", "")):
-                        return True
-    return False
+    found, _ = cozempic_hook_schema_state(path)
+    return found
 
 
 def run_uninstall(scope: str = "global", purge: bool = False) -> dict:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -283,7 +283,7 @@ def _save_settings(path: Path, settings: dict) -> None:
     entire Claude Code config on a bad interrupt.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    import os as _os, tempfile as _tempfile, stat as _stat
+    import os as _os, tempfile as _tempfile
 
     # Capture original permissions before we replace (Claude Code creates
     # settings.json as 0o644; mkstemp creates 0o600 — we must restore).
@@ -895,8 +895,8 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
             if _REMIND_COUNTER.exists():
                 _REMIND_COUNTER.unlink()
                 result["remind_counter_removed"] = True
-        except OSError:
-            pass
+        except OSError as exc:
+            result["errors"].append(f"Could not remove remind counter: {exc}")
 
     if scope in ("global", "all") and not global_cleanup_failed:
         # Opt-out: keep global auto-init from re-wiring after global uninstall.

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -846,7 +846,8 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     Removes hooks (per scope), the global slash command (global/all), the remind
     counter, and — with global/all purge — the ~/.cozempic data dir + savings ledger.
     On successful global/all cleanup, leaves the global-init marker as the auto-init
-    opt-out so init does not silently re-wire (explicit `cozempic init` still works).
+    opt-out; successful project/all cleanup similarly leaves the project opt-out.
+    Explicit `cozempic init` still works in either case.
     """
     targets_by_scope = {
         "global": [(str(Path.home()), path) for path in _global_settings_paths()],
@@ -907,7 +908,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         except OSError as exc:
             result["errors"].append(f"Could not persist global uninstall opt-out: {exc}")
 
-    if purge and scope in ("global", "all"):
+    if purge and scope in ("global", "all") and not global_cleanup_failed:
         import shutil as _sh
         for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
             try:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -816,7 +816,7 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
             if p.exists():
                 data.append(str(p))
     return {"hooks_in": hook_targets, "slash_command": slash_present,
-            "remind_counter": _REMIND_COUNTER.exists(), "purge_data": data,
+            "remind_counter": scope in ("global", "all") and _REMIND_COUNTER.exists(), "purge_data": data,
             "errors": errors}
 
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -497,6 +497,7 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
         added: list[str] = []
         updated: list[str] = []
         skipped: list[str] = []
+        repaired = False
 
         # #158: bake the absolute interpreter into the hook fallback so the guard
         # resolves even when bare `cozempic` isn't on the hook's PATH.
@@ -507,6 +508,16 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
             existing = hooks.get(event_name, [])
             if not isinstance(existing, list):
                 existing = []
+                repaired = True
+            valid_existing = [
+                entry
+                for entry in existing
+                if isinstance(entry, dict)
+                and ("hooks" not in entry or isinstance(entry["hooks"], list))
+            ]
+            if len(valid_existing) != len(existing):
+                existing = valid_existing
+                repaired = True
 
             for new_entry in hook_entries:
                 matcher = new_entry.get("matcher", "")
@@ -586,7 +597,7 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
 
         # Only write if something changed
         backup = None
-        if added or updated:
+        if added or updated or repaired:
             backup = _backup_settings(path)
             _save_settings(path, settings)
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -804,20 +804,24 @@ def uninstall_slash_command() -> dict:
 
 def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """Read-only: report what `run_uninstall(scope, purge)` WOULD remove. No writes."""
+    global_paths = _global_settings_paths()
+    project_paths = _project_settings_paths(".")
     scopes_by_name = {
-        "global": _global_settings_paths(),
-        "project": _project_settings_paths("."),
-        "all": [*_global_settings_paths(), *_project_settings_paths(".")],
+        "global": global_paths,
+        "project": project_paths,
+        "all": [*global_paths, *project_paths],
     }
     if scope not in scopes_by_name:
         raise ValueError(f"Unknown uninstall scope: {scope}")
     scopes = scopes_by_name[scope]
     hook_targets = []
     hook_errors = []
+    global_cleanup_failed = False
     for p in scopes:
         state = cozempic_hook_schema_state(p)
         if state.error:
             hook_errors.append(state.error)
+            global_cleanup_failed = global_cleanup_failed or p in global_paths
         elif state.found:
             hook_targets.append(str(p))
     slash = _global_slash_path()
@@ -830,12 +834,14 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
             slash_error = f"Could not read slash command: {exc}"
             slash_present = False
     data = []
-    if purge and scope in ("global", "all"):
+    purge_skipped = purge and scope in ("global", "all") and global_cleanup_failed
+    if purge and scope in ("global", "all") and not purge_skipped:
         for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
             if p.exists():
                 data.append(str(p))
     return {"hooks_in": hook_targets, "slash_command": slash_present,
             "remind_counter": scope in ("global", "all") and _REMIND_COUNTER.exists(), "purge_data": data,
+            "purge_skipped": purge_skipped,
             "hook_errors": hook_errors, "slash_error": slash_error,
             "errors": [*hook_errors, *([slash_error] if slash_error else [])]}
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -226,6 +226,10 @@ def _settings_path(project_dir: str) -> Path:
     return Path(project_dir) / ".claude" / "settings.json"
 
 
+def project_uninstall_marker(project_dir: str) -> Path:
+    return Path(project_dir) / ".claude" / ".cozempic_uninstalled"
+
+
 def _load_settings(path: Path) -> dict:
     """Load settings.json, returning empty dict if missing."""
     if path.exists():
@@ -474,7 +478,10 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
                 "backup_path": None,
                 "error": f"could not parse {path}: {exc}. Back up + fix the file, then rerun.",
             }
-        hooks = settings.setdefault("hooks", {})
+        hooks = settings.get("hooks")
+        if not isinstance(hooks, dict):
+            hooks = {}
+            settings["hooks"] = hooks
 
         added: list[str] = []
         updated: list[str] = []
@@ -487,6 +494,8 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
 
         for event_name, hook_entries in canonical_hooks.items():
             existing = hooks.get(event_name, [])
+            if not isinstance(existing, list):
+                existing = []
 
             for new_entry in hook_entries:
                 matcher = new_entry.get("matcher", "")
@@ -626,6 +635,8 @@ def run_init(
     Returns combined result dict.
     """
     hook_result = wire_hooks(project_dir, settings_path=settings_path)
+    if settings_path is None and not hook_result.get("error"):
+        project_uninstall_marker(project_dir).unlink(missing_ok=True)
     slash_result = {"installed": False, "path": None, "already_existed": False}
 
     if not skip_slash:
@@ -764,6 +775,11 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
         result["hooks"].append(hook_result)
         if hook_result.get("error"):
             result["errors"].append(hook_result["error"])
+        elif directory == ".":
+            try:
+                project_uninstall_marker(directory).touch()
+            except OSError:
+                pass
 
     if scope in ("global", "all"):
         result["slash_command"] = uninstall_slash_command()

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -807,7 +807,8 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     if scope in ("global", "all") and slash.exists():
         try:
             slash_present = _slash_is_ours(slash.read_text(encoding="utf-8", errors="surrogateescape"))
-        except OSError:
+        except OSError as exc:
+            errors.append(f"Could not read slash command: {exc}")
             slash_present = False
     data = []
     if purge:
@@ -859,14 +860,17 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
 
     if scope in ("global", "all"):
         result["slash_command"] = uninstall_slash_command()
+        if result["slash_command"].get("error"):
+            result["errors"].append(result["slash_command"]["error"])
 
     # Cleanup the nudge counter (cosmetic, safe).
-    try:
-        if _REMIND_COUNTER.exists():
-            _REMIND_COUNTER.unlink()
-            result["remind_counter_removed"] = True
-    except OSError:
-        pass
+    if scope in ("global", "all"):
+        try:
+            if _REMIND_COUNTER.exists():
+                _REMIND_COUNTER.unlink()
+                result["remind_counter_removed"] = True
+        except OSError:
+            pass
 
     if scope in ("global", "all") and not global_cleanup_failed:
         # Opt-out: keep global auto-init from re-wiring after global uninstall.

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import shutil
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
@@ -136,36 +137,72 @@ def _entry_has_current_cozempic_hook(hook_entry: dict) -> bool:
     return False
 
 
-def cozempic_hook_schema_state(settings_path: Path) -> tuple[bool, bool]:
-    """Return whether ``settings_path`` has Cozempic hooks and all are current."""
-    try:
-        settings = _load_settings(settings_path)
-    except (OSError, json.JSONDecodeError):
-        return False, True
+@dataclass(frozen=True)
+class CozempicHookSchemaState:
+    """Managed-hook state for one or more Claude settings files."""
 
+    found: bool
+    current: bool
+    error: str | None = None
+
+
+def _iter_entry_hook_commands(entry: object):
+    if not isinstance(entry, dict):
+        return
+    for hook in entry.get("hooks", []) or []:
+        if isinstance(hook, dict):
+            command = hook.get("command")
+            if isinstance(command, str):
+                yield command
+
+
+def _iter_hook_commands(settings: dict):
     hooks = settings.get("hooks", {}) or {}
     if not isinstance(hooks, dict):
-        return False, True
-
-    found = False
-    stale = False
+        return
     for entries in hooks.values():
-        if not isinstance(entries, list):
-            continue
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            for hook in entry.get("hooks", []) or []:
-                if not isinstance(hook, dict):
-                    continue
-                command = str(hook.get("command", ""))
-                if not _is_cozempic_command(command):
-                    continue
-                found = True
-                if not _is_current_cozempic_command(command):
-                    stale = True
+        if isinstance(entries, list):
+            for entry in entries:
+                yield from _iter_entry_hook_commands(entry)
 
-    return found, not stale
+
+def _hook_schema_state(settings: dict) -> CozempicHookSchemaState:
+    commands = [
+        command for command in _iter_hook_commands(settings)
+        if _is_cozempic_command(command)
+    ]
+    return CozempicHookSchemaState(
+        found=bool(commands),
+        current=all(_is_current_cozempic_command(command) for command in commands),
+    )
+
+
+def cozempic_hook_schema_state(settings_path: Path) -> CozempicHookSchemaState:
+    """Return managed-hook state for ``settings_path`` without masking errors."""
+    try:
+        settings = _load_settings(settings_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return CozempicHookSchemaState(
+            found=False,
+            current=False,
+            error=f"could not parse {settings_path}: {exc}",
+        )
+    return _hook_schema_state(settings)
+
+
+def cozempic_hook_schema_state_for_paths(
+    settings_paths: tuple[Path, ...],
+) -> CozempicHookSchemaState:
+    """Return combined state for settings files that jointly affect a project."""
+    found = False
+    current = True
+    for settings_path in settings_paths:
+        state = cozempic_hook_schema_state(settings_path)
+        if state.error:
+            return state
+        found = found or state.found
+        current = current and state.current
+    return CozempicHookSchemaState(found=found, current=current)
 
 
 def has_current_schema(settings: dict) -> bool:
@@ -669,8 +706,7 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
 
 
 def _settings_has_cozempic_hooks(path: Path) -> bool:
-    found, _ = cozempic_hook_schema_state(path)
-    return found
+    return cozempic_hook_schema_state(path).found
 
 
 def run_uninstall(scope: str = "global", purge: bool = False) -> dict:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -529,8 +529,10 @@ def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
                 if "hooks" in entry:
                     hooks_list = [hook for hook in entry["hooks"] if isinstance(hook, dict)]
                     if len(hooks_list) != len(entry["hooks"]):
-                        entry = {**entry, "hooks": hooks_list}
                         repaired = True
+                        if not hooks_list:
+                            continue
+                        entry = {**entry, "hooks": hooks_list}
                 valid_existing.append(entry)
             existing = valid_existing
 
@@ -794,10 +796,6 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     return {"hooks_in": hook_targets, "slash_command": slash_present,
             "remind_counter": _REMIND_COUNTER.exists(), "purge_data": data,
             "errors": errors}
-
-
-def _settings_has_cozempic_hooks(path: Path) -> bool:
-    return cozempic_hook_schema_state(path).found
 
 
 def run_uninstall(scope: str = "global", purge: bool = False) -> dict:

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -405,7 +405,8 @@ def _resolve_cozempic_python() -> tuple[str, bool]:
     # Degrade to a real `python3` if sys.executable is empty (exotic frozen
     # interpreters) so the baked fallback is never an empty command.
     exe = sys.executable or shutil.which("python3") or "python3"
-    ephemeral = any(m in exe for m in (
+    normalized_exe = exe.replace("\\", "/")
+    ephemeral = any(m in normalized_exe for m in (
         "/.cache/uv/", "/cache/uv/", "/environments-v", "/uv-run", "/tmp/", "/var/folders/",
     ))
     return exe, ephemeral
@@ -435,8 +436,8 @@ def _bake_cozempic_path(hooks: dict, abs_python: str) -> dict:
     return out
 
 
-def wire_hooks(project_dir: str) -> dict:
-    """Add cozempic checkpoint hooks to .claude/settings.json.
+def wire_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
+    """Add cozempic checkpoint hooks to a project's settings.json.
 
     Idempotent within a schema version. Detects STALE cozempic hooks
     (installed by an older cozempic whose schema marker is absent/old) and
@@ -449,7 +450,7 @@ def wire_hooks(project_dir: str) -> dict:
       skipped  — list of hook events already at current schema
       settings_path, backup_path
     """
-    path = _settings_path(project_dir)
+    path = settings_path or _settings_path(project_dir)
 
     if not COZEMPIC_HOOKS:
         return {
@@ -610,12 +611,18 @@ def install_slash_command(project_dir: str) -> dict:
     return {"installed": True, "path": str(target), "already_existed": already_existed, "updated": already_existed}
 
 
-def run_init(project_dir: str, skip_slash: bool = False) -> dict:
+def run_init(
+    project_dir: str,
+    skip_slash: bool = False,
+    settings_path: Path | None = None,
+) -> dict:
     """Full init: wire hooks + install slash command.
+
+    ``settings_path`` lets global init target Claude's configured profile.
 
     Returns combined result dict.
     """
-    hook_result = wire_hooks(project_dir)
+    hook_result = wire_hooks(project_dir, settings_path=settings_path)
     slash_result = {"installed": False, "path": None, "already_existed": False}
 
     if not skip_slash:
@@ -639,6 +646,11 @@ _REMIND_COUNTER = Path.home() / ".cozempic_remind_counter"
 def _global_slash_path() -> Path:
     from .session import get_claude_dir
     return get_claude_dir() / "commands" / "cozempic.md"
+
+
+def _global_settings_path() -> Path:
+    from .session import get_claude_dir
+    return get_claude_dir() / "settings.json"
 
 
 def _slash_is_ours(content: str) -> bool:
@@ -682,12 +694,18 @@ def uninstall_slash_command() -> dict:
 
 def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
     """Read-only: report what `run_uninstall(scope, purge)` WOULD remove. No writes."""
-    scopes = {"global": [str(Path.home())], "project": ["."],
-              "all": [str(Path.home()), "."]}.get(scope, [str(Path.home())])
+    scopes = {
+        "global": [_global_settings_path()],
+        "project": [_settings_path(".")],
+        "all": [_global_settings_path(), _settings_path(".")],
+    }.get(scope, [_global_settings_path()])
     hook_targets = []
-    for d in scopes:
-        p = _settings_path(d)
-        if p.exists() and _settings_has_cozempic_hooks(p):
+    errors = []
+    for p in scopes:
+        state = cozempic_hook_schema_state(p)
+        if state.error:
+            errors.append(state.error)
+        elif state.found:
             hook_targets.append(str(p))
     slash = _global_slash_path()
     slash_present = False
@@ -702,7 +720,8 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
             if p.exists():
                 data.append(str(p))
     return {"hooks_in": hook_targets, "slash_command": slash_present,
-            "remind_counter": _REMIND_COUNTER.exists(), "purge_data": data}
+            "remind_counter": _REMIND_COUNTER.exists(), "purge_data": data,
+            "errors": errors}
 
 
 def _settings_has_cozempic_hooks(path: Path) -> bool:
@@ -717,13 +736,20 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     leaves the global-init marker in place as the auto-init opt-out, so init does
     not silently re-wire on the next run (explicit `cozempic init` still works).
     """
-    dirs = {"global": [str(Path.home())], "project": ["."],
-            "all": [str(Path.home()), "."]}.get(scope, [str(Path.home())])
+    targets = {
+        "global": [(str(Path.home()), _global_settings_path())],
+        "project": [(".", None)],
+        "all": [(str(Path.home()), _global_settings_path()), (".", None)],
+    }.get(scope, [(str(Path.home()), _global_settings_path())])
     result: dict = {"scope": scope, "hooks": [], "slash_command": None,
-                    "remind_counter_removed": False, "purged": [], "opt_out_set": False}
+                    "remind_counter_removed": False, "purged": [], "opt_out_set": False,
+                    "errors": []}
 
-    for d in dirs:
-        result["hooks"].append(uninstall_hooks(d))
+    for directory, settings_path in targets:
+        hook_result = uninstall_hooks(directory, settings_path=settings_path)
+        result["hooks"].append(hook_result)
+        if hook_result.get("error"):
+            result["errors"].append(hook_result["error"])
 
     if scope in ("global", "all"):
         result["slash_command"] = uninstall_slash_command()
@@ -757,7 +783,7 @@ def run_uninstall(scope: str = "global", purge: bool = False) -> dict:
     return result
 
 
-def uninstall_hooks(project_dir: str) -> dict:
+def uninstall_hooks(project_dir: str, settings_path: Path | None = None) -> dict:
     """Remove cozempic-installed hooks from a settings.json. Idempotent.
 
     Surgical — removes only cozempic commands, preserving any user-authored
@@ -766,7 +792,7 @@ def uninstall_hooks(project_dir: str) -> dict:
 
     Returns: {removed: list[str], settings_path: str | None, backup_path: str | None}
     """
-    path = _settings_path(project_dir)
+    path = settings_path or _settings_path(project_dir)
     if not path.exists():
         return {"removed": [], "settings_path": None, "backup_path": None}
 

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -819,7 +819,7 @@ def preview_uninstall(scope: str = "global", purge: bool = False) -> dict:
             errors.append(f"Could not read slash command: {exc}")
             slash_present = False
     data = []
-    if purge:
+    if purge and scope in ("global", "all"):
         for p in (Path.home() / ".cozempic", Path.home() / ".cozempic_savings.json"):
             if p.exists():
                 data.append(str(p))

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -178,6 +178,27 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                         cli._maybe_auto_init(["list"])
                         ri.assert_called_once()
 
+    def test_refreshes_stale_project_hooks_despite_uninstall_marker(self):
+        """A stale installation establishes consent even if marker cleanup failed."""
+        from cozempic import cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            (home / ".claude").mkdir(parents=True)
+            project = self._make_project(tmp)
+            self._write_stale_hooks(project / ".claude")
+            (project / ".claude" / ".cozempic_uninstalled").touch()
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(
+                        cli,
+                        "run_init",
+                        return_value={"hooks": {"added": [], "updated": ["SessionStart[]"]}},
+                    ) as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_called_once()
+
     def test_warns_when_global_current_and_local_hooks_present(self):
         """Global hooks current + local hooks exist -> warn to stderr."""
         from cozempic import cli

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -1,6 +1,5 @@
 """Tests for _maybe_auto_init() skipping local init when global hooks are current."""
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -16,10 +15,10 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
         (project / ".claude").mkdir(parents=True)
         return project
 
-    def _write_current_hooks(self, claude_dir):
+    def _write_current_hooks(self, claude_dir, filename="settings.json"):
         """Write a settings.json with current-schema cozempic hooks."""
         from cozempic.init import HOOK_SCHEMA_MARKER
-        settings = claude_dir / "settings.json"
+        settings = claude_dir / filename
         settings.write_text(json.dumps({
             "hooks": {
                 "SessionStart": [{
@@ -80,6 +79,21 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                     with mock.patch.object(cli, "run_init", return_value={"hooks": {"added": ["SessionStart[]"], "updated": []}}) as ri:
                         cli._maybe_auto_init(["list"])
                         ri.assert_called_once()
+
+    def test_skips_when_project_local_hooks_current(self):
+        """A current local hook must not be duplicated into settings.json."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            (home / ".claude").mkdir(parents=True)
+            project = self._make_project(tmp)
+            self._write_current_hooks(project / ".claude", "settings.local.json")
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init") as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_not_called()
 
     def test_fires_when_global_hooks_stale(self):
         """Global hooks stale (old schema) -> local auto-init should fire."""

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -272,6 +272,21 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                         cli._maybe_auto_init(["list"])
                         run_init.assert_not_called()
 
+    def test_skips_when_project_settings_are_valid_non_object_json(self):
+        """A scalar settings.local.json must not crash or be overwritten."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            (home / ".claude").mkdir(parents=True)
+            project = self._make_project(tmp)
+            (project / ".claude" / "settings.local.json").write_text("[]")
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init") as run_init:
+                        cli._maybe_auto_init(["list"])
+                        run_init.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -31,9 +31,9 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
             }
         }))
 
-    def _write_stale_hooks(self, claude_dir):
+    def _write_stale_hooks(self, claude_dir, filename="settings.json"):
         """Write a settings.json with stale (pre-schema) cozempic hooks."""
-        settings = claude_dir / "settings.json"
+        settings = claude_dir / filename
         settings.write_text(json.dumps({
             "hooks": {
                 "SessionStart": [{
@@ -62,6 +62,61 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                     with mock.patch.object(cli, "run_init") as ri:
                         cli._maybe_auto_init(["list"])
                         ri.assert_not_called()
+
+    def test_skips_when_managed_global_hooks_current_despite_stale_local_file(self):
+        """Global settings.local.json must not override managed global hooks."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_current_hooks(home_claude)
+            self._write_stale_hooks(home_claude, "settings.local.json")
+            project = self._make_project(tmp)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init") as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_not_called()
+
+    def test_skips_when_managed_global_hooks_current_despite_malformed_local_file(self):
+        """Unreadable unmanaged global-local state must not trigger local hooks."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            self._write_current_hooks(home_claude)
+            (home_claude / "settings.local.json").write_text("{broken json")
+            project = self._make_project(tmp)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init") as ri:
+                        cli._maybe_auto_init(["list"])
+                        ri.assert_not_called()
+
+    def test_skips_local_init_when_managed_global_settings_are_malformed(self):
+        """Do not install local hooks while managed global settings need repair."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home_claude = home / ".claude"
+            home_claude.mkdir(parents=True)
+            (home_claude / "settings.json").write_text("{broken json")
+            project = self._make_project(tmp)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch("sys.stderr") as mock_stderr:
+                        with mock.patch.object(cli, "run_init") as ri:
+                            cli._maybe_auto_init(["list"])
+                            ri.assert_not_called()
+            output = "".join(
+                call.args[0] for call in mock_stderr.write.call_args_list if call.args
+            )
+            self.assertIn("auto-init skipped", output)
 
     def test_fires_when_global_hooks_absent(self):
         """No global hooks -> local auto-init should fire."""

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -9,6 +9,16 @@ from unittest import mock
 class TestAutoInitGlobalSkip(unittest.TestCase):
     """_maybe_auto_init() must skip local init when global hooks are current."""
 
+    def setUp(self):
+        self._config_patch = mock.patch(
+            "cozempic.session.get_claude_dir",
+            side_effect=lambda: Path.home() / ".claude",
+        )
+        self._config_patch.start()
+
+    def tearDown(self):
+        self._config_patch.stop()
+
     def _make_project(self, tmpdir):
         """Create a fake project with .claude/ dir under tmpdir."""
         project = Path(tmpdir) / "myproject"
@@ -234,14 +244,33 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
             # cwd IS the home dir -- home_claude == claude_dir
             with mock.patch.object(cli.Path, "home", return_value=home):
                 with mock.patch.object(cli.Path, "cwd", return_value=home):
-                    # Return False so the local check falls through to run_init.
+                    # Return an empty local state so the local check falls through to run_init.
                     # If the guard were missing, the global-skip branch would fire
                     # (real hooks ARE current) and return early -- run_init would
                     # never be called. So run_init being called proves the guard works.
-                    with mock.patch.object(cli, "_project_is_cozempic_current", return_value=False):
+                    with mock.patch.object(
+                        cli,
+                        "_project_cozempic_hook_state",
+                        return_value=mock.Mock(found=False, current=False, error=None),
+                    ):
                         with mock.patch.object(cli, "run_init", return_value={"hooks": {"added": ["SessionStart[]"], "updated": []}}) as ri:
                             cli._maybe_auto_init(["list"])
                             ri.assert_called_once()
+
+    def test_skips_when_project_settings_are_malformed(self):
+        """A broken local settings file must not be overwritten by auto-init."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            (home / ".claude").mkdir(parents=True)
+            project = self._make_project(tmp)
+            (project / ".claude" / "settings.local.json").write_text("{broken json")
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli.Path, "cwd", return_value=project):
+                    with mock.patch.object(cli, "run_init") as run_init:
+                        cli._maybe_auto_init(["list"])
+                        run_init.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -1,4 +1,5 @@
 """Tests for _maybe_auto_init() skipping local init when global hooks are current."""
+import io
 import json
 import tempfile
 import unittest
@@ -286,6 +287,24 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                     with mock.patch.object(cli, "run_init") as run_init:
                         cli._maybe_auto_init(["list"])
                         run_init.assert_not_called()
+
+    def test_reports_local_cleanup_error_after_auto_init(self):
+        """A cleanup failure must not hide behind a successful main settings write."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            project = self._make_project(tmp)
+            stderr = io.StringIO()
+            result = {
+                "hooks": {"added": [], "updated": [], "repaired": False},
+                "local_cleanup": {"error": "could not parse settings.local.json"},
+            }
+            with mock.patch.object(cli.Path, "cwd", return_value=project), \
+                    mock.patch.object(cli, "_global_claude_dir", return_value=project / ".claude"), \
+                    mock.patch.object(cli, "_project_cozempic_hook_state", return_value=mock.Mock(found=False, current=False, error=None)), \
+                    mock.patch.object(cli, "run_init", return_value=result), \
+                    mock.patch.object(cli.sys, "stderr", stderr):
+                cli._maybe_auto_init(["list"])
+            self.assertIn("local settings cleanup FAILED", stderr.getvalue())
 
     def test_global_uninstall_opt_out_blocks_project_auto_init(self):
         from cozempic import cli

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -287,6 +287,19 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                         cli._maybe_auto_init(["list"])
                         run_init.assert_not_called()
 
+    def test_global_uninstall_opt_out_blocks_project_auto_init(self):
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            project = self._make_project(tmp)
+            marker = Path(tmp) / "global-uninstalled"
+            marker.touch()
+            with mock.patch.object(cli.Path, "cwd", return_value=project), \
+                    mock.patch.object(cli, "_global_init_marker", return_value=marker), \
+                    mock.patch.object(cli, "_managed_cozempic_hook_state", return_value=mock.Mock(found=False, current=False, error=None)), \
+                    mock.patch.object(cli, "run_init") as run_init:
+                cli._maybe_auto_init(["list"])
+            run_init.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_auto_init_global_skip.py
+++ b/tests/test_auto_init_global_skip.py
@@ -295,7 +295,10 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
             project = self._make_project(tmp)
             stderr = io.StringIO()
             result = {
-                "hooks": {"added": [], "updated": [], "repaired": False},
+                "hooks": {
+                    "added": [], "updated": [], "repaired": False,
+                    "warnings": ["Could not clear project uninstall marker: permission denied"],
+                },
                 "local_cleanup": {"error": "could not parse settings.local.json"},
             }
             with mock.patch.object(cli.Path, "cwd", return_value=project), \
@@ -305,6 +308,7 @@ class TestAutoInitGlobalSkip(unittest.TestCase):
                     mock.patch.object(cli.sys, "stderr", stderr):
                 cli._maybe_auto_init(["list"])
             self.assertIn("local settings cleanup FAILED", stderr.getvalue())
+            self.assertIn("Could not clear project uninstall marker", stderr.getvalue())
 
     def test_global_uninstall_opt_out_blocks_project_auto_init(self):
         from cozempic import cli

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -55,6 +55,15 @@ class TestCozempicSettingsShape(unittest.TestCase):
         self.assertEqual(result.status, "warning")
         self.assertIn("SessionStart", result.message)
 
+    def test_project_non_object_hooks_is_actionable_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / ".claude").mkdir()
+            (project / ".claude" / "settings.json").write_text('{"hooks": "broken"}')
+            with patch("cozempic.doctor.Path.cwd", return_value=project):
+                result = check_cozempic_project_init()
+        self.assertEqual(result.status, "warning")
+
 
 class TestClaudeJsonCorruption(unittest.TestCase):
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -12,6 +12,8 @@ from unittest.mock import patch
 from cozempic.doctor import (
     check_agent_model_mismatch,
     check_claude_json_corruption,
+    check_cozempic_hooks,
+    check_cozempic_project_init,
     check_corrupted_tool_use,
     check_hooks_trust_flag,
     check_orphaned_tool_results,
@@ -22,6 +24,27 @@ from cozempic.doctor import (
     fix_hooks_trust_flag,
     fix_stale_tmp_artifacts,
 )
+
+
+class TestCozempicSettingsShape(unittest.TestCase):
+    def test_global_scalar_settings_is_actionable_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp)
+            (config / "settings.json").write_text("null")
+            with patch("cozempic.doctor.get_claude_dir", return_value=config):
+                result = check_cozempic_hooks()
+        self.assertEqual(result.status, "warning")
+        self.assertIn("JSON object", result.message)
+
+    def test_project_scalar_settings_is_actionable_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / ".claude").mkdir()
+            (project / ".claude" / "settings.json").write_text("[]")
+            with patch("cozempic.doctor.Path.cwd", return_value=project):
+                result = check_cozempic_project_init()
+        self.assertEqual(result.status, "warning")
+        self.assertIn("JSON object", result.message)
 
 
 class TestClaudeJsonCorruption(unittest.TestCase):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -46,6 +46,15 @@ class TestCozempicSettingsShape(unittest.TestCase):
         self.assertEqual(result.status, "warning")
         self.assertIn("JSON object", result.message)
 
+    def test_malformed_nested_hooks_are_actionable_warnings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp)
+            (config / "settings.json").write_text('{"hooks": {"SessionStart": [{"hooks": null}]}}')
+            with patch("cozempic.doctor.get_claude_dir", return_value=config):
+                result = check_cozempic_hooks()
+        self.assertEqual(result.status, "warning")
+        self.assertIn("SessionStart", result.message)
+
 
 class TestClaudeJsonCorruption(unittest.TestCase):
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -46,6 +46,32 @@ class TestCozempicSettingsShape(unittest.TestCase):
         self.assertEqual(result.status, "warning")
         self.assertIn("JSON object", result.message)
 
+    def test_project_malformed_settings_is_actionable_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / ".claude").mkdir()
+            (project / ".claude" / "settings.json").write_text("{broken json")
+            with patch("cozempic.doctor.Path.cwd", return_value=project):
+                result = check_cozempic_project_init()
+        self.assertEqual(result.status, "warning")
+        self.assertIn("could not parse", result.message)
+
+    def test_global_local_settings_contribute_expected_hooks(self):
+        from cozempic.init import HOOK_SCHEMA_MARKER
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp)
+            expected = ("SessionStart", "PreCompact", "PostCompact", "Stop")
+            (config / "settings.local.json").write_text(json.dumps({
+                "hooks": {
+                    event: [{"hooks": [{"command": f"cozempic guard # {HOOK_SCHEMA_MARKER}"}]}]
+                    for event in expected
+                }
+            }))
+            with patch("cozempic.doctor.get_claude_dir", return_value=config):
+                result = check_cozempic_hooks()
+        self.assertEqual(result.status, "ok")
+
     def test_malformed_nested_hooks_are_actionable_warnings(self):
         with tempfile.TemporaryDirectory() as tmp:
             config = Path(tmp)

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -133,6 +133,54 @@ class TestGlobalAutoInit(unittest.TestCase):
             run_init.assert_not_called()
             self.assertFalse((home_claude / "settings.json").exists())
 
+    def test_marker_with_malformed_global_settings_surfaces_error(self):
+        """A marker must not turn unreadable managed settings into a decline."""
+        from cozempic import cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            home_claude = self._stub_home_claude(tmp)
+            (home_claude / "settings.json").write_text("{broken json")
+            marker = self._stub_marker(tmp)
+            marker.touch()
+
+            with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
+                with mock.patch.object(cli.Path, "home", return_value=home):
+                    with mock.patch("sys.stderr") as mock_stderr:
+                        with mock.patch.object(cli, "run_init") as run_init:
+                            cli._maybe_global_init(["list"])
+
+            run_init.assert_not_called()
+            output = "".join(
+                call.args[0] for call in mock_stderr.write.call_args_list if call.args
+            )
+            self.assertIn("global init FAILED", output)
+            self.assertIn("could not parse", output)
+
+    def test_stale_global_hook_establishes_consent_without_prompt(self):
+        """Pre-marker hooks must refresh without a second consent prompt."""
+        from cozempic import cli
+        from cozempic.init import HOOK_SCHEMA_MARKER
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            home_claude = self._stub_home_claude(tmp)
+            self._write_stale_global_hook(home_claude)
+            marker = self._stub_marker(tmp)
+
+            with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
+                with mock.patch.object(cli.Path, "home", return_value=home):
+                    with mock.patch.object(cli.sys.stdin, "isatty", return_value=True):
+                        with mock.patch.object(cli.sys.stderr, "isatty", return_value=True):
+                            with mock.patch("builtins.input") as prompt:
+                                cli._maybe_global_init(["list"])
+
+            prompt.assert_not_called()
+            command = json.loads(
+                (home_claude / "settings.json").read_text()
+            )["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            self.assertIn(HOOK_SCHEMA_MARKER, command)
+
     def test_current_global_hook_ignores_stale_local_hook(self):
         """An unmanaged local stale hook cannot make global wiring stale."""
         from cozempic import cli

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -334,6 +334,40 @@ class TestGlobalAutoInit(unittest.TestCase):
             self.assertTrue((profile / "settings.json").exists())
             self.assertFalse((home / ".claude" / "settings.json").exists())
 
+    def test_decline_in_one_profile_does_not_suppress_another(self):
+        """Each CLAUDE_CONFIG_DIR profile owns its global-init decision."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            first = Path(tmp) / "first"
+            second = Path(tmp) / "second"
+            first.mkdir()
+            second.mkdir()
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch("cozempic.session.get_claude_dir", return_value=first):
+                    with mock.patch.object(cli.sys.stdin, "isatty", return_value=True):
+                        with mock.patch.object(cli.sys.stderr, "isatty", return_value=True):
+                            with mock.patch("builtins.input", return_value="n"):
+                                cli._maybe_global_init(["list"])
+                with mock.patch("cozempic.session.get_claude_dir", return_value=second):
+                    with mock.patch.object(cli.sys.stdin, "isatty", return_value=False):
+                        cli._maybe_global_init(["list"])
+            self.assertTrue((first / ".cozempic_global_initialized").exists())
+            self.assertTrue((second / "settings.json").exists())
+
+    def test_valid_non_object_global_settings_reports_error(self):
+        """A valid JSON scalar must not crash global auto-init."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            profile = Path(tmp) / "profile"
+            profile.mkdir()
+            (profile / "settings.json").write_text("null")
+            with mock.patch("cozempic.session.get_claude_dir", return_value=profile):
+                with mock.patch("sys.stderr") as stderr:
+                    cli._maybe_global_init(["list"])
+            output = "".join(call.args[0] for call in stderr.write.call_args_list if call.args)
+            self.assertIn("settings.json must be a JSON object", output)
+
 
 class TestUninstallHooks(unittest.TestCase):
     def test_removes_cozempic_hooks_only(self):

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -769,7 +769,7 @@ class TestGlobalInitFailure(unittest.TestCase):
                         "cozempic.session.get_claude_dir", return_value=profile
                     ):
                         output = io.StringIO()
-                        with mock.patch.object(cli.sys, "stdout", output):
+                        with self.assertRaises(SystemExit), mock.patch.object(cli.sys, "stdout", output):
                             cli.cmd_init(args)
             self.assertFalse(marker.exists())
             self.assertIn("Setup incomplete", output.getvalue())
@@ -788,7 +788,7 @@ class TestGlobalInitFailure(unittest.TestCase):
         args = argparse.Namespace(uninstall_global=False, global_install=False, cwd=None,
                                   no_slash_command=True)
         output = io.StringIO()
-        with mock.patch.object(cli, "run_init", return_value=result), mock.patch.object(cli.sys, "stdout", output):
+        with self.assertRaises(SystemExit), mock.patch.object(cli, "run_init", return_value=result), mock.patch.object(cli.sys, "stdout", output):
             cli.cmd_init(args)
         self.assertIn("Setup incomplete", output.getvalue())
         self.assertNotIn("Setup complete", output.getvalue())

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -8,6 +8,18 @@ from unittest import mock
 
 
 class TestGlobalAutoInit(unittest.TestCase):
+    def setUp(self):
+        # These legacy tests model the default profile; dedicated tests below
+        # cover CLAUDE_CONFIG_DIR explicitly.
+        self._config_patch = mock.patch(
+            "cozempic.session.get_claude_dir",
+            side_effect=lambda: Path.home() / ".claude",
+        )
+        self._config_patch.start()
+
+    def tearDown(self):
+        self._config_patch.stop()
+
     def _stub_marker(self, tmpdir):
         return Path(tmpdir) / ".cozempic_global_initialized"
 
@@ -303,6 +315,24 @@ class TestGlobalAutoInit(unittest.TestCase):
                             cli._maybe_global_init([help_flag])
                     self.assertFalse((Path(tmp) / ".claude" / "settings.json").exists())
                     self.assertFalse(marker.exists())
+
+    def test_global_init_honors_config_dir(self):
+        """Global hooks belong to Claude's configured profile, not ~/.claude."""
+        from cozempic import cli
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            profile = Path(tmp) / "profile"
+            profile.mkdir()
+            marker = self._stub_marker(tmp)
+            with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
+                with mock.patch.object(cli.Path, "home", return_value=home):
+                    with mock.patch(
+                        "cozempic.session.get_claude_dir", return_value=profile
+                    ):
+                        with mock.patch.object(cli.sys.stdin, "isatty", return_value=False):
+                            cli._maybe_global_init(["list"])
+            self.assertTrue((profile / "settings.json").exists())
+            self.assertFalse((home / ".claude" / "settings.json").exists())
 
 
 class TestUninstallHooks(unittest.TestCase):
@@ -636,6 +666,30 @@ class TestGlobalInitFailure(unittest.TestCase):
                                 cli._maybe_global_init(["list"])
             self.assertFalse(marker.exists(), "failure must not become an opt-out")
             self.assertEqual(run_init.call_count, 2)
+
+    def test_explicit_global_init_error_does_not_mark_declined(self):
+        from cozempic import cli
+        import argparse
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            profile = Path(tmp) / "profile"
+            profile.mkdir()
+            marker = Path(tmp) / ".cozempic_global_initialized"
+            (profile / "settings.json").write_text("{broken json")
+            args = argparse.Namespace(
+                uninstall_global=False,
+                global_install=True,
+                cwd=None,
+                no_slash_command=True,
+            )
+            with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
+                with mock.patch.object(cli.Path, "home", return_value=home):
+                    with mock.patch(
+                        "cozempic.session.get_claude_dir", return_value=profile
+                    ):
+                        cli.cmd_init(args)
+            self.assertFalse(marker.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -115,6 +115,23 @@ class TestGlobalAutoInit(unittest.TestCase):
             run_init.assert_not_called()
             self.assertTrue((claude_dir / ".cozempic_global_initialized").exists())
 
+    def test_legacy_marker_still_blocks_init_when_migration_fails(self):
+        from cozempic import cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            legacy_marker = home / ".cozempic_global_initialized"
+            legacy_marker.touch()
+            with mock.patch.dict(os.environ, {}, clear=True), \
+                    mock.patch("cozempic.init.Path.home", return_value=home), \
+                    mock.patch("cozempic.session.get_claude_dir", return_value=claude_dir), \
+                    mock.patch.object(Path, "touch", side_effect=OSError("read-only")), \
+                    mock.patch.object(cli, "run_init") as run_init:
+                cli._maybe_global_init(["list"])
+            run_init.assert_not_called()
+
     def test_refreshes_stale_hooks_when_marker_exists(self):
         """A prior global install must refresh after the package schema changes."""
         from cozempic import cli

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -652,6 +652,18 @@ class TestPIDReuseCheck(unittest.TestCase):
 
 
 class TestAtomicWrite(unittest.TestCase):
+    def test_wire_hooks_reports_write_failure(self):
+        from cozempic.init import wire_hooks
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir()
+            path.write_text("{}")
+            with mock.patch("cozempic.init._save_settings", side_effect=OSError("disk full")):
+                result = wire_hooks(tmp, settings_path=path)
+
+        self.assertEqual(result["error"], f"could not write {path}: disk full")
+
     def test_save_settings_is_atomic_on_json_error(self):
         """If json serialization raises mid-write, the existing settings.json
         must remain intact (atomic write via tempfile + os.replace)."""

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -30,6 +30,36 @@ class TestGlobalAutoInit(unittest.TestCase):
             },
         }))
 
+    def _write_current_global_hook(self, claude_dir):
+        from cozempic.init import HOOK_SCHEMA_MARKER
+
+        settings = claude_dir / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": f"cozempic guard --daemon # {HOOK_SCHEMA_MARKER}",
+                    }],
+                }],
+            },
+        }))
+
+    def _write_stale_local_hook(self, claude_dir):
+        settings = claude_dir / "settings.local.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "cozempic guard --daemon # cozempic-hook-schema=v10",
+                    }],
+                }],
+            },
+        }))
+
     def test_skipped_when_env_set(self):
         from cozempic import cli
         with tempfile.TemporaryDirectory() as tmp:
@@ -81,6 +111,43 @@ class TestGlobalAutoInit(unittest.TestCase):
             settings = json.loads((home_claude / "settings.json").read_text())
             command = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
             self.assertIn(HOOK_SCHEMA_MARKER, command)
+
+    def test_marker_does_not_rewire_for_stale_local_hook(self):
+        """Global init must ignore settings.local.json it does not manage."""
+        from cozempic import cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            home_claude = self._stub_home_claude(tmp)
+            self._write_stale_local_hook(home_claude)
+            marker = self._stub_marker(tmp)
+            marker.touch()
+
+            with mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("COZEMPIC_NO_GLOBAL_INIT", None)
+                with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
+                    with mock.patch.object(cli.Path, "home", return_value=home):
+                        with mock.patch.object(cli, "run_init") as run_init:
+                            cli._maybe_global_init(["list"])
+
+            run_init.assert_not_called()
+            self.assertFalse((home_claude / "settings.json").exists())
+
+    def test_current_global_hook_ignores_stale_local_hook(self):
+        """An unmanaged local stale hook cannot make global wiring stale."""
+        from cozempic import cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            home_claude = self._stub_home_claude(tmp)
+            self._write_current_global_hook(home_claude)
+            self._write_stale_local_hook(home_claude)
+
+            with mock.patch.object(cli.Path, "home", return_value=home):
+                with mock.patch.object(cli, "run_init") as run_init:
+                    cli._maybe_global_init(["list"])
+
+            run_init.assert_not_called()
 
     def test_skipped_when_no_claude_dir(self):
         from cozempic import cli
@@ -359,6 +426,53 @@ class TestStaleHookRefresh(unittest.TestCase):
             self.assertEqual(cmds[0], "export MY_SETUP=1")
             # Last cmd is the second user cmd (still at end)
             self.assertEqual(cmds[-1], "echo 'session started' >> /tmp/user.log")
+
+    def test_duplicate_matcher_entries_are_consolidated(self):
+        """A stale duplicate cannot survive beside a current canonical hook."""
+        from cozempic.init import HOOK_SCHEMA_MARKER, _is_cozempic_command, wire_hooks
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            settings_path = Path(tmp) / ".claude" / "settings.json"
+            settings_path.write_text(json.dumps({
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "",
+                            "hooks": [{
+                                "type": "command",
+                                "command": f"cozempic guard --daemon # {HOOK_SCHEMA_MARKER}",
+                            }],
+                        },
+                        {
+                            "matcher": "",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "cozempic guard --daemon # cozempic-hook-schema=v10",
+                                },
+                                {"type": "command", "command": "echo keep-me"},
+                            ],
+                        },
+                    ],
+                },
+            }))
+
+            result = wire_hooks(tmp)
+            after = json.loads(settings_path.read_text())
+            commands = [
+                hook["command"]
+                for entry in after["hooks"]["SessionStart"]
+                for hook in entry["hooks"]
+            ]
+            cozempic_commands = [
+                command for command in commands if _is_cozempic_command(command)
+            ]
+
+            self.assertIn("SessionStart[]", result["updated"])
+            self.assertEqual(len(cozempic_commands), 1)
+            self.assertIn(HOOK_SCHEMA_MARKER, cozempic_commands[0])
+            self.assertIn("echo keep-me", commands)
 
     def test_current_schema_hook_is_skipped(self):
         """wire_hooks on an already-current settings.json must not touch it."""

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -1,4 +1,5 @@
 """Tests for global auto-init + uninstall + opt-out paths."""
+import io
 import json
 import os
 import tempfile
@@ -722,8 +723,11 @@ class TestGlobalInitFailure(unittest.TestCase):
                     with mock.patch(
                         "cozempic.session.get_claude_dir", return_value=profile
                     ):
-                        cli.cmd_init(args)
+                        output = io.StringIO()
+                        with mock.patch.object(cli.sys, "stdout", output):
+                            cli.cmd_init(args)
             self.assertFalse(marker.exists())
+            self.assertIn("Setup incomplete", output.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -99,6 +99,22 @@ class TestGlobalAutoInit(unittest.TestCase):
                             cli._maybe_global_init(["list"])
                             ri.assert_not_called()
 
+    def test_legacy_default_marker_migrates_without_reinstalling(self):
+        from cozempic import cli
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True)
+            (home / ".cozempic_global_initialized").touch()
+            with mock.patch.dict(os.environ, {}, clear=True), \
+                    mock.patch("cozempic.init.Path.home", return_value=home), \
+                    mock.patch("cozempic.session.get_claude_dir", return_value=claude_dir), \
+                    mock.patch.object(cli, "run_init") as run_init:
+                cli._maybe_global_init(["list"])
+            run_init.assert_not_called()
+            self.assertTrue((claude_dir / ".cozempic_global_initialized").exists())
+
     def test_refreshes_stale_hooks_when_marker_exists(self):
         """A prior global install must refresh after the package schema changes."""
         from cozempic import cli

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -774,6 +774,25 @@ class TestGlobalInitFailure(unittest.TestCase):
             self.assertFalse(marker.exists())
             self.assertIn("Setup incomplete", output.getvalue())
 
+    def test_explicit_init_local_cleanup_error_does_not_report_success(self):
+        from cozempic import cli
+        import argparse
+
+        result = {
+            "hooks": {"added": [], "updated": [], "repaired": False, "skipped": [],
+                      "warnings": [], "backup_path": None, "settings_path": "settings.json"},
+            "local_cleanup": {"error": "could not parse settings.local.json"},
+            "slash_command": {"updated": False, "installed": False, "already_existed": False,
+                              "path": "cozempic.md"},
+        }
+        args = argparse.Namespace(uninstall_global=False, global_install=False, cwd=None,
+                                  no_slash_command=True)
+        output = io.StringIO()
+        with mock.patch.object(cli, "run_init", return_value=result), mock.patch.object(cli.sys, "stdout", output):
+            cli.cmd_init(args)
+        self.assertIn("Setup incomplete", output.getvalue())
+        self.assertNotIn("Setup complete", output.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -16,6 +16,20 @@ class TestGlobalAutoInit(unittest.TestCase):
         d.mkdir(parents=True, exist_ok=True)
         return d
 
+    def _write_stale_global_hook(self, claude_dir):
+        settings = claude_dir / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "cozempic guard --daemon # cozempic-hook-schema=v10",
+                    }],
+                }],
+            },
+        }))
+
     def test_skipped_when_env_set(self):
         from cozempic import cli
         with tempfile.TemporaryDirectory() as tmp:
@@ -41,6 +55,32 @@ class TestGlobalAutoInit(unittest.TestCase):
                         with mock.patch.object(cli, "run_init") as ri:
                             cli._maybe_global_init(["list"])
                             ri.assert_not_called()
+
+    def test_refreshes_stale_hooks_when_marker_exists(self):
+        """A prior global install must refresh after the package schema changes."""
+        from cozempic import cli
+        from cozempic.init import HOOK_SCHEMA_MARKER
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            home_claude = self._stub_home_claude(tmp)
+            self._write_stale_global_hook(home_claude)
+            marker = self._stub_marker(tmp)
+            marker.touch()
+
+            with mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("COZEMPIC_NO_GLOBAL_INIT", None)
+                with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
+                    with mock.patch.object(cli.Path, "home", return_value=home):
+                        with mock.patch.object(cli.sys.stdin, "isatty", return_value=True):
+                            with mock.patch.object(cli.sys.stderr, "isatty", return_value=True):
+                                with mock.patch("builtins.input") as prompt:
+                                    cli._maybe_global_init(["list"])
+
+            prompt.assert_not_called()
+            settings = json.loads((home_claude / "settings.json").read_text())
+            command = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            self.assertIn(HOOK_SCHEMA_MARKER, command)
 
     def test_skipped_when_no_claude_dir(self):
         from cozempic import cli

--- a/tests/test_global_init.py
+++ b/tests/test_global_init.py
@@ -618,10 +618,9 @@ class TestWireHooksGracefulParseFailure(unittest.TestCase):
             self.assertIn("could not parse", result["error"])
 
 
-class TestDoSMarkerOnFailure(unittest.TestCase):
-    def test_marker_touched_on_run_init_failure(self):
-        """If run_init raises, the marker must still be touched to prevent
-        a DoS loop of re-attempts. (Bug 6.1)"""
+class TestGlobalInitFailure(unittest.TestCase):
+    def test_run_init_failure_does_not_become_a_decline(self):
+        """A failed install must retry instead of creating an opt-out marker."""
         from cozempic import cli
         with tempfile.TemporaryDirectory() as tmp:
             # Fake home with .claude dir
@@ -631,9 +630,12 @@ class TestDoSMarkerOnFailure(unittest.TestCase):
             with mock.patch.object(cli, "_GLOBAL_INIT_MARKER", marker):
                 with mock.patch.object(cli.Path, "home", return_value=Path(tmp)):
                     with mock.patch.object(cli.sys.stdin, "isatty", return_value=False):
-                        with mock.patch.object(cli, "run_init", side_effect=OSError("boom")):
-                            cli._maybe_global_init(["list"])
-            self.assertTrue(marker.exists(), "marker must be touched even on failure")
+                        with mock.patch.object(cli.sys.stderr, "isatty", return_value=False):
+                            with mock.patch.object(cli, "run_init", side_effect=OSError("boom")) as run_init:
+                                cli._maybe_global_init(["list"])
+                                cli._maybe_global_init(["list"])
+            self.assertFalse(marker.exists(), "failure must not become an opt-out")
+            self.assertEqual(run_init.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -111,6 +111,19 @@ class TestResolveAndBake(unittest.TestCase):
             self.assertTrue(all(isinstance(entry, dict) for entry in entries))
             self.assertTrue(all(isinstance(entry.get("hooks"), list) for entry in entries))
 
+    def test_wire_hooks_repairs_non_object_hook_elements(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                '{"hooks": {"SessionStart": [{"hooks": ["bad", {"command": "echo ok"}]}]}}'
+            )
+            result = cz.wire_hooks(tmp)
+            self.assertTrue(result["repaired"])
+            settings = json.loads(path.read_text())
+            hooks = settings["hooks"]["SessionStart"][0]["hooks"]
+            self.assertTrue(all(isinstance(hook, dict) for hook in hooks))
+
     def test_hook_state_tolerates_truthy_non_list_containers(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / ".claude" / "settings.json"
@@ -135,6 +148,14 @@ class TestResolveAndBake(unittest.TestCase):
             self.assertNotIn("cozempic", local.read_text())
             settings = json.loads((Path(tmp) / ".claude" / "settings.json").read_text())
             self.assertIn("cozempic", json.dumps(settings))
+
+    def test_init_reports_malformed_local_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / ".claude" / "settings.local.json"
+            local.parent.mkdir(parents=True)
+            local.write_text("{broken json")
+            result = cz.run_init(tmp, skip_slash=True)
+            self.assertIn("error", result["local_cleanup"])
 
 
 class TestWireHooksBakes(unittest.TestCase):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -115,6 +115,14 @@ class TestResolveAndBake(unittest.TestCase):
             path.write_text('{"hooks": {"SessionStart": [{"hooks": 5}]}}')
             self.assertFalse(cz.cozempic_hook_schema_state(path).error)
 
+    def test_hook_commands_tolerate_non_string_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"hooks": {"SessionStart": [{"hooks": [{"command": null}]}]}}')
+            self.assertFalse(cz.wire_hooks(tmp).get("error"))
+            self.assertFalse(cz.uninstall_hooks(tmp).get("error"))
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -88,6 +88,16 @@ class TestResolveAndBake(unittest.TestCase):
             self.assertIn("JSON object", cz.wire_hooks(tmp)["error"])
             self.assertIn("JSON object", cz.uninstall_hooks(tmp)["error"])
 
+    def test_null_hook_containers_are_repaired(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"hooks": {"SessionStart": null}}')
+            result = cz.wire_hooks(tmp)
+            self.assertFalse(result.get("error"))
+            settings = json.loads(path.read_text())
+            self.assertIsInstance(settings["hooks"]["SessionStart"], list)
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -126,6 +126,16 @@ class TestResolveAndBake(unittest.TestCase):
             self.assertFalse(cz.wire_hooks(tmp).get("error"))
             self.assertFalse(cz.uninstall_hooks(tmp).get("error"))
 
+    def test_init_replaces_stale_local_hooks_with_project_hooks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / ".claude" / "settings.local.json"
+            local.parent.mkdir(parents=True)
+            local.write_text('{"hooks": {"SessionStart": [{"hooks": [{"command": "{ cozempic guard; } # cozempic-hook-schema=v1"}]}]}}')
+            cz.run_init(tmp, skip_slash=True)
+            self.assertNotIn("cozempic", local.read_text())
+            settings = json.loads((Path(tmp) / ".claude" / "settings.json").read_text())
+            self.assertIn("cozempic", json.dumps(settings))
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -124,6 +124,16 @@ class TestResolveAndBake(unittest.TestCase):
             hooks = settings["hooks"]["SessionStart"][0]["hooks"]
             self.assertTrue(all(isinstance(hook, dict) for hook in hooks))
 
+    def test_wire_hooks_drops_entries_with_only_invalid_hooks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"hooks": {"SessionStart": [{"hooks": ["bad"]}]}}')
+            cz.wire_hooks(tmp)
+            settings = json.loads(path.read_text())
+            entries = settings["hooks"]["SessionStart"]
+            self.assertTrue(all(entry.get("hooks") for entry in entries))
+
     def test_hook_state_tolerates_truthy_non_list_containers(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / ".claude" / "settings.json"

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -108,6 +108,13 @@ class TestResolveAndBake(unittest.TestCase):
             settings = json.loads(path.read_text())
             self.assertTrue(any(isinstance(entry, dict) for entry in settings["hooks"]["SessionStart"]))
 
+    def test_hook_state_tolerates_truthy_non_list_containers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"hooks": {"SessionStart": [{"hooks": 5}]}}')
+            self.assertFalse(cz.cozempic_hook_schema_state(path).error)
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -79,6 +79,15 @@ class TestResolveAndBake(unittest.TestCase):
                 _, eph = cz._resolve_cozempic_python()
                 self.assertFalse(eph, f"{p} should be persistent")
 
+    def test_settings_scalar_returns_error_not_crash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text("[]")
+            self.assertTrue(cz.cozempic_hook_schema_state(path).error)
+            self.assertIn("JSON object", cz.wire_hooks(tmp)["error"])
+            self.assertIn("JSON object", cz.uninstall_hooks(tmp)["error"])
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -167,6 +167,18 @@ class TestResolveAndBake(unittest.TestCase):
             result = cz.run_init(tmp, skip_slash=True)
             self.assertIn("error", result["local_cleanup"])
 
+    def test_init_keeps_local_hooks_when_primary_write_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            local = Path(tmp) / ".claude" / "settings.local.json"
+            local.parent.mkdir(parents=True)
+            local.write_text('{"hooks": {"SessionStart": []}}')
+            with patch("cozempic.init.wire_hooks", return_value={"error": "primary failed"}), \
+                    patch("cozempic.init.uninstall_hooks") as uninstall_hooks:
+                result = cz.run_init(tmp, skip_slash=True)
+            self.assertEqual(result["hooks"]["error"], "primary failed")
+            self.assertIsNone(result["local_cleanup"])
+            uninstall_hooks.assert_not_called()
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -88,6 +88,15 @@ class TestResolveAndBake(unittest.TestCase):
             self.assertIn("JSON object", cz.wire_hooks(tmp)["error"])
             self.assertIn("JSON object", cz.uninstall_hooks(tmp)["error"])
 
+    def test_wire_hooks_reports_non_dict_top_level_hooks_as_repaired(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"hooks": "broken"}')
+            result = cz.wire_hooks(tmp)
+            self.assertTrue(result["repaired"])
+            self.assertIsInstance(json.loads(path.read_text())["hooks"], dict)
+
     def test_null_hook_containers_are_repaired(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / ".claude" / "settings.json"

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -98,6 +98,16 @@ class TestResolveAndBake(unittest.TestCase):
             settings = json.loads(path.read_text())
             self.assertIsInstance(settings["hooks"]["SessionStart"], list)
 
+    def test_wire_hooks_repairs_malformed_nested_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".claude" / "settings.json"
+            path.parent.mkdir(parents=True)
+            path.write_text('{"hooks": {"SessionStart": [null, {"matcher": "", "hooks": null}]}}')
+            result = cz.wire_hooks(tmp)
+            self.assertFalse(result.get("error"))
+            settings = json.loads(path.read_text())
+            self.assertTrue(any(isinstance(entry, dict) for entry in settings["hooks"]["SessionStart"]))
+
 
 class TestWireHooksBakes(unittest.TestCase):
     def test_wire_hooks_writes_absolute_fallback_and_reports_ephemeral(self):

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -106,7 +106,10 @@ class TestResolveAndBake(unittest.TestCase):
             result = cz.wire_hooks(tmp)
             self.assertFalse(result.get("error"))
             settings = json.loads(path.read_text())
-            self.assertTrue(any(isinstance(entry, dict) for entry in settings["hooks"]["SessionStart"]))
+            entries = settings["hooks"]["SessionStart"]
+            self.assertTrue(entries)
+            self.assertTrue(all(isinstance(entry, dict) for entry in entries))
+            self.assertTrue(all(isinstance(entry.get("hooks"), list) for entry in entries))
 
     def test_hook_state_tolerates_truthy_non_list_containers(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_hook_path_baking.py
+++ b/tests/test_hook_path_baking.py
@@ -54,6 +54,11 @@ class TestResolveAndBake(unittest.TestCase):
                 _, eph = cz._resolve_cozempic_python()
                 self.assertTrue(eph, f"{p} should be ephemeral")
 
+    def test_resolve_flags_windows_uvx_ephemeral(self):
+        with patch("cozempic.init.sys.executable", r"C:\Users\x\.cache\uv\environments-v2\abc\python.exe"):
+            _, ephemeral = cz._resolve_cozempic_python()
+        self.assertTrue(ephemeral)
+
     def test_resolve_degrades_when_sys_executable_empty(self):
         # exotic frozen interpreters can have an empty sys.executable — must NOT
         # return "" (which would bake an empty `'' -m cozempic` no-op command).

--- a/tests/test_nudge.py
+++ b/tests/test_nudge.py
@@ -145,12 +145,20 @@ class TestNudge(unittest.TestCase):
             payload = json.dumps({"transcript_path": str(t), "session_id": "s1"})
             out = io.StringIO()
             import os
-            e = {k: v for k, v in os.environ.items() if not k.startswith("COZEMPIC_NUDGE")}
+            e = {k: v for k, v in os.environ.items()
+                 if not k.startswith("COZEMPIC_NUDGE") and k != "CLAUDE_CONFIG_DIR"}
             with patch("sys.stdin", io.StringIO(payload)), patch("sys.stdout", out), \
                  patch("pathlib.Path.home", return_value=self.home), \
                  patch.dict(os.environ, e, clear=True):
                 cmd_nudge(None)  # must not raise (and should still fire the 55 nudge)
             self.assertIn("56%", out.getvalue(), bad)
+
+    def test_state_file_honors_claude_config_dir(self):
+        profile = self.tmp / "profile"
+        profile.mkdir()
+        self._run(560_000, "profile-state", env={"CLAUDE_CONFIG_DIR": str(profile)})
+        self.assertTrue((profile / "cozempic-metrics" / "nudge-state.json").exists())
+        self.assertFalse((self.home / ".claude" / "cozempic-metrics" / "nudge-state.json").exists())
 
     def test_tiers_from_sidecar(self):
         # The guard records its resolved reload-tier fractions; the nudge fires at

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -341,6 +341,25 @@ class TestPreviewAndDryRun(_Base):
         preview = cz_init.preview_uninstall("global")
         self.assertTrue(preview["errors"])
 
+    def test_uninstall_creates_missing_opt_out_marker_parents(self):
+        self.assertTrue(cz_init.run_uninstall("global")["opt_out_set"])
+        self.assertTrue((self.home / ".cozempic_global_initialized").exists())
+
+        project = self.home / "project"
+        project.mkdir()
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            self.assertTrue(cz_init.run_uninstall("project")["project_opt_out_set"])
+        finally:
+            os.chdir(previous_cwd)
+        self.assertTrue((project / ".claude" / ".cozempic_uninstalled").exists())
+
+    def test_install_slash_command_returns_error_instead_of_raising(self):
+        with patch("cozempic.init.shutil.copy2", side_effect=OSError("disk full")):
+            result = cz_init.install_slash_command(".")
+        self.assertIn("Could not install slash command", result["error"])
+
     def test_uninstall_rejects_unknown_scope(self):
         with self.assertRaisesRegex(ValueError, "Unknown uninstall scope"):
             cz_init.preview_uninstall("typo")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -152,6 +152,13 @@ class TestRunUninstall(_Base):
             result = cz_init.run_uninstall("global", purge=True)
         self.assertIn("Purge failed", result["errors"][0])
 
+    def test_project_scope_purge_keeps_global_data(self):
+        (self.home / ".cozempic").mkdir()
+        (self.home / ".cozempic_savings.json").write_text("{}")
+        cz_init.run_uninstall("project", purge=True)
+        self.assertTrue((self.home / ".cozempic").exists())
+        self.assertTrue((self.home / ".cozempic_savings.json").exists())
+
     def test_cmd_uninstall_prints_non_hook_errors(self):
         from cozempic import cli
 
@@ -260,6 +267,15 @@ class TestPreviewAndDryRun(_Base):
             cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=True, dry_run=False))
         prompt.assert_not_called()
         run_uninstall.assert_called_once_with("global", False)
+
+    def test_project_purge_is_rejected(self):
+        from cozempic import cli
+
+        output = io.StringIO()
+        with patch("sys.stdout", output), patch.object(cz_init, "run_uninstall") as run_uninstall:
+            cli.cmd_uninstall(argparse.Namespace(project=True, all=False, purge=True, dry_run=False))
+        self.assertIn("only applies to global data", output.getvalue())
+        run_uninstall.assert_not_called()
 
     def test_project_preview_does_not_offer_global_remind_counter_removal(self):
         (self.home / ".cozempic_remind_counter").write_text("3")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -242,6 +242,13 @@ class TestRunUninstall(_Base):
         self.assertTrue(res["remind_counter_removed"])
         self.assertFalse((self.home / ".cozempic_remind_counter").exists())
 
+    def test_reports_remind_counter_removal_failure(self):
+        counter = self.home / ".cozempic_remind_counter"
+        counter.write_text("3")
+        with patch.object(Path, "unlink", side_effect=OSError("permission denied")):
+            res = cz_init.run_uninstall("global")
+        self.assertIn("Could not remove remind counter: permission denied", res["errors"])
+
     def test_surfaces_malformed_global_settings(self):
         path = self.home / ".claude" / "settings.json"
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -49,6 +49,12 @@ class _Base(unittest.TestCase):
         p.write_text(json.dumps(settings))
         return p
 
+    def _write_global_local_settings(self, settings):
+        p = self.home / ".claude" / "settings.local.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(settings))
+        return p
+
     def _write_slash(self, content):
         p = self.home / ".claude" / "commands" / "cozempic.md"
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -173,6 +179,7 @@ class TestPreviewAndDryRun(_Base):
         from cozempic import cli
 
         with patch.object(cli.sys.stdin, "isatty", return_value=True), \
+                patch.object(cli.sys.stderr, "isatty", return_value=True), \
                 patch.object(cli, "_prompt_with_timeout", return_value="n") as prompt, \
                 patch.object(cz_init, "run_uninstall") as run_uninstall:
             cli.cmd_uninstall(
@@ -197,6 +204,16 @@ class TestPreviewAndDryRun(_Base):
         prev = cz_init.preview_uninstall("global")
         self.assertIn(str(sp), prev["hooks_in"])
         self.assertEqual(sp.read_text(), before)  # untouched
+
+    def test_global_uninstall_and_preview_include_local_settings(self):
+        settings = _settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        })
+        local = self._write_global_local_settings(settings)
+        preview = cz_init.preview_uninstall("global")
+        self.assertIn(str(local), preview["hooks_in"])
+        cz_init.run_uninstall("global")
+        self.assertNotIn("cozempic", local.read_text())
 
     def test_cmd_dry_run_changes_nothing(self):
         from cozempic import cli

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -168,6 +168,17 @@ class TestRunUninstall(_Base):
 
 
 class TestPreviewAndDryRun(_Base):
+    def test_purge_uses_bounded_confirmation(self):
+        from cozempic import cli
+
+        with patch.object(cli, "_prompt_with_timeout", return_value="n") as prompt, \
+                patch.object(cz_init, "run_uninstall") as run_uninstall:
+            cli.cmd_uninstall(
+                argparse.Namespace(project=False, all=False, purge=True, dry_run=False)
+            )
+        prompt.assert_called_once_with("  Continue? [y/N] ", timeout=30, default="n")
+        run_uninstall.assert_not_called()
+
     def test_preview_reports_without_mutating(self):
         sp = self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -299,6 +299,11 @@ class TestPreviewAndDryRun(_Base):
             os.chdir(previous_cwd)
         self.assertFalse(preview["remind_counter"])
 
+    def test_project_preview_does_not_offer_global_purge(self):
+        (self.home / ".cozempic").mkdir()
+        preview = cz_init.preview_uninstall("project", purge=True)
+        self.assertEqual(preview["purge_data"], [])
+
     def test_preview_reports_without_mutating(self):
         sp = self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -300,7 +300,7 @@ class TestPreviewAndDryRun(_Base):
         from cozempic import cli
 
         output = io.StringIO()
-        with patch("sys.stdout", output), patch.object(cz_init, "run_uninstall") as run_uninstall:
+        with self.assertRaisesRegex(SystemExit, "2"), patch("sys.stdout", output), patch.object(cz_init, "run_uninstall") as run_uninstall:
             cli.cmd_uninstall(argparse.Namespace(project=True, all=False, purge=True, dry_run=False))
         self.assertIn("only applies to global data", output.getvalue())
         run_uninstall.assert_not_called()
@@ -406,7 +406,7 @@ class TestPreviewAndDryRun(_Base):
             "slash_error": "Could not read slash command: permission denied",
         }
         output = io.StringIO()
-        with patch("cozempic.init.preview_uninstall", return_value=preview), patch("sys.stdout", output):
+        with self.assertRaises(SystemExit), patch("cozempic.init.preview_uninstall", return_value=preview), patch("sys.stdout", output):
             cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=True, dry_run=True))
         text = output.getvalue()
         self.assertIn("Hooks: ERROR — invalid settings", text)

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -178,6 +178,27 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
+    def test_purge_preview_is_skipped_when_global_hook_cleanup_fails(self):
+        from cozempic import cli
+
+        path = self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{broken json")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+
+        preview = cz_init.preview_uninstall("global", purge=True)
+
+        self.assertTrue(preview["purge_skipped"])
+        self.assertEqual(preview["purge_data"], [])
+
+        output = io.StringIO()
+        with self.assertRaises(SystemExit), patch("sys.stdout", output):
+            cli.cmd_uninstall(
+                argparse.Namespace(project=False, all=False, purge=True, dry_run=True)
+            )
+        self.assertIn("Purge data: skipped due to a hook/settings error above", output.getvalue())
+
     def test_uninstall_write_failure_is_reported(self):
         self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -136,6 +136,14 @@ class TestRunUninstall(_Base):
             )
         self.assertIn("ERROR", output.getvalue())
 
+    def test_surfaces_valid_non_object_global_settings(self):
+        path = self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("null")
+        result = cz_init.run_uninstall("global")
+        self.assertTrue(result["errors"])
+        self.assertIn("JSON object", result["errors"][0])
+
 
 class TestPreviewAndDryRun(_Base):
     def test_preview_reports_without_mutating(self):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -152,6 +152,19 @@ class TestRunUninstall(_Base):
             result = cz_init.run_uninstall("global", purge=True)
         self.assertIn("Purge failed", result["errors"][0])
 
+    def test_purge_is_skipped_when_global_hook_cleanup_fails(self):
+        path = self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{broken json")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+
+        result = cz_init.run_uninstall("global", purge=True)
+
+        self.assertTrue(result["errors"])
+        self.assertEqual(result["purged"], [])
+        self.assertTrue(data_dir.exists())
+
     def test_uninstall_write_failure_is_reported(self):
         self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -171,13 +171,22 @@ class TestPreviewAndDryRun(_Base):
     def test_purge_uses_bounded_confirmation(self):
         from cozempic import cli
 
-        with patch.object(cli, "_prompt_with_timeout", return_value="n") as prompt, \
+        with patch.object(cli.sys.stdin, "isatty", return_value=True), \
+                patch.object(cli, "_prompt_with_timeout", return_value="n") as prompt, \
                 patch.object(cz_init, "run_uninstall") as run_uninstall:
             cli.cmd_uninstall(
                 argparse.Namespace(project=False, all=False, purge=True, dry_run=False)
             )
         prompt.assert_called_once_with("  Continue? [y/N] ", timeout=30, default="n")
         run_uninstall.assert_not_called()
+
+    def test_purge_requires_interactive_confirmation(self):
+        from cozempic import cli
+
+        with patch.object(cli.sys.stdin, "isatty", return_value=False), \
+                patch.object(cli, "_prompt_with_timeout") as prompt:
+            cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=True, dry_run=False))
+        prompt.assert_not_called()
 
     def test_preview_reports_without_mutating(self):
         sp = self._write_global_settings(_settings_with({

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -86,6 +86,21 @@ class TestRunUninstall(_Base):
         cz_init.run_init(str(project), skip_slash=True)
         self.assertFalse(marker.exists())
 
+    def test_project_uninstall_error_does_not_set_opt_out_marker(self):
+        project = self.home / "project-error"
+        claude = project / ".claude"
+        claude.mkdir(parents=True)
+        (claude / "settings.json").write_text('{"hooks": {}}')
+        (claude / "settings.local.json").write_text("{broken json")
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            result = cz_init.run_uninstall("project")
+        finally:
+            os.chdir(previous_cwd)
+        self.assertTrue(result["errors"])
+        self.assertFalse((claude / ".cozempic_uninstalled").exists())
+
     def test_removes_global_hooks_and_slash(self):
         self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -178,6 +178,20 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
+    def test_purge_is_skipped_when_global_local_cleanup_fails(self):
+        path = self.home / ".claude" / "settings.local.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{broken json")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+
+        result = cz_init.run_uninstall("global", purge=True)
+
+        self.assertTrue(result["errors"])
+        self.assertTrue(result["opt_out_set"])
+        self.assertTrue(result["purge_skipped"])
+        self.assertTrue(data_dir.exists())
+
     def test_purge_is_skipped_when_slash_cleanup_fails(self):
         self._write_slash("# cozempic\nDiagnose and prune bloated Claude Code context\n")
         data_dir = self.home / ".cozempic"

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -171,6 +171,7 @@ class TestRunUninstall(_Base):
         path.write_text("{broken json")
         result = cz_init.run_uninstall("global")
         self.assertTrue(result["errors"])
+        self.assertFalse(result["opt_out_set"])
 
         from cozempic import cli
         output = io.StringIO()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -102,6 +102,18 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["errors"])
         self.assertFalse((claude / ".cozempic_uninstalled").exists())
 
+    def test_global_local_settings_error_still_sets_managed_opt_out_marker(self):
+        claude = self.home / ".claude"
+        claude.mkdir(parents=True, exist_ok=True)
+        (claude / "settings.json").write_text('{"hooks": {}}')
+        (claude / "settings.local.json").write_text("{broken json")
+
+        result = cz_init.run_uninstall("global")
+
+        self.assertTrue(result["errors"])
+        self.assertTrue(result["opt_out_set"])
+        self.assertTrue((self.home / ".cozempic_global_initialized").exists())
+
     def test_removes_global_hooks_and_slash(self):
         self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -193,10 +193,8 @@ class TestRunUninstall(_Base):
             "errors": ["Purge failed for /home/example/.cozempic: permission denied"],
         }
         output = io.StringIO()
-        with patch("cozempic.init.run_uninstall", return_value=result), patch("sys.stdout", output):
-            cli.cmd_uninstall(
-                argparse.Namespace(project=False, all=False, purge=False, dry_run=False)
-            )
+        with self.assertRaises(SystemExit), patch("cozempic.init.run_uninstall", return_value=result), patch("sys.stdout", output):
+            cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=False))
         self.assertIn("ERROR: Purge failed", output.getvalue())
 
     def test_slash_backup_failure_is_reported_without_removal(self):
@@ -259,7 +257,7 @@ class TestRunUninstall(_Base):
 
         from cozempic import cli
         output = io.StringIO()
-        with patch("sys.stdout", output):
+        with self.assertRaises(SystemExit), patch("sys.stdout", output):
             cli.cmd_uninstall(
                 argparse.Namespace(project=False, all=False, purge=False, dry_run=False)
             )
@@ -318,6 +316,16 @@ class TestPreviewAndDryRun(_Base):
         finally:
             os.chdir(previous_cwd)
         self.assertFalse(preview["remind_counter"])
+
+    def test_project_dry_run_omits_global_uninstall_items(self):
+        from cozempic import cli
+
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            cli.cmd_uninstall(argparse.Namespace(project=True, all=False, purge=False, dry_run=True))
+
+        self.assertNotIn("Slash command", output.getvalue())
+        self.assertNotIn("Remind counter", output.getvalue())
 
     def test_project_preview_does_not_offer_global_purge(self):
         (self.home / ".cozempic").mkdir()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -152,6 +152,16 @@ class TestRunUninstall(_Base):
             result = cz_init.run_uninstall("global", purge=True)
         self.assertIn("Purge failed", result["errors"][0])
 
+    def test_uninstall_write_failure_is_reported(self):
+        self._write_global_settings(_settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        }))
+        with patch("cozempic.init._save_settings", side_effect=OSError("disk full")):
+            result = cz_init.run_uninstall("global")
+        self.assertEqual(result["errors"], [
+            f"could not write {self.home / '.claude' / 'settings.json'}: disk full"
+        ])
+
     def test_project_scope_purge_keeps_global_data(self):
         (self.home / ".cozempic").mkdir()
         (self.home / ".cozempic_savings.json").write_text("{}")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -71,11 +71,12 @@ class TestRunUninstall(_Base):
         previous_cwd = Path.cwd()
         os.chdir(project)
         try:
-            cz_init.run_uninstall("project")
+            result = cz_init.run_uninstall("project")
         finally:
             os.chdir(previous_cwd)
         marker = project / ".claude" / ".cozempic_uninstalled"
         self.assertTrue(marker.exists())
+        self.assertTrue(result["project_opt_out_set"])
         self.assertFalse((self.home / ".cozempic_global_initialized").exists())
 
         with patch.object(cli.Path, "cwd", return_value=project):
@@ -150,6 +151,45 @@ class TestRunUninstall(_Base):
         with patch("shutil.rmtree", side_effect=OSError("permission denied")):
             result = cz_init.run_uninstall("global", purge=True)
         self.assertIn("Purge failed", result["errors"][0])
+
+    def test_cmd_uninstall_prints_non_hook_errors(self):
+        from cozempic import cli
+
+        result = {
+            "hooks": [],
+            "slash_command": None,
+            "purged": [],
+            "opt_out_set": False,
+            "errors": ["Purge failed for /home/example/.cozempic: permission denied"],
+        }
+        output = io.StringIO()
+        with patch("cozempic.init.run_uninstall", return_value=result), patch("sys.stdout", output):
+            cli.cmd_uninstall(
+                argparse.Namespace(project=False, all=False, purge=False, dry_run=False)
+            )
+        self.assertIn("ERROR: Purge failed", output.getvalue())
+
+    def test_slash_backup_failure_is_reported_without_removal(self):
+        slash = self._write_slash("# cozempic\nDiagnose and prune bloated Claude Code context\n")
+        with patch("cozempic.init.shutil.copy2", side_effect=OSError("disk full")):
+            result = cz_init.uninstall_slash_command()
+        self.assertIn("Could not back up", result["error"])
+        self.assertTrue(slash.exists())
+
+    def test_init_marker_cleanup_failure_is_a_warning(self):
+        project = self.home / "project-marker-error"
+        project.mkdir()
+        marker = unittest.mock.Mock()
+        marker.unlink.side_effect = OSError("permission denied")
+        result = None
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            with patch.object(cz_init, "project_uninstall_marker", return_value=marker):
+                result = cz_init.run_init(".", skip_slash=True)
+        finally:
+            os.chdir(previous_cwd)
+        self.assertIn("Could not clear project uninstall marker", result["hooks"]["warnings"][0])
 
     def test_no_purge_keeps_data(self):
         (self.home / ".cozempic").mkdir()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -144,6 +144,13 @@ class TestRunUninstall(_Base):
         # opt-out marker still set even on purge (so auto-init doesn't re-fire)
         self.assertTrue((self.home / ".cozempic_global_initialized").exists())
 
+    def test_purge_failure_is_reported(self):
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+        with patch("shutil.rmtree", side_effect=OSError("permission denied")):
+            result = cz_init.run_uninstall("global", purge=True)
+        self.assertIn("Purge failed", result["errors"][0])
+
     def test_no_purge_keeps_data(self):
         (self.home / ".cozempic").mkdir()
         (self.home / ".cozempic_savings.json").write_text("{}")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -8,6 +8,7 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -225,6 +226,25 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
+    def test_purge_is_skipped_when_remind_counter_cleanup_fails(self):
+        counter = self.home / ".cozempic_remind_counter"
+        counter.write_text("3")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+        original_unlink = Path.unlink
+
+        def fail_counter_unlink(path, *args, **kwargs):
+            if path == counter:
+                raise OSError("permission denied")
+            return original_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", autospec=True, side_effect=fail_counter_unlink):
+            result = cz_init.run_uninstall("global", purge=True)
+
+        self.assertTrue(result["errors"])
+        self.assertTrue(result["purge_skipped"])
+        self.assertTrue(data_dir.exists())
+
     def test_all_purge_is_skipped_when_project_cleanup_fails(self):
         project = self.home / "project"
         local_settings = project / ".claude" / "settings.local.json"
@@ -408,6 +428,23 @@ class TestRunUninstall(_Base):
         with patch.object(Path, "unlink", side_effect=OSError("permission denied")):
             res = cz_init.run_uninstall("global")
         self.assertIn("Could not remove remind counter: permission denied", res["errors"])
+
+    def test_backup_settings_avoids_same_second_collisions(self):
+        path = self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True)
+        path.write_text('{"before": true}')
+        fixed_time = datetime(2026, 7, 27, 9, 0, 0)
+
+        with patch.object(cz_init, "datetime") as mock_datetime:
+            mock_datetime.now.return_value = fixed_time
+            first = cz_init._backup_settings(path)
+            path.write_text('{"after": true}')
+            second = cz_init._backup_settings(path)
+
+        self.assertNotEqual(first, second)
+        self.assertEqual(first.read_text(), '{"before": true}')
+        self.assertEqual(second.read_text(), '{"after": true}')
+        self.assertTrue(first.name.startswith("settings.json.20260727_090000"))
 
     def test_surfaces_malformed_global_settings(self):
         path = self.home / ".claude" / "settings.json"

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -191,6 +191,26 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
+    def test_purge_is_skipped_when_global_opt_out_cannot_be_persisted(self):
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+        marker = self.home / "blocked" / ".cozempic_global_initialized"
+        original_touch = Path.touch
+
+        def fail_marker_touch(path, *args, **kwargs):
+            if path == marker:
+                raise OSError("permission denied")
+            return original_touch(path, *args, **kwargs)
+
+        with patch.object(cz_init, "_global_init_marker", return_value=marker), patch.object(
+            Path, "touch", autospec=True, side_effect=fail_marker_touch
+        ):
+            result = cz_init.run_uninstall("global", purge=True)
+
+        self.assertTrue(result["errors"])
+        self.assertTrue(result["purge_skipped"])
+        self.assertTrue(data_dir.exists())
+
     def test_purge_preview_is_skipped_when_global_hook_cleanup_fails(self):
         from cozempic import cli
 
@@ -428,6 +448,22 @@ class TestPreviewAndDryRun(_Base):
         self.assertIn(str(local), preview["hooks_in"])
         cz_init.run_uninstall("global")
         self.assertNotIn("cozempic", local.read_text())
+
+    def test_deprecated_global_uninstall_removes_local_settings_too(self):
+        from cozempic import cli
+
+        settings = _settings_with({
+            "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]
+        })
+        primary = self._write_global_settings(settings)
+        local = self._write_global_local_settings(settings)
+
+        with patch("sys.stdout", io.StringIO()):
+            cli.cmd_init(argparse.Namespace(uninstall_global=True))
+
+        self.assertNotIn("cozempic", primary.read_text())
+        self.assertNotIn("cozempic", local.read_text())
+        self.assertTrue((self.home / ".cozempic_global_initialized").exists())
 
     def test_cmd_dry_run_changes_nothing(self):
         from cozempic import cli

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -163,6 +163,7 @@ class TestRunUninstall(_Base):
 
         self.assertTrue(result["errors"])
         self.assertEqual(result["purged"], [])
+        self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
     def test_uninstall_write_failure_is_reported(self):
@@ -196,6 +197,18 @@ class TestRunUninstall(_Base):
         with self.assertRaises(SystemExit), patch("cozempic.init.run_uninstall", return_value=result), patch("sys.stdout", output):
             cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=False))
         self.assertIn("ERROR: Purge failed", output.getvalue())
+
+    def test_cmd_uninstall_reports_skipped_purge(self):
+        from cozempic import cli
+
+        result = {
+            "hooks": [], "slash_command": None, "purged": [], "purge_skipped": True,
+            "opt_out_set": False, "errors": ["could not parse settings"],
+        }
+        output = io.StringIO()
+        with self.assertRaises(SystemExit), patch("cozempic.init.run_uninstall", return_value=result), patch("sys.stdout", output):
+            cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=False))
+        self.assertIn("Purge skipped due to a hook/settings error", output.getvalue())
 
     def test_slash_backup_failure_is_reported_without_removal(self):
         slash = self._write_slash("# cozempic\nDiagnose and prune bloated Claude Code context\n")

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -178,6 +178,19 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
+    def test_purge_is_skipped_when_slash_cleanup_fails(self):
+        self._write_slash("# cozempic\nDiagnose and prune bloated Claude Code context\n")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+
+        with patch("cozempic.init.shutil.copy2", side_effect=OSError("disk full")):
+            result = cz_init.run_uninstall("global", purge=True)
+
+        self.assertTrue(result["errors"])
+        self.assertEqual(result["purged"], [])
+        self.assertTrue(result["purge_skipped"])
+        self.assertTrue(data_dir.exists())
+
     def test_purge_preview_is_skipped_when_global_hook_cleanup_fails(self):
         from cozempic import cli
 
@@ -198,6 +211,24 @@ class TestRunUninstall(_Base):
                 argparse.Namespace(project=False, all=False, purge=True, dry_run=True)
             )
         self.assertIn("Purge data: skipped due to a hook/settings error above", output.getvalue())
+
+    def test_purge_preview_is_skipped_when_slash_read_fails(self):
+        slash = self._write_slash("# cozempic\nDiagnose and prune bloated Claude Code context\n")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+        original_read_text = Path.read_text
+
+        def fail_slash_read(path, *args, **kwargs):
+            if path == slash:
+                raise OSError("permission denied")
+            return original_read_text(path, *args, **kwargs)
+
+        with patch.object(Path, "read_text", autospec=True, side_effect=fail_slash_read):
+            preview = cz_init.preview_uninstall("global", purge=True)
+
+        self.assertTrue(preview["purge_skipped"])
+        self.assertEqual(preview["purge_data"], [])
+        self.assertTrue(preview["slash_error"])
 
     def test_uninstall_write_failure_is_reported(self):
         self._write_global_settings(_settings_with({

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -70,6 +70,7 @@ class TestRunUninstall(_Base):
             os.chdir(previous_cwd)
         marker = project / ".claude" / ".cozempic_uninstalled"
         self.assertTrue(marker.exists())
+        self.assertFalse((self.home / ".cozempic_global_initialized").exists())
 
         with patch.object(cli.Path, "cwd", return_value=project):
             with patch.object(cli, "run_init") as auto_init:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -255,9 +255,23 @@ class TestPreviewAndDryRun(_Base):
         from cozempic import cli
 
         with patch.object(cli.sys.stdin, "isatty", return_value=False), \
-                patch.object(cli, "_prompt_with_timeout") as prompt:
+                patch.object(cli, "_prompt_with_timeout") as prompt, \
+                patch.object(cz_init, "run_uninstall") as run_uninstall:
             cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=True, dry_run=False))
         prompt.assert_not_called()
+        run_uninstall.assert_called_once_with("global", False)
+
+    def test_project_preview_does_not_offer_global_remind_counter_removal(self):
+        (self.home / ".cozempic_remind_counter").write_text("3")
+        project = self.home / "project"
+        project.mkdir()
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            preview = cz_init.preview_uninstall("project")
+        finally:
+            os.chdir(previous_cwd)
+        self.assertFalse(preview["remind_counter"])
 
     def test_preview_reports_without_mutating(self):
         sp = self._write_global_settings(_settings_with({

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -225,6 +225,57 @@ class TestRunUninstall(_Base):
         self.assertTrue(result["purge_skipped"])
         self.assertTrue(data_dir.exists())
 
+    def test_all_purge_is_skipped_when_project_cleanup_fails(self):
+        project = self.home / "project"
+        local_settings = project / ".claude" / "settings.local.json"
+        local_settings.parent.mkdir(parents=True)
+        local_settings.write_text("{broken json")
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            result = cz_init.run_uninstall("all", purge=True)
+            preview = cz_init.preview_uninstall("all", purge=True)
+        finally:
+            os.chdir(previous_cwd)
+
+        self.assertTrue(result["errors"])
+        self.assertTrue(result["purge_skipped"])
+        self.assertFalse(result["project_opt_out_set"])
+        self.assertTrue(data_dir.exists())
+        self.assertTrue(preview["purge_skipped"])
+        self.assertEqual(preview["purge_data"], [])
+
+    def test_all_purge_is_skipped_when_project_opt_out_cannot_be_persisted(self):
+        project = self.home / "project"
+        (project / ".claude").mkdir(parents=True)
+        data_dir = self.home / ".cozempic"
+        data_dir.mkdir()
+        marker = project / ".claude" / ".cozempic_uninstalled"
+        original_touch = Path.touch
+
+        def fail_project_marker_touch(path, *args, **kwargs):
+            if path == marker:
+                raise OSError("permission denied")
+            return original_touch(path, *args, **kwargs)
+
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            with patch.object(cz_init, "project_uninstall_marker", return_value=marker), patch.object(
+                Path, "touch", autospec=True, side_effect=fail_project_marker_touch
+            ):
+                result = cz_init.run_uninstall("all", purge=True)
+        finally:
+            os.chdir(previous_cwd)
+
+        self.assertTrue(result["errors"])
+        self.assertTrue(result["purge_skipped"])
+        self.assertFalse(result["project_opt_out_set"])
+        self.assertTrue(data_dir.exists())
+
     def test_purge_preview_is_skipped_when_global_hook_cleanup_fails(self):
         from cozempic import cli
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -57,6 +57,28 @@ class _Base(unittest.TestCase):
 
 
 class TestRunUninstall(_Base):
+    def test_project_uninstall_blocks_auto_init_until_explicit_init(self):
+        from cozempic import cli
+
+        project = self.home / "project"
+        (project / ".claude").mkdir(parents=True)
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            cz_init.run_uninstall("project")
+        finally:
+            os.chdir(previous_cwd)
+        marker = project / ".claude" / ".cozempic_uninstalled"
+        self.assertTrue(marker.exists())
+
+        with patch.object(cli.Path, "cwd", return_value=project):
+            with patch.object(cli, "run_init") as auto_init:
+                cli._maybe_auto_init(["list"])
+                auto_init.assert_not_called()
+
+        cz_init.run_init(str(project), skip_slash=True)
+        self.assertFalse(marker.exists())
+
     def test_removes_global_hooks_and_slash(self):
         self._write_global_settings(_settings_with({
             "SessionStart": [{"hooks": [{"type": "command", "command": COZ_CMD}]}]

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -341,6 +341,32 @@ class TestPreviewAndDryRun(_Base):
         preview = cz_init.preview_uninstall("global")
         self.assertTrue(preview["errors"])
 
+    def test_uninstall_rejects_unknown_scope(self):
+        with self.assertRaisesRegex(ValueError, "Unknown uninstall scope"):
+            cz_init.preview_uninstall("typo")
+        with self.assertRaisesRegex(ValueError, "Unknown uninstall scope"):
+            cz_init.run_uninstall("typo")
+
+    def test_dry_run_labels_slash_errors_and_formats_paths(self):
+        from cozempic import cli
+
+        preview = {
+            "hooks_in": ["/one/settings.json", "/two/settings.local.json"],
+            "slash_command": False,
+            "remind_counter": False,
+            "purge_data": ["/home/example/.cozempic"],
+            "hook_errors": ["invalid settings"],
+            "slash_error": "Could not read slash command: permission denied",
+        }
+        output = io.StringIO()
+        with patch("cozempic.init.preview_uninstall", return_value=preview), patch("sys.stdout", output):
+            cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=True, dry_run=True))
+        text = output.getvalue()
+        self.assertIn("Hooks: ERROR — invalid settings", text)
+        self.assertIn("Slash command: ERROR — Could not read slash command", text)
+        self.assertIn("/one/settings.json, /two/settings.local.json", text)
+        self.assertNotIn("['/one/settings.json'", text)
+
 
 class TestOptOutHolds(_Base):
     def test_opt_out_marker_blocks_refire(self):

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -383,6 +383,8 @@ class TestPreviewAndDryRun(_Base):
         text = output.getvalue()
         self.assertIn("Hooks: ERROR — invalid settings", text)
         self.assertIn("Slash command: ERROR — Could not read slash command", text)
+        self.assertIn("Slash command (~/.claude/commands/cozempic.md): (could not determine)", text)
+        self.assertNotIn("(not present / not ours)", text)
         self.assertIn("/one/settings.json, /two/settings.local.json", text)
         self.assertNotIn("['/one/settings.json'", text)
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -348,7 +348,14 @@ class TestRunUninstall(_Base):
     def test_project_scope_purge_keeps_global_data(self):
         (self.home / ".cozempic").mkdir()
         (self.home / ".cozempic_savings.json").write_text("{}")
-        cz_init.run_uninstall("project", purge=True)
+        project = self.home / "project"
+        project.mkdir()
+        previous_cwd = Path.cwd()
+        os.chdir(project)
+        try:
+            cz_init.run_uninstall("project", purge=True)
+        finally:
+            os.chdir(previous_cwd)
         self.assertTrue((self.home / ".cozempic").exists())
         self.assertTrue((self.home / ".cozempic_savings.json").exists())
 

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -322,7 +322,8 @@ class TestPreviewAndDryRun(_Base):
     def test_purge_uses_bounded_confirmation(self):
         from cozempic import cli
 
-        with patch.object(cli.sys.stdin, "isatty", return_value=True), \
+        with self.assertRaisesRegex(SystemExit, "1"), \
+                patch.object(cli.sys.stdin, "isatty", return_value=True), \
                 patch.object(cli.sys.stderr, "isatty", return_value=True), \
                 patch.object(cli, "_prompt_with_timeout", return_value="n") as prompt, \
                 patch.object(cz_init, "run_uninstall") as run_uninstall:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import tempfile
@@ -120,6 +121,21 @@ class TestRunUninstall(_Base):
         self.assertTrue(res["remind_counter_removed"])
         self.assertFalse((self.home / ".cozempic_remind_counter").exists())
 
+    def test_surfaces_malformed_global_settings(self):
+        path = self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{broken json")
+        result = cz_init.run_uninstall("global")
+        self.assertTrue(result["errors"])
+
+        from cozempic import cli
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            cli.cmd_uninstall(
+                argparse.Namespace(project=False, all=False, purge=False, dry_run=False)
+            )
+        self.assertIn("ERROR", output.getvalue())
+
 
 class TestPreviewAndDryRun(_Base):
     def test_preview_reports_without_mutating(self):
@@ -141,6 +157,13 @@ class TestPreviewAndDryRun(_Base):
         cli.cmd_uninstall(argparse.Namespace(project=False, all=False, purge=False, dry_run=True))
         self.assertEqual(sp.read_text(), before)
         self.assertFalse((self.home / ".cozempic_global_initialized").exists())  # no opt-out write either
+
+    def test_preview_reports_malformed_settings(self):
+        path = self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{broken json")
+        preview = cz_init.preview_uninstall("global")
+        self.assertTrue(preview["errors"])
 
 
 class TestOptOutHolds(_Base):


### PR DESCRIPTION
## Summary

- Refresh existing stale global Cozempic hooks even when the global-init marker is present.
- Preserve the marker-without-hooks path as a prior user opt-out.
- Cover migration of a legacy schema-v10 global hook without prompting.

## Why

A package upgrade can ship a safer SessionStart hook while an earlier globally installed hook remains in `~/.claude/settings.json`. The marker previously suppressed the refresh path, leaving the old hook active.

## Tests

- `uv run --frozen --with pytest pytest tests/test_global_init.py tests/test_auto_init_global_skip.py -q`
- `uv run --frozen --with pytest pytest tests/test_guard_race_2026_05_18.py::TestR1_DaemonProcessRace::test_two_processes_one_winner -q`
- `uv run --frozen --with pytest pytest -x -q` reached 791 passed and 5 skipped before the existing nondeterministic guard-race test produced two winners in one of 50 iterations; its isolated rerun passed.

## Review

Required review tiers: tier-1,tier-2,tier-3

Approval authority: requester
