### PR TITLE
test(guard): stabilize spawn-race fixtures

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1078,6 +1078,11 @@ def cmd_guard(args):
         else:
             reason = result.get("reason") or "unknown (no started/already_running/reason set)"
             print(f"  Guard daemon failed to start: {reason}")
+        if result.get("orphaned_pid"):
+            print(
+                f"  Guard warning: PID {result['orphaned_pid']} may still be running; stop it manually.",
+                file=sys.stderr,
+            )
         return
 
     start_guard(

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1045,6 +1045,11 @@ def cmd_guard(args):
             print(f"  Guard daemon reloaded (PID {result['old_pid']} → {result['new_pid']})")
         else:
             print(f"  Guard reload skipped: {result.get('reason')}")
+        if result.get("orphaned_pid"):
+            print(
+                f"  Guard warning: PID {result['orphaned_pid']} may still be running; stop it manually.",
+                file=sys.stderr,
+            )
         return
 
     if args.daemon:

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -298,7 +298,7 @@ def _is_lock_held(lock_path: Path) -> bool:
     except ImportError:
         return True
     try:
-        flags = os.O_RDWR
+        flags = os.O_RDWR | getattr(os, "O_NONBLOCK", 0)
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         fd = os.open(str(lock_path), flags)

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -340,9 +340,7 @@ def _unheld_lock_artifacts(pattern: str) -> list[Path]:
 
 
 def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[Path], list[Path]]:
-    """Scan `_TMP_DIR` and partition cozempic artifacts into four buckets:
-    stale .pid/.pid.tmp files, orphan .log/.lock files, and kept files (unused here
-    but isolates the pure-IO from the status/message logic).
+    """Scan `_TMP_DIR` into stale PID/temp files, orphan logs/locks/markers.
 
     Never returns a file listed in `_is_protected_tmp_artifact`.
     """
@@ -386,7 +384,10 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
     orphan_locks = [
         *_unheld_lock_artifacts("cozempic_hook_*.lock"),
     ]
-    orphan_markers = _glob_tmp_artifacts("cozempic_guard_*.orphan")
+    orphan_markers = [
+        path for path in _glob_tmp_artifacts("cozempic_guard_*.orphan*")
+        if not _is_protected_tmp_artifact(path.name)
+    ]
 
     return stale_pids, stale_temps, orphan_logs, orphan_locks, orphan_markers
 
@@ -395,11 +396,13 @@ def check_stale_tmp_artifacts() -> CheckResult:
     """Detect accumulated cozempic runtime artifacts left behind by crashed
     or abnormally-terminated guard daemons.
 
-    Surfaces three classes of artifact:
+    Surfaces five classes of artifact:
       - stale /tmp/cozempic_guard_*.pid files whose PID is dead or not a
         cozempic guard (PID-reuse safe via `_is_cozempic_guard_process`)
+      - stale /tmp/cozempic_guard_*.pid.tmp files left by interrupted spawns
       - /tmp/cozempic_guard_*.log files with no matching live guard
       - /tmp/cozempic_hook_*.lock files not currently held by any flock
+      - /tmp/cozempic_guard_*.orphan* markers for guards that could not stop
 
     Global append-only files (cozempic_guard.log, cozempic_reload.log) and
     the circuit-breaker state file (cozempic_breaker_*.json) are ignored —
@@ -451,7 +454,7 @@ def check_stale_tmp_artifacts() -> CheckResult:
 
 
 def fix_stale_tmp_artifacts() -> str:
-    """Delete stale .pid, orphan .log, and orphan .lock files.
+    """Delete stale PID/temp files and orphan logs, locks, and markers.
 
     Re-classifies artifacts at fix time (the set may have changed since the
     check ran) so a guard that went live between check and fix is protected.

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import platform
 import shutil
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,9 +19,8 @@ from .session import find_sessions, get_claude_dir, get_claude_json_path
 
 # Directory where cozempic writes runtime artifacts (.pid / .log / .lock files).
 # Exposed as a module-level constant so tests can redirect it to a tmpdir
-# without monkeypatching every glob call. Always points at POSIX /tmp today;
-# a future Windows port would swap this for tempfile.gettempdir().
-_TMP_DIR = Path("/tmp")
+# without monkeypatching every glob call.
+_TMP_DIR = Path(tempfile.gettempdir()) if platform.system() == "Windows" else Path("/tmp")
 
 
 @dataclass
@@ -246,14 +246,16 @@ _PROTECTED_TMP_NAMES = frozenset({
     "cozempic_guard.log",
     "cozempic_reload.log",
 })
-_PROTECTED_TMP_PREFIXES = ("cozempic_breaker_",)
+_PROTECTED_TMP_PREFIXES = ("cozempic_breaker_", "cozempic_hook_")
 
 
 def _is_protected_tmp_artifact(name: str) -> bool:
     """True if the file is an intentionally-persistent global artifact."""
     if name in _PROTECTED_TMP_NAMES:
         return True
-    return any(name.startswith(p) for p in _PROTECTED_TMP_PREFIXES)
+    return name.endswith(".pid.reclaim-lock") or any(
+        name.startswith(prefix) for prefix in _PROTECTED_TMP_PREFIXES
+    )
 
 
 def _is_live_guard_pid(pid: int) -> bool:
@@ -335,7 +337,6 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
     Never returns a file listed in `_is_protected_tmp_artifact`.
     """
     stale_pids: list[Path] = []
-    stale_temps: list[Path] = []
     orphan_logs: list[Path] = []
     orphan_locks: list[Path] = []
 

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -385,6 +385,16 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
         if not _is_lock_held(lock_path):
             orphan_locks.append(lock_path)
 
+    try:
+        reclaim_entries = list(_TMP_DIR.glob("cozempic_guard_*.pid.reclaim-lock"))
+    except OSError:
+        reclaim_entries = []
+    for lock_path in reclaim_entries:
+        if _is_protected_tmp_artifact(lock_path.name):
+            continue
+        if not _is_lock_held(lock_path):
+            orphan_locks.append(lock_path)
+
     return stale_pids, stale_temps, orphan_logs, orphan_locks
 
 

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -429,7 +429,7 @@ def check_stale_tmp_artifacts() -> CheckResult:
     size_bytes = 0
     for path in (*stale_pids, *stale_temps, *orphan_logs, *orphan_locks, *orphan_markers):
         try:
-            size_bytes += path.stat().st_size
+            size_bytes += path.lstat().st_size
         except OSError:
             pass
 

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -1192,15 +1192,14 @@ def check_cozempic_daemon_running() -> CheckResult:
     Verifies via `_is_cozempic_guard_process` (ps argv match) so a PID-reused
     stranger process doesn't produce a false-positive "daemon running".
     """
-    from pathlib import Path as _Path
-    import os as _os, glob as _glob
+    import os as _os
     from .guard import _is_cozempic_guard_process
     from .spawn_lock import _parse_pidfile_pid
     pids_alive: list[int] = []
-    for pidf in _glob.glob("/tmp/cozempic_guard_*.pid"):
+    for pid_path in _TMP_DIR.glob("cozempic_guard_*.pid"):
         # Tolerant parse: handles both legacy 1-line and new 3-line
         # pidfile formats (PR #93 item #5). Returns 0 on garble.
-        pid = _parse_pidfile_pid(_Path(pidf))
+        pid = _parse_pidfile_pid(pid_path)
         if pid <= 0:
             continue
         try:

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -271,6 +271,8 @@ def _is_live_guard_pid(pid: int) -> bool:
     """
     import os as _os
 
+    if pid <= 0:
+        return False
     try:
         _os.kill(pid, 0)
     except PermissionError:
@@ -373,7 +375,7 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
         else:
             stale_pids.append(pid_path)
     stale_temps = [
-        path for path in _glob_tmp_artifacts("cozempic_guard_*.pid.tmp")
+        path for path in _glob_tmp_artifacts("cozempic_guard_*.pid*.tmp")
         if not _is_protected_tmp_artifact(path.name)
         and _is_stale_tmp_artifact(path, _DOCTOR_PID_TMP_STALE_SECONDS)
     ]
@@ -444,7 +446,15 @@ def check_stale_tmp_artifacts() -> CheckResult:
     if orphan_locks:
         parts.append(f"{len(orphan_locks)} orphan .lock file(s)")
     if orphan_markers:
-        parts.append(f"{len(orphan_markers)} orphan guard marker(s)")
+        from .spawn_lock import _parse_pidfile_pid
+
+        orphan_pids = sorted(
+            {pid for path in orphan_markers if (pid := _parse_pidfile_pid(path)) > 0}
+        )
+        marker_detail = f"{len(orphan_markers)} orphan guard marker(s)"
+        if orphan_pids:
+            marker_detail += f" (PIDs: {', '.join(map(str, orphan_pids))})"
+        parts.append(marker_detail)
     detail = ", ".join(parts)
 
     return CheckResult(

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -7,6 +7,7 @@ config bugs, oversized sessions, stale backups, and disk usage.
 from __future__ import annotations
 
 import json
+import os
 import platform
 import shutil
 import tempfile
@@ -248,6 +249,9 @@ _PROTECTED_TMP_NAMES = frozenset({
     "cozempic_reload.log",
 })
 _PROTECTED_TMP_PREFIXES = ("cozempic_breaker_",)
+# A doctor run is an operator cleanup action, not a live spawn contender. Give
+# a slow daemon publication ample time to finish before considering its temp file.
+_DOCTOR_PID_TMP_STALE_SECONDS = 60
 
 
 def _is_protected_tmp_artifact(name: str) -> bool:
@@ -290,23 +294,26 @@ def _is_lock_held(lock_path: Path) -> bool:
     except ImportError:
         return True
     try:
-        fd = open(lock_path, "a+")
+        flags = os.O_RDWR
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(lock_path), flags)
     except OSError:
         # Can't open — leave the file alone.
         return True
     try:
         try:
-            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except (BlockingIOError, OSError):
             return True
         # Acquired — lock was orphaned. Release before returning.
         try:
-            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            fcntl.flock(fd, fcntl.LOCK_UN)
         except OSError:
             pass
         return False
     finally:
-        fd.close()
+        os.close(fd)
 
 
 def _glob_tmp_artifacts(pattern: str) -> list[Path]:
@@ -361,11 +368,10 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
             live_slugs.add(slug)
         else:
             stale_pids.append(pid_path)
-    from .spawn_lock import _FRESH_PIDFILE_SECONDS
     stale_temps = [
         path for path in _glob_tmp_artifacts("cozempic_guard_*.pid.tmp")
         if not _is_protected_tmp_artifact(path.name)
-        and _is_stale_tmp_artifact(path, _FRESH_PIDFILE_SECONDS)
+        and _is_stale_tmp_artifact(path, _DOCTOR_PID_TMP_STALE_SECONDS)
     ]
 
     for log_path in _glob_tmp_artifacts("cozempic_guard_*.log"):
@@ -378,7 +384,6 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
 
     orphan_locks = [
         *_unheld_lock_artifacts("cozempic_hook_*.lock"),
-        *_unheld_lock_artifacts("cozempic_guard_*.pid.reclaim-lock"),
     ]
 
     return stale_pids, stale_temps, orphan_logs, orphan_locks

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -247,7 +247,7 @@ _PROTECTED_TMP_NAMES = frozenset({
     "cozempic_guard.log",
     "cozempic_reload.log",
 })
-_PROTECTED_TMP_PREFIXES = ("cozempic_breaker_", "cozempic_hook_")
+_PROTECTED_TMP_PREFIXES = ("cozempic_breaker_",)
 
 
 def _is_protected_tmp_artifact(name: str) -> bool:
@@ -317,6 +317,8 @@ def _glob_tmp_artifacts(pattern: str) -> list[Path]:
 
 
 def _is_stale_tmp_artifact(path: Path, max_age_seconds: float) -> bool:
+    if path.is_symlink():
+        return True
     try:
         return time.time() - path.stat().st_mtime >= max_age_seconds
     except OSError:

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -273,7 +273,9 @@ def _is_live_guard_pid(pid: int) -> bool:
 
     try:
         _os.kill(pid, 0)
-    except (ProcessLookupError, PermissionError, OSError):
+    except PermissionError:
+        return True
+    except (ProcessLookupError, OSError):
         return False
     from .guard import _is_cozempic_guard_process
     return _is_cozempic_guard_process(pid)
@@ -352,6 +354,7 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
     live_slugs: set[str] = set()
 
     from .spawn_lock import _parse_pidfile_pid
+    from .spawn_lock import pidfile_is_fresh
     for pid_path in _glob_tmp_artifacts("cozempic_guard_*.pid"):
         if _is_protected_tmp_artifact(pid_path.name):
             continue
@@ -360,8 +363,10 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
         # pidfile formats (PR #93 item #5). Returns 0 on garble → we
         # classify as stale.
         pid = _parse_pidfile_pid(pid_path)
-        if pid <= 0:
+        if pid <= 0 and not pidfile_is_fresh(pid_path):
             stale_pids.append(pid_path)
+            continue
+        if pid <= 0:
             continue
         if _is_live_guard_pid(pid):
             live_slugs.add(slug)

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import platform
 import shutil
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -305,7 +306,7 @@ def _is_lock_held(lock_path: Path) -> bool:
         fd.close()
 
 
-def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path]]:
+def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[Path]]:
     """Scan `_TMP_DIR` and partition cozempic artifacts into three buckets:
     stale .pid/.log files, orphan .lock files, and kept files (unused here
     but isolates the pure-IO from the status/message logic).
@@ -313,6 +314,7 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path]]:
     Never returns a file listed in `_is_protected_tmp_artifact`.
     """
     stale_pids: list[Path] = []
+    stale_temps: list[Path] = []
     orphan_logs: list[Path] = []
     orphan_locks: list[Path] = []
 
@@ -345,6 +347,20 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path]]:
     pid_slugs = {p.stem[len("cozempic_guard_"):] for p in pid_files}
 
     try:
+        tmp_entries = list(_TMP_DIR.glob("cozempic_guard_*.pid.tmp"))
+    except OSError:
+        tmp_entries = []
+    from .spawn_lock import _FRESH_PIDFILE_SECONDS
+    for tmp_path in tmp_entries:
+        if _is_protected_tmp_artifact(tmp_path.name):
+            continue
+        try:
+            if time.time() - tmp_path.stat().st_mtime >= _FRESH_PIDFILE_SECONDS:
+                stale_temps.append(tmp_path)
+        except OSError:
+            continue
+
+    try:
         log_entries = list(_TMP_DIR.glob("cozempic_guard_*.log"))
     except OSError:
         log_entries = []
@@ -369,7 +385,7 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path]]:
         if not _is_lock_held(lock_path):
             orphan_locks.append(lock_path)
 
-    return stale_pids, orphan_logs, orphan_locks
+    return stale_pids, stale_temps, orphan_logs, orphan_locks
 
 
 def check_stale_tmp_artifacts() -> CheckResult:
@@ -386,8 +402,8 @@ def check_stale_tmp_artifacts() -> CheckResult:
     the circuit-breaker state file (cozempic_breaker_*.json) are ignored —
     those are intentionally persistent.
     """
-    stale_pids, orphan_logs, orphan_locks = _classify_tmp_artifacts()
-    total = len(stale_pids) + len(orphan_logs) + len(orphan_locks)
+    stale_pids, stale_temps, orphan_logs, orphan_locks = _classify_tmp_artifacts()
+    total = len(stale_pids) + len(stale_temps) + len(orphan_logs) + len(orphan_locks)
 
     if total == 0:
         return CheckResult(
@@ -398,7 +414,7 @@ def check_stale_tmp_artifacts() -> CheckResult:
 
     # Size aggregate — helps surface the "96 log files" case.
     size_bytes = 0
-    for path in (*stale_pids, *orphan_logs, *orphan_locks):
+    for path in (*stale_pids, *stale_temps, *orphan_logs, *orphan_locks):
         try:
             size_bytes += path.stat().st_size
         except OSError:
@@ -410,6 +426,8 @@ def check_stale_tmp_artifacts() -> CheckResult:
     parts = []
     if stale_pids:
         parts.append(f"{len(stale_pids)} stale .pid file(s)")
+    if stale_temps:
+        parts.append(f"{len(stale_temps)} stale .pid.tmp file(s)")
     if orphan_logs:
         parts.append(f"{len(orphan_logs)} orphan .log file(s)")
     if orphan_locks:
@@ -435,9 +453,9 @@ def fix_stale_tmp_artifacts() -> str:
     Every unlink uses `missing_ok=True` to tolerate races with concurrent
     cleanup from `_is_guard_running_for_session`.
     """
-    stale_pids, orphan_logs, orphan_locks = _classify_tmp_artifacts()
+    stale_pids, stale_temps, orphan_logs, orphan_locks = _classify_tmp_artifacts()
     deleted = 0
-    for path in (*stale_pids, *orphan_logs, *orphan_locks):
+    for path in (*stale_pids, *stale_temps, *orphan_logs, *orphan_locks):
         try:
             path.unlink(missing_ok=True)
             deleted += 1

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -20,7 +20,8 @@ from .session import find_sessions, get_claude_dir, get_claude_json_path
 # Directory where cozempic writes runtime artifacts (.pid / .log / .lock files).
 # Exposed as a module-level constant so tests can redirect it to a tmpdir
 # without monkeypatching every glob call.
-_TMP_DIR = Path(tempfile.gettempdir()) if platform.system() == "Windows" else Path("/tmp")
+# Only fixed Cozempic artifact names are unlinked below; Path.unlink never follows symlinks.
+_TMP_DIR = Path(tempfile.gettempdir()) if platform.system() == "Windows" else Path("/tmp")  # NOSONAR
 
 
 @dataclass

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -10,6 +10,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -306,6 +307,8 @@ def _is_lock_held(lock_path: Path) -> bool:
         # Can't open — leave the file alone.
         return True
     try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return True
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except (BlockingIOError, OSError):

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -339,7 +339,7 @@ def _unheld_lock_artifacts(pattern: str) -> list[Path]:
     ]
 
 
-def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[Path]]:
+def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[Path], list[Path]]:
     """Scan `_TMP_DIR` and partition cozempic artifacts into four buckets:
     stale .pid/.pid.tmp files, orphan .log/.lock files, and kept files (unused here
     but isolates the pure-IO from the status/message logic).
@@ -349,6 +349,7 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
     stale_pids: list[Path] = []
     orphan_logs: list[Path] = []
     orphan_locks: list[Path] = []
+    orphan_markers: list[Path] = []
 
     live_slugs: set[str] = set()
 
@@ -385,8 +386,9 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
     orphan_locks = [
         *_unheld_lock_artifacts("cozempic_hook_*.lock"),
     ]
+    orphan_markers = _glob_tmp_artifacts("cozempic_guard_*.orphan")
 
-    return stale_pids, stale_temps, orphan_logs, orphan_locks
+    return stale_pids, stale_temps, orphan_logs, orphan_locks, orphan_markers
 
 
 def check_stale_tmp_artifacts() -> CheckResult:
@@ -403,8 +405,8 @@ def check_stale_tmp_artifacts() -> CheckResult:
     the circuit-breaker state file (cozempic_breaker_*.json) are ignored —
     those are intentionally persistent.
     """
-    stale_pids, stale_temps, orphan_logs, orphan_locks = _classify_tmp_artifacts()
-    total = len(stale_pids) + len(stale_temps) + len(orphan_logs) + len(orphan_locks)
+    stale_pids, stale_temps, orphan_logs, orphan_locks, orphan_markers = _classify_tmp_artifacts()
+    total = len(stale_pids) + len(stale_temps) + len(orphan_logs) + len(orphan_locks) + len(orphan_markers)
 
     if total == 0:
         return CheckResult(
@@ -415,7 +417,7 @@ def check_stale_tmp_artifacts() -> CheckResult:
 
     # Size aggregate — helps surface the "96 log files" case.
     size_bytes = 0
-    for path in (*stale_pids, *stale_temps, *orphan_logs, *orphan_locks):
+    for path in (*stale_pids, *stale_temps, *orphan_logs, *orphan_locks, *orphan_markers):
         try:
             size_bytes += path.stat().st_size
         except OSError:
@@ -433,6 +435,8 @@ def check_stale_tmp_artifacts() -> CheckResult:
         parts.append(f"{len(orphan_logs)} orphan .log file(s)")
     if orphan_locks:
         parts.append(f"{len(orphan_locks)} orphan .lock file(s)")
+    if orphan_markers:
+        parts.append(f"{len(orphan_markers)} orphan guard marker(s)")
     detail = ", ".join(parts)
 
     return CheckResult(
@@ -454,9 +458,18 @@ def fix_stale_tmp_artifacts() -> str:
     Every unlink uses `missing_ok=True` to tolerate races with concurrent
     cleanup from `_is_guard_running_for_session`.
     """
-    stale_pids, stale_temps, orphan_logs, orphan_locks = _classify_tmp_artifacts()
+    stale_pids, stale_temps, orphan_logs, orphan_locks, orphan_markers = _classify_tmp_artifacts()
     deleted = 0
     for path in (*stale_pids, *stale_temps, *orphan_logs, *orphan_locks):
+        try:
+            path.unlink(missing_ok=True)
+            deleted += 1
+        except OSError:
+            pass
+    from .spawn_lock import _parse_pidfile_pid
+    for path in orphan_markers:
+        if _is_live_guard_pid(_parse_pidfile_pid(path)):
+            continue
         try:
             path.unlink(missing_ok=True)
             deleted += 1

--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -306,9 +306,30 @@ def _is_lock_held(lock_path: Path) -> bool:
         fd.close()
 
 
+def _glob_tmp_artifacts(pattern: str) -> list[Path]:
+    try:
+        return list(_TMP_DIR.glob(pattern))
+    except OSError:
+        return []
+
+
+def _is_stale_tmp_artifact(path: Path, max_age_seconds: float) -> bool:
+    try:
+        return time.time() - path.stat().st_mtime >= max_age_seconds
+    except OSError:
+        return False
+
+
+def _unheld_lock_artifacts(pattern: str) -> list[Path]:
+    return [
+        path for path in _glob_tmp_artifacts(pattern)
+        if not _is_protected_tmp_artifact(path.name) and not _is_lock_held(path)
+    ]
+
+
 def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[Path]]:
-    """Scan `_TMP_DIR` and partition cozempic artifacts into three buckets:
-    stale .pid/.log files, orphan .lock files, and kept files (unused here
+    """Scan `_TMP_DIR` and partition cozempic artifacts into four buckets:
+    stale .pid/.pid.tmp files, orphan .log/.lock files, and kept files (unused here
     but isolates the pure-IO from the status/message logic).
 
     Never returns a file listed in `_is_protected_tmp_artifact`.
@@ -319,15 +340,9 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
     orphan_locks: list[Path] = []
 
     live_slugs: set[str] = set()
-    pid_files: list[Path] = []
-
-    try:
-        entries = list(_TMP_DIR.glob("cozempic_guard_*.pid"))
-    except OSError:
-        entries = []
 
     from .spawn_lock import _parse_pidfile_pid
-    for pid_path in entries:
+    for pid_path in _glob_tmp_artifacts("cozempic_guard_*.pid"):
         if _is_protected_tmp_artifact(pid_path.name):
             continue
         slug = pid_path.stem[len("cozempic_guard_"):]  # strip prefix, keep before .pid
@@ -342,58 +357,25 @@ def _classify_tmp_artifacts() -> tuple[list[Path], list[Path], list[Path], list[
             live_slugs.add(slug)
         else:
             stale_pids.append(pid_path)
-        pid_files.append(pid_path)
-
-    pid_slugs = {p.stem[len("cozempic_guard_"):] for p in pid_files}
-
-    try:
-        tmp_entries = list(_TMP_DIR.glob("cozempic_guard_*.pid.tmp"))
-    except OSError:
-        tmp_entries = []
     from .spawn_lock import _FRESH_PIDFILE_SECONDS
-    for tmp_path in tmp_entries:
-        if _is_protected_tmp_artifact(tmp_path.name):
-            continue
-        try:
-            if time.time() - tmp_path.stat().st_mtime >= _FRESH_PIDFILE_SECONDS:
-                stale_temps.append(tmp_path)
-        except OSError:
-            continue
+    stale_temps = [
+        path for path in _glob_tmp_artifacts("cozempic_guard_*.pid.tmp")
+        if not _is_protected_tmp_artifact(path.name)
+        and _is_stale_tmp_artifact(path, _FRESH_PIDFILE_SECONDS)
+    ]
 
-    try:
-        log_entries = list(_TMP_DIR.glob("cozempic_guard_*.log"))
-    except OSError:
-        log_entries = []
-    for log_path in log_entries:
+    for log_path in _glob_tmp_artifacts("cozempic_guard_*.log"):
         if _is_protected_tmp_artifact(log_path.name):
             continue
         slug = log_path.stem[len("cozempic_guard_"):]
         if slug in live_slugs:
             continue  # paired with a live guard
-        if slug in pid_slugs:
-            orphan_logs.append(log_path)  # paired with a stale .pid — delete together
-        else:
-            orphan_logs.append(log_path)  # no pid file at all — orphan
+        orphan_logs.append(log_path)  # paired with stale/no .pid — delete together
 
-    try:
-        lock_entries = list(_TMP_DIR.glob("cozempic_hook_*.lock"))
-    except OSError:
-        lock_entries = []
-    for lock_path in lock_entries:
-        if _is_protected_tmp_artifact(lock_path.name):
-            continue
-        if not _is_lock_held(lock_path):
-            orphan_locks.append(lock_path)
-
-    try:
-        reclaim_entries = list(_TMP_DIR.glob("cozempic_guard_*.pid.reclaim-lock"))
-    except OSError:
-        reclaim_entries = []
-    for lock_path in reclaim_entries:
-        if _is_protected_tmp_artifact(lock_path.name):
-            continue
-        if not _is_lock_held(lock_path):
-            orphan_locks.append(lock_path)
+    orphan_locks = [
+        *_unheld_lock_artifacts("cozempic_hook_*.lock"),
+        *_unheld_lock_artifacts("cozempic_guard_*.pid.reclaim-lock"),
+    ]
 
     return stale_pids, stale_temps, orphan_logs, orphan_locks
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -771,7 +771,9 @@ def start_guard(
     # Record PID + start_time NOW — earliest point where both claude_pid and
     # session_id are known and Claude's identity is confirmed by find_claude_pid.
     if claude_pid:
-        _record_claude_identity(sess["session_id"], claude_pid)
+        _record_claude_identity(
+            sess["session_id"], claude_pid, session_path=session_path
+        )
     claude_alive = True
 
     prune_count = 0
@@ -3655,8 +3657,6 @@ def start_guard_daemon(
                 if log_dir:
                     os.makedirs(log_dir, exist_ok=True)
                 lf = _open_guard_log(log_file)
-            artifact = "pidfile"
-
             try:
                 from datetime import datetime
                 lf.write(f"\n--- Guard daemon started at {datetime.now().isoformat()} ---\n")
@@ -3693,12 +3693,15 @@ def start_guard_daemon(
                 stale_tmp_path = pid_path.with_suffix(".pid.tmp")
                 if stale_tmp_path.is_symlink() or stale_tmp_path.exists():
                     stale_tmp_path.unlink(missing_ok=True)
+                artifact = "pidfile"
                 _tmp_fd, tmp_name = tempfile.mkstemp(
                     prefix=f"{pid_path.name}.", suffix=".tmp", dir=pid_path.parent
                 )
                 tmp_path = Path(tmp_name)
                 try:
+                    artifact = "guard subprocess"
                     proc = subprocess.Popen(cmd_parts, **popen_kwargs)
+                    artifact = "pidfile"
                 except BaseException:
                     os.close(_tmp_fd)
                     tmp_path.unlink(missing_ok=True)
@@ -3973,13 +3976,15 @@ def _get_pid_start_time(pid: int) -> float | None:
     return _get_pid_start_time_psutil(pid)
 
 
-def _record_claude_identity(session_id: str, pid: int) -> None:
+def _record_claude_identity(
+    session_id: str, pid: int, session_path: Path | None = None
+) -> None:
     """Record (pid, start_time) for the anti-recycling gate. Call once at startup.
 
     Validates pid is actually Claude (argv check) before recording — defense
     in depth in case a future caller bypasses find_claude_pid's identity gate.
     """
-    if not _is_claude_process(pid):
+    if not _is_claude_process(pid, session_path=session_path):
         return
     start_time = _get_pid_start_time(pid)
     if start_time is not None and session_id:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3718,19 +3718,11 @@ def start_guard_daemon(
                     )
                 else:
                     popen_kwargs["start_new_session"] = True
-                # Reserve the publication path before spawning. A fresh temp
-                # file may belong to a peer; an old regular file is a crashed
-                # spawn reservation and can be reclaimed safely.
+                # The exclusive PID claim above means any leftover publication
+                # temp belongs to a previous failed spawn, never a live peer.
                 tmp_path = pid_path.with_suffix(".pid.tmp")
-                from .spawn_lock import _FRESH_PIDFILE_SECONDS
-                if tmp_path.is_symlink():
+                if tmp_path.is_symlink() or tmp_path.exists():
                     tmp_path.unlink(missing_ok=True)
-                elif tmp_path.exists():
-                    try:
-                        if time.time() - tmp_path.stat().st_mtime >= _FRESH_PIDFILE_SECONDS:
-                            tmp_path.unlink(missing_ok=True)
-                    except OSError:
-                        pass
                 _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
                 if hasattr(os, "O_NOFOLLOW"):
                     _tmp_flags |= os.O_NOFOLLOW
@@ -3754,10 +3746,9 @@ def start_guard_daemon(
             # O_NOFOLLOW) instead of Path.write_text. The default write_text
             # follows symlinks — an attacker who pre-plants the .pid.tmp
             # path as a symlink to ~/.zshrc or ~/.ssh/authorized_keys would
-            # have the file overwritten with the PID number. O_EXCL also
-            # surfaces orphan .pid.tmp files (from a prior SIGKILLed spawn)
-            # as a FileExistsError instead of silently truncating them,
-            # which closes a re-attack window in CRIT C3.
+            # have the file overwritten with the PID number. Leftovers are
+            # reclaimed only after this process owns the PID-file claim, and
+            # O_EXCL closes the unlink-to-open re-attack window.
             # CRIT C3 fix: catch ANY exception (not just OSError) around
             # the write+rename block. A SIGINT/InterruptedError or other
             # non-OSError between write_text and rename used to leak the
@@ -4269,6 +4260,7 @@ def reload_self_daemon(
         protect_patterns=protect_patterns,
     )
     result = start_guard_daemon(**daemon_args)
+    orphaned_pid = result.get("orphaned_pid")
     if not result.get("started") and not result.get("already_running"):
         time.sleep(1)
         # Only clear a pid file we know is stale (pointing at a dead pid).
@@ -4292,6 +4284,7 @@ def reload_self_daemon(
         except (ValueError, OSError):
             pid_path.unlink(missing_ok=True)
         result = start_guard_daemon(**daemon_args)
+        orphaned_pid = orphaned_pid or result.get("orphaned_pid")
 
     reloaded = bool(result.get("started") or result.get("already_running"))
     if reloaded:
@@ -4304,6 +4297,7 @@ def reload_self_daemon(
         "old_pid": old_pid,
         "new_pid": result.get("pid"),
         "log_file": result.get("log_file"),
+        "orphaned_pid": orphaned_pid,
         "reason": reason,
     }
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3718,16 +3718,24 @@ def start_guard_daemon(
                     )
                 else:
                     popen_kwargs["start_new_session"] = True
-                # Reserve the publication path before spawning. A pre-existing
-                # temp file must fail before a detached child can be orphaned.
+                # Reserve the publication path before spawning. A fresh temp
+                # file may belong to a peer; an old regular file is a crashed
+                # spawn reservation and can be reclaimed safely.
                 tmp_path = pid_path.with_suffix(".pid.tmp")
+                from .spawn_lock import _FRESH_PIDFILE_SECONDS
+                if tmp_path.exists() and not tmp_path.is_symlink():
+                    try:
+                        if time.time() - tmp_path.stat().st_mtime >= _FRESH_PIDFILE_SECONDS:
+                            tmp_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
                 _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
                 if hasattr(os, "O_NOFOLLOW"):
                     _tmp_flags |= os.O_NOFOLLOW
                 _tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
                 try:
                     proc = subprocess.Popen(cmd_parts, **popen_kwargs)
-                except Exception:
+                except BaseException:
                     os.close(_tmp_fd)
                     tmp_path.unlink(missing_ok=True)
                     raise
@@ -3802,7 +3810,7 @@ def start_guard_daemon(
                     # Some filesystems (network FS, tmpfs on certain
                     # kernels) reject directory fsync — best-effort.
                     pass
-            except Exception:
+            except BaseException:
                 # Unlink any partial .pid.tmp we may have created so a
                 # retry can succeed. unlink is symlink-safe (operates on
                 # the directory entry, not the symlink target).

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -552,11 +552,11 @@ def _make_sigterm_handler(session_id, session_path, overflow_watcher):
             if overflow_watcher:
                 try:
                     overflow_watcher.stop()
-                except BaseException:
+                except (Exception, KeyboardInterrupt):
                     pass
             try:
                 _safe_unlink_session_pidfile(session_id)
-            except BaseException:
+            except (Exception, KeyboardInterrupt):
                 pass
             try:
                 clear_armed(session_id, session_path)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -193,6 +193,7 @@ def _hard_prune_counts_as_futile(result: dict) -> bool:
 from ._validation import ConfigError
 from .executor import run_prescription
 from .helpers import (
+    atomic_write_text,
     hashable_str,
     _pid_is_alive as _pid_is_alive_canonical,
     is_ssh_session,
@@ -2198,7 +2199,9 @@ def _wait_for_exit(pid: int, timeout: float = 5.0) -> bool:
         try:
             os.kill(pid, 0)
             time.sleep(0.2)
-        except (ProcessLookupError, PermissionError, OSError):
+        except PermissionError:
+            return False
+        except (ProcessLookupError, OSError):
             return True
     return False
 
@@ -3171,15 +3174,7 @@ def _write_armed_atomic(path: Path, data: dict) -> None:
     the nudge process — which both write it — can't tear each other's writes. The
     temp is always cleaned up (no .tmp orphan on a write/replace failure)."""
     import json as _json
-    tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
-    try:
-        tmp.write_text(_json.dumps(data))
-        os.replace(tmp, path)
-    finally:
-        try:
-            tmp.unlink(missing_ok=True)  # no-op after a successful replace
-        except Exception:
-            pass
+    atomic_write_text(path, _json.dumps(data))
 
 
 def write_armed(session_id, session_path, tier: int, projected_pct: float) -> None:
@@ -3267,19 +3262,7 @@ def _reload_rate_exceeded(ledger_path: Path, now: float | None = None) -> tuple[
         return True, len(hist)
     hist.append(now)
     try:
-        # Atomic write (tmp + os.replace): a SIGKILL mid-write leaves a stale
-        # .tmp rather than a partial ledger, preventing the `except Exception:
-        # hist = []` silent reset that would clear the storm-guard count.
-        # Mirrors _write_armed_atomic (guard.py:2780) — same pattern, string payload.
-        _tmp = ledger_path.with_suffix(ledger_path.suffix + f".tmp{os.getpid()}")
-        try:
-            _tmp.write_text(_json.dumps(hist[-_RELOAD_LEDGER_HIST_CAP:]))
-            os.replace(_tmp, ledger_path)
-        finally:
-            try:
-                _tmp.unlink(missing_ok=True)  # no-op after a successful replace
-            except Exception:
-                pass
+        atomic_write_text(ledger_path, _json.dumps(hist[-_RELOAD_LEDGER_HIST_CAP:]))
     except Exception:
         pass
     return False, len(hist)
@@ -3388,82 +3371,30 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
         return None
     try:
         # Tolerant parse: handles both legacy 1-line and new 3-line
-        # pidfile formats (PR #93 item #5). Returns 0 on garbled/empty
-        # content — caller's `if pid <= 0` branch then unlinks the stale
-        # file. Replaces `int(read_text().strip())` which would raise
-        # ValueError on 3-line content and (via the except below) skip
-        # the unlink, leaking the stale file.
+        # pidfile formats (PR #93 item #5). This probe never unlinks a
+        # pidfile: a peer can create its exclusive claim between a stale
+        # observation and an unlink. DaemonSpawnClaim owns serialized stale
+        # recovery immediately before any new spawn.
         from .spawn_lock import _parse_pidfile_pid
         pid = _parse_pidfile_pid(pid_path)
         if pid <= 0:
-            # A peer can have created the exclusive claim but not written
-            # its parent PID yet. Keep a fresh unreadable/empty claim so a
-            # concurrent probe cannot delete the peer's single-flight lock.
-            from .spawn_lock import _FRESH_PIDFILE_SECONDS
-            try:
-                age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
-            except OSError:
-                age = 0.0
-            if age >= _FRESH_PIDFILE_SECONDS:
-                pid_path.unlink(missing_ok=True)
             return None
         os.kill(pid, 0)
         # Verify the PID is actually our guard — defend against PID reuse.
         if not _is_cozempic_guard_process(pid):
-            # Don't eagerly unlink a fresh-looking pidfile here. A peer
-            # process that just did O_CREAT|O_EXCL in DaemonSpawnClaim has
-            # written its own parent PID into the file BEFORE renaming to
-            # the daemon PID; in that brief window the holding PID is a
-            # legitimate Python process that isn't yet a cozempic guard.
-            # Treating it as PID-reuse and unlinking would destroy the
-            # peer's claim and let multiple workers spawn. Only unlink
-            # truly old pidfiles — those are real PID-reuse or genuine
-            # stale state from a crashed prior spawn. The threshold is
-            # shared with ``DaemonSpawnClaim._is_pidfile_fresh`` so both
-            # sides of the claim/probe dichotomy agree on what "fresh"
-            # means (H1 fix — single source of truth).
-            from .spawn_lock import _FRESH_PIDFILE_SECONDS
-            try:
-                age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
-            except OSError:
-                age = 0.0
-            if age >= _FRESH_PIDFILE_SECONDS:
-                pid_path.unlink(missing_ok=True)
             return None
         return pid
-    except (ValueError, ProcessLookupError, PermissionError):
-        # Apparently dead PID — but a freshly-written pidfile that holds
-        # the soon-to-exist daemon PID can momentarily look "dead" while
-        # the daemon is still starting (a real Popen returns the child
-        # PID before the OS finishes wiring up the process; test mocks
-        # use fake PIDs that are never alive). Only unlink truly old
-        # pidfiles to avoid destroying a peer's just-completed claim
-        # and letting another worker spawn a duplicate daemon. Same
-        # threshold as the holder-alive-but-not-guard branch above.
-        from .spawn_lock import _FRESH_PIDFILE_SECONDS
-        try:
-            age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
-        except OSError:
-            age = 0.0
-        if age >= _FRESH_PIDFILE_SECONDS:
-            pid_path.unlink(missing_ok=True)
+    except PermissionError:
+        return pid
+    except (ValueError, ProcessLookupError):
         return None
     except OSError:
         # Windows: os.kill(pid, 0) raises a bare OSError [WinError 87]
         # (invalid parameter) for a non-existent PID instead of the POSIX
-        # ProcessLookupError caught above. Treat it as a dead PID, reusing the
-        # same freshness-aware unlink so we don't destroy a peer's just-written
-        # claim. Re-raise on POSIX, where a bare OSError here is unexpected and
-        # must not be silently masked.
+        # ProcessLookupError caught above. Treat it as dead without mutating
+        # the path; DaemonSpawnClaim serializes stale recovery before spawn.
         if os.name != "nt":
             raise
-        from .spawn_lock import _FRESH_PIDFILE_SECONDS
-        try:
-            age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
-        except OSError:
-            age = 0.0
-        if age >= _FRESH_PIDFILE_SECONDS:
-            pid_path.unlink(missing_ok=True)
         return None
 
 
@@ -3741,13 +3672,13 @@ def start_guard_daemon(
                     popen_kwargs["start_new_session"] = True
                 # The exclusive PID claim above means any leftover publication
                 # temp belongs to a previous failed spawn, never a live peer.
-                tmp_path = pid_path.with_suffix(".pid.tmp")
-                if tmp_path.is_symlink() or tmp_path.exists():
-                    tmp_path.unlink(missing_ok=True)
-                _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
-                if hasattr(os, "O_NOFOLLOW"):
-                    _tmp_flags |= os.O_NOFOLLOW
-                _tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
+                stale_tmp_path = pid_path.with_suffix(".pid.tmp")
+                if stale_tmp_path.is_symlink() or stale_tmp_path.exists():
+                    stale_tmp_path.unlink(missing_ok=True)
+                _tmp_fd, tmp_name = tempfile.mkstemp(
+                    prefix=f"{pid_path.name}.", suffix=".tmp", dir=pid_path.parent
+                )
+                tmp_path = Path(tmp_name)
                 try:
                     proc = subprocess.Popen(cmd_parts, **popen_kwargs)
                 except BaseException:
@@ -3763,13 +3694,9 @@ def start_guard_daemon(
             # rename see either the parent PID (alive) or the daemon PID
             # (alive). Never empty, never "0", never partial.
             #
-            # CRIT C1 fix: open the .pid.tmp via os.open(O_CREAT|O_EXCL|
-            # O_NOFOLLOW) instead of Path.write_text. The default write_text
-            # follows symlinks — an attacker who pre-plants the .pid.tmp
-            # path as a symlink to ~/.zshrc or ~/.ssh/authorized_keys would
-            # have the file overwritten with the PID number. Leftovers are
-            # reclaimed only after this process owns the PID-file claim, and
-            # O_EXCL closes the unlink-to-open re-attack window.
+            # Use a unique mkstemp reservation rather than a deterministic
+            # .pid.tmp path: it cannot collide with a peer or follow a planted
+            # symlink, and os.replace publishes it atomically.
             # CRIT C3 fix: catch ANY exception (not just OSError) around
             # the write+rename block. A SIGINT/InterruptedError or other
             # non-OSError between write_text and rename used to leak the
@@ -4293,11 +4220,11 @@ def reload_self_daemon(
         pid_path = _pid_file_for_session(session_id)
         try:
             if pid_path.exists():
-                from .spawn_lock import _parse_pidfile_pid
+                from .spawn_lock import _parse_pidfile_pid, pidfile_is_fresh
                 stale_pid = _parse_pidfile_pid(pid_path)
                 if stale_pid <= 0:
-                    # Garbled or empty — treat as stale and unlink.
-                    pid_path.unlink(missing_ok=True)
+                    if not pidfile_is_fresh(pid_path):
+                        pid_path.unlink(missing_ok=True)
                     stale_pid = 0
                 try:
                     if stale_pid > 0:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1886,7 +1886,7 @@ def guard_prune_cycle(
             _write_holder["error"] = "conflict"
             print(f"  [{_now()}] Deferred prune write skipped — {exc}", file=sys.stderr)
             _repair_after_terminate()
-        except OSError as exc:
+        except (OSError, KeyboardInterrupt) as exc:
             _write_holder["error"] = "oserror"
             # Disk-full / EIO / permission at the post-kill write instant. The
             # write is atomic (save_messages leaves the original intact on any

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3192,6 +3192,7 @@ def read_armed(session_id: str | None, session_path: Path | None = None) -> dict
             if key in armed and (
                 isinstance(armed[key], bool)
                 or not isinstance(armed[key], (int, float))
+                or not math.isfinite(armed[key])
             ):
                 armed.pop(key)
         if "warned" in armed and not isinstance(armed["warned"], bool):
@@ -3575,6 +3576,29 @@ def start_guard_daemon(
         log_file = _guard_tmp_root() / f"cozempic_guard_{pid_key}.log"
         pid_path = _guard_tmp_root() / f"cozempic_guard_{pid_key}.pid"
 
+    # A failed PID handoff can leave a detached child alive without a pidfile.
+    # Preserve that child as an in-flight daemon until it exits rather than
+    # letting a later hook invocation start a duplicate.
+    orphan_prefix = f"{pid_path.with_suffix('').name}.orphan."
+    try:
+        for orphan_marker in pid_path.parent.glob(f"{orphan_prefix}*"):
+            try:
+                orphan_pid = int(orphan_marker.name[len(orphan_prefix):])
+            except ValueError:
+                orphan_marker.unlink(missing_ok=True)
+                continue
+            if _pid_is_alive(orphan_pid) and _is_cozempic_guard_process(orphan_pid):
+                return {
+                    "started": False,
+                    "pid": orphan_pid,
+                    "pid_file": str(pid_path),
+                    "log_file": None,
+                    "already_running": True,
+                }
+            orphan_marker.unlink(missing_ok=True)
+    except OSError:
+        pass
+
     if claude_pid is None:
         claude_pid = find_claude_pid()
 
@@ -3815,6 +3839,19 @@ def start_guard_daemon(
                     try:
                         record_orphan(orphaned_guard_pid)
                     except OSError:
+                        pass
+                    try:
+                        from .spawn_lock import INIT_SPAWN_DAEMON
+                        from datetime import datetime as _dt
+
+                        atomic_write_text(
+                            pid_path,
+                            f"{orphaned_guard_pid}\n"
+                            f"{_dt.now().isoformat(timespec='seconds')}\n"
+                            f"{INIT_SPAWN_DAEMON}\n",
+                        )
+                        claim.handed_off = True
+                    except Exception:
                         pass
                     print(
                         f"  Cozempic: guard PID {orphaned_guard_pid} may still be running; "
@@ -4203,6 +4240,16 @@ def reload_self_daemon(
     if not old_pid:
         return {"reloaded": False, "reason": "no daemon running for session"}
 
+    def refuse_replacement(reason: str) -> dict:
+        return {
+            "reloaded": False,
+            "old_pid": old_pid,
+            "new_pid": None,
+            "log_file": None,
+            "orphaned_pid": None,
+            "reason": reason,
+        }
+
     # Verify the PID is actually our daemon — defend against PID reuse.
     if not _is_cozempic_guard_process(old_pid):
         # Stale pid file pointing at a recycled (non-cozempic) PID. Clear it
@@ -4214,10 +4261,14 @@ def reload_self_daemon(
     else:
         try:
             os.kill(old_pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
+        except ProcessLookupError:
             if _pid_file_points_to(session_id, old_pid):
                 _pid_file_for_session(session_id).unlink(missing_ok=True)
             old_pid = None
+        except PermissionError:
+            return refuse_replacement(
+                "existing daemon cannot be signaled; refusing to start a second daemon"
+            )
 
         if old_pid is not None and not _wait_for_exit(old_pid, timeout=10.0):
             # Didn't exit on SIGTERM — escalate, but only if we still see our
@@ -4226,10 +4277,18 @@ def reload_self_daemon(
             if _is_cozempic_guard_process(old_pid):
                 try:
                     os.kill(old_pid, signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
-                    pass
+                except ProcessLookupError:
+                    old_pid = None
+                except PermissionError:
+                    return refuse_replacement(
+                        "existing daemon cannot be killed; refusing to start a second daemon"
+                    )
+            if old_pid is not None and not _wait_for_exit(old_pid, timeout=10.0):
+                return refuse_replacement(
+                    "existing daemon did not exit after SIGKILL; refusing to start a second daemon"
+                )
             # CAS unlink — don't wipe a fresh pid file from a concurrent spawn
-            if _pid_file_points_to(session_id, old_pid):
+            if old_pid is not None and _pid_file_points_to(session_id, old_pid):
                 _pid_file_for_session(session_id).unlink(missing_ok=True)
         elif old_pid is not None:
             # Clean exit. CAS unlink — if a concurrent SessionStart hook
@@ -4278,8 +4337,10 @@ def reload_self_daemon(
                         os.kill(stale_pid, 0)
                     # Still alive — leave the pid file alone and let
                     # start_guard_daemon below return already_running.
-                except (ProcessLookupError, PermissionError):
+                except ProcessLookupError:
                     pid_path.unlink(missing_ok=True)
+                except PermissionError:
+                    pass
         except (ValueError, OSError):
             pid_path.unlink(missing_ok=True)
         result = start_guard_daemon(**daemon_args)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2667,7 +2667,7 @@ def _open_guard_log(log_file: Path):
         flags |= os.O_NOFOLLOW
     fd = os.open(str(log_file), flags, 0o600)
     try:
-        return os.fdopen(fd, "a", encoding="utf-8")
+        return os.fdopen(fd, "a", encoding="utf-8", errors="surrogateescape")
     except BaseException:
         os.close(fd)
         raise

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2659,6 +2659,19 @@ def _guard_tmp_root() -> Path:
     return Path("/tmp")
 
 
+def _open_guard_log(log_file: Path):
+    """Open a guard log without following a planted symlink."""
+    flags = os.O_CREAT | os.O_APPEND | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(log_file), flags, 0o600)
+    try:
+        return os.fdopen(fd, "a", encoding="utf-8")
+    except BaseException:
+        os.close(fd)
+        raise
+
+
 # ── Cross-respawn reload-rate ledger (regrow-loop / reload-storm backstop) ────
 # A confirmed prune that frees real bytes but leaves the session destined to
 # re-hit the HARD threshold reloads, exits the daemon, and a fresh guard
@@ -3385,7 +3398,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
             return None
         return pid
     except PermissionError:
-        return pid
+        return pid if _is_cozempic_guard_process(pid) else None
     except (ValueError, ProcessLookupError):
         return None
     except OSError:
@@ -3632,12 +3645,12 @@ def start_guard_daemon(
             # mid-spawn (race with operator cleanup, /tmp eviction, etc.)
             # recreate it once and retry the open.
             try:
-                lf = open(log_file, "a", encoding="utf-8")
+                lf = _open_guard_log(log_file)
             except FileNotFoundError:
                 log_dir = os.path.dirname(str(log_file))
                 if log_dir:
                     os.makedirs(log_dir, exist_ok=True)
-                lf = open(log_file, "a", encoding="utf-8")
+                lf = _open_guard_log(log_file)
 
             try:
                 from datetime import datetime

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -1396,6 +1396,12 @@ def start_guard(
             _safe_unlink_session_pidfile(sess["session_id"])
         except Exception:
             pass
+        # A daemon that exits through a normal loop path must not leave an
+        # armed reload from an earlier turn for its successor to trust.
+        try:
+            clear_armed(sess["session_id"], session_path)
+        except Exception:
+            pass
 
 
 def _detect_interactive(claude_pid: int | None) -> bool:
@@ -3637,6 +3643,22 @@ def start_guard_daemon(
             "already_running": False,
         }
 
+    orphan_marker = pid_path.with_suffix(".orphan")
+
+    def record_orphan(pid: int) -> None:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{orphan_marker.name}.", suffix=".tmp", dir=orphan_marker.parent
+        )
+        try:
+            os.write(fd, f"{pid}\n".encode("ascii"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        try:
+            os.replace(tmp_name, orphan_marker)
+        finally:
+            Path(tmp_name).unlink(missing_ok=True)
+
     try:
         orphaned_guard_pid: int | None = None
         # Build the guard command
@@ -3823,6 +3845,10 @@ def start_guard_daemon(
                 except (AttributeError, OSError):
                     orphaned_guard_pid = proc.pid
                 if orphaned_guard_pid is not None:
+                    try:
+                        record_orphan(orphaned_guard_pid)
+                    except OSError:
+                        pass
                     print(
                         f"  Cozempic: guard PID {orphaned_guard_pid} may still be running; "
                         "stop it manually.",

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3316,7 +3316,11 @@ def _cleanup_legacy_pid(cwd: str) -> None:
     legacy = _pid_file_for_cwd(cwd)
     if legacy.exists():
         try:
-            pid = int(legacy.read_text().strip())
+            from .spawn_lock import _parse_pidfile_pid
+
+            pid = _parse_pidfile_pid(legacy)
+            if pid <= 0:
+                raise ValueError("invalid legacy pidfile")
             os.kill(pid, 0)
             # Only SIGTERM if we can confirm this is actually our daemon.
             if _is_cozempic_guard_process(pid):
@@ -3639,9 +3643,11 @@ def start_guard_daemon(
         # structured `{started: False, reason: ...}`. The claim's
         # __exit__ will unlink the PID file on exception, so a retry is
         # possible.
-        # Defense-in-depth: if the log file's parent dir was removed mid-spawn
-        # (race with operator cleanup, /tmp eviction, etc.), recreate it once.
         try:
+            artifact = "log file"
+            # Defense-in-depth: if the log file's parent dir was removed
+            # mid-spawn (race with operator cleanup, /tmp eviction, etc.)
+            # recreate it once and retry the open.
             try:
                 lf = _open_guard_log(log_file)
             except FileNotFoundError:
@@ -3649,17 +3655,7 @@ def start_guard_daemon(
                 if log_dir:
                     os.makedirs(log_dir, exist_ok=True)
                 lf = _open_guard_log(log_file)
-        except OSError as exc:
-            return {
-                "started": False,
-                "reason": f"log file: {exc}",
-                "pid": None,
-                "pid_file": str(pid_path),
-                "log_file": None,
-                "already_running": False,
-            }
-
-        try:
+            artifact = "pidfile"
 
             try:
                 from datetime import datetime
@@ -3818,7 +3814,7 @@ def start_guard_daemon(
             return {
                 "started": False,
                 "reason": (
-                    f"pidfile: {exc}"
+                    f"{artifact}: {exc}"
                     + (f"; guard PID {orphaned_guard_pid} may still be running"
                        if orphaned_guard_pid is not None else "")
                 ),
@@ -4264,7 +4260,8 @@ def reload_self_daemon(
     if reloaded:
         reason = "ok"
     else:
-        reason = "could not start fresh daemon after retry — session is unprotected"
+        detail = result.get("reason", "unknown failure")
+        reason = f"could not start fresh daemon after retry — session is unprotected ({detail})"
 
     return {
         "reloaded": reloaded,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -552,11 +552,11 @@ def _make_sigterm_handler(session_id, session_path, overflow_watcher):
             if overflow_watcher:
                 try:
                     overflow_watcher.stop()
-                except Exception:
+                except BaseException:
                     pass
             try:
                 _safe_unlink_session_pidfile(session_id)
-            except Exception:
+            except BaseException:
                 pass
             try:
                 clear_armed(session_id, session_path)
@@ -3844,6 +3844,7 @@ def start_guard_daemon(
                        if orphaned_guard_pid is not None else "")
                 ),
                 "pid": None,
+                "orphaned_pid": orphaned_guard_pid,
                 "pid_file": str(pid_path),
                 "log_file": None,
                 "already_running": False,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3199,7 +3199,7 @@ def _write_armed_atomic(path: Path, data: dict) -> None:
     atomic_write_text(path, _json.dumps(data))
 
 
-def write_armed(session_id, session_path, tier: int, projected_pct: float) -> None:
+def write_armed(session_id, session_path, tier: int, projected_pct: float | None) -> None:
     import time as _time
     try:
         p = _reload_armed_path(session_id, session_path)
@@ -3212,7 +3212,7 @@ def write_armed(session_id, session_path, tier: int, projected_pct: float) -> No
         # the warned-before-reload timeout; keep a known projection if none given.
         warned = bool(existing.get("warned"))
         armed_at = existing.get("armed_at") or _time.time()
-        proj = round(projected_pct, 1) if projected_pct else existing.get("projected_pct", 0.0)
+        proj = round(projected_pct, 1) if projected_pct is not None else existing.get("projected_pct", 0.0)
         _write_armed_atomic(p, {"tier": tier, "projected_pct": proj,
                                 "warned": warned, "armed_at": armed_at})
     except Exception:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -2101,7 +2101,7 @@ def _detect_claude_flags(pid: int) -> str:
     try:
         import psutil
         parts = psutil.Process(pid).cmdline()
-    except (ImportError, Exception):
+    except Exception:
         pass
 
     # Fallback: ps -o args= + shlex.split (loses space-boundary info on macOS).
@@ -3186,7 +3186,12 @@ def read_armed(session_id: str | None, session_path: Path | None = None) -> dict
         p = _reload_armed_path(session_id, session_path)
         text = _read_regular_text(p)
         armed = _json.loads(text) if text is not None else None
-        return armed if isinstance(armed, dict) else None
+        if not isinstance(armed, dict):
+            return None
+        for key in ("armed_at", "tier"):
+            if key in armed and not isinstance(armed[key], (int, float)):
+                armed.pop(key)
+        return armed
     except Exception:
         return None
 
@@ -3819,7 +3824,7 @@ def start_guard_daemon(
             # Tell the claim "we wrote the real PID — leave the file in
             # place on clean exit; the daemon now owns its lifecycle."
             claim.handed_off = True
-        except OSError as exc:
+        except Exception as exc:
             # The .pid.tmp orphan was already cleaned by the inner
             # try/except above; here we only need to surface the failure.
             # The claim's __exit__ will unlink the .pid file because

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -21,6 +21,7 @@ import os
 import platform
 import re
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -2665,8 +2666,12 @@ def _open_guard_log(log_file: Path):
     flags = os.O_CREAT | os.O_APPEND | os.O_WRONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
     fd = os.open(str(log_file), flags, 0o600)
     try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise OSError("guard log is not a regular file")
         return os.fdopen(fd, "a", encoding="utf-8", errors="surrogateescape")
     except BaseException:
         os.close(fd)
@@ -3177,8 +3182,10 @@ def _reload_armed_path(session_id: str | None, session_path: Path | None = None)
 def read_armed(session_id: str | None, session_path: Path | None = None) -> dict | None:
     import json as _json
     try:
+        from .reload_lock import _read_regular_text
         p = _reload_armed_path(session_id, session_path)
-        return _json.loads(p.read_text()) if p.exists() else None
+        text = _read_regular_text(p)
+        return _json.loads(text) if text is not None else None
     except Exception:
         return None
 
@@ -3266,7 +3273,9 @@ def _reload_rate_exceeded(ledger_path: Path, now: float | None = None) -> tuple[
         now = _time.time()
     window = _reload_ledger_window_s()
     try:
-        hist = _json.loads(ledger_path.read_text()) if ledger_path.exists() else []
+        from .reload_lock import _read_regular_text
+        text = _read_regular_text(ledger_path)
+        hist = _json.loads(text) if text is not None else []
         if not isinstance(hist, list):
             hist = []
     except Exception:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3632,6 +3632,15 @@ def start_guard_daemon(
             "log_file": None,
             "already_running": True,
         }
+    except OSError as exc:
+        return {
+            "started": False,
+            "reason": f"pidfile claim: {exc}",
+            "pid": None,
+            "pid_file": str(pid_path),
+            "log_file": None,
+            "already_running": False,
+        }
 
     try:
         # Build the guard command

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3604,17 +3604,12 @@ def start_guard_daemon(
         claude_pid = find_claude_pid()
 
     # ── Cross-process spawn claim (Bug 2 + Bug 3 fix, V4 rework) ────────────
-    # The PID file IS the lock. O_CREAT|O_EXCL on the PID file is the only
-    # primitive used: POSIX guarantees exactly one process wins the create,
-    # all others see EEXIST and become losers via DaemonAlreadyStarting.
-    # This mirrors reload_lock.py:200-262 (same pattern, different file).
+    # The PID file is the fast-path claim: O_CREAT|O_EXCL guarantees exactly
+    # one winner. Stale recovery also takes a persistent companion lock so two
+    # contenders cannot replace the same stale PID file concurrently.
     #
-    # Why not fcntl.flock on a separate sentinel? Race-reproducer's V4 stress
-    # (10 processes × 30 iterations) found a textbook flock-unlink race: when
-    # the holder unlinks the sentinel on release, peers immediately O_CREAT
-    # NEW inodes and their flocks attach to those new inodes — different
-    # kernel objects, so multiple "winners" each acquire flock simultaneously.
-    # See spawn_lock.py module docstring for the full failure mode + evidence.
+    # The companion lock path is never unlinked, avoiding the old flock-unlink
+    # race where contenders could lock separate replacement inodes.
     from .spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim
 
     try:
@@ -3722,7 +3717,19 @@ def start_guard_daemon(
                     )
                 else:
                     popen_kwargs["start_new_session"] = True
-                proc = subprocess.Popen(cmd_parts, **popen_kwargs)
+                # Reserve the publication path before spawning. A pre-existing
+                # temp file must fail before a detached child can be orphaned.
+                tmp_path = pid_path.with_suffix(".pid.tmp")
+                _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+                if hasattr(os, "O_NOFOLLOW"):
+                    _tmp_flags |= os.O_NOFOLLOW
+                _tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
+                try:
+                    proc = subprocess.Popen(cmd_parts, **popen_kwargs)
+                except Exception:
+                    os.close(_tmp_fd)
+                    tmp_path.unlink(missing_ok=True)
+                    raise
             finally:
                 lf.close()
 
@@ -3740,7 +3747,6 @@ def start_guard_daemon(
             # surfaces orphan .pid.tmp files (from a prior SIGKILLed spawn)
             # as a FileExistsError instead of silently truncating them,
             # which closes a re-attack window in CRIT C3.
-            tmp_path = pid_path.with_suffix(".pid.tmp")
             # CRIT C3 fix: catch ANY exception (not just OSError) around
             # the write+rename block. A SIGINT/InterruptedError or other
             # non-OSError between write_text and rename used to leak the
@@ -3748,10 +3754,6 @@ def start_guard_daemon(
             try:
                 from .spawn_lock import INIT_SPAWN_DAEMON
                 from datetime import datetime as _dt
-                _tmp_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
-                if hasattr(os, "O_NOFOLLOW"):
-                    _tmp_flags |= os.O_NOFOLLOW
-                _tmp_fd = os.open(str(tmp_path), _tmp_flags, 0o600)
                 try:
                     # 3-line payload: pid + iso-timestamp + initiator.
                     # Mirrors DaemonSpawnClaim._claim and
@@ -3803,6 +3805,17 @@ def start_guard_daemon(
                 # Unlink any partial .pid.tmp we may have created so a
                 # retry can succeed. unlink is symlink-safe (operates on
                 # the directory entry, not the symlink target).
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    try:
+                        proc.kill()
+                        proc.wait(timeout=5)
+                    except (AttributeError, OSError, subprocess.TimeoutExpired):
+                        pass
+                except (AttributeError, OSError):
+                    pass
                 try:
                     tmp_path.unlink(missing_ok=True)
                 except OSError:

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3185,7 +3185,8 @@ def read_armed(session_id: str | None, session_path: Path | None = None) -> dict
         from .reload_lock import _read_regular_text
         p = _reload_armed_path(session_id, session_path)
         text = _read_regular_text(p)
-        return _json.loads(text) if text is not None else None
+        armed = _json.loads(text) if text is not None else None
+        return armed if isinstance(armed, dict) else None
     except Exception:
         return None
 

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3638,6 +3638,7 @@ def start_guard_daemon(
         }
 
     try:
+        orphaned_guard_pid: int | None = None
         # Build the guard command
         cmd_parts = [
             sys.executable, "-m", "cozempic.cli", "guard",
@@ -3813,9 +3814,15 @@ def start_guard_daemon(
                         proc.kill()
                         proc.wait(timeout=5)
                     except (AttributeError, OSError, subprocess.TimeoutExpired):
-                        pass
+                        orphaned_guard_pid = proc.pid
                 except (AttributeError, OSError):
-                    pass
+                    orphaned_guard_pid = proc.pid
+                if orphaned_guard_pid is not None:
+                    print(
+                        f"  Cozempic: guard PID {orphaned_guard_pid} may still be running; "
+                        "stop it manually.",
+                        file=sys.stderr,
+                    )
                 try:
                     tmp_path.unlink(missing_ok=True)
                 except OSError:
@@ -3831,7 +3838,11 @@ def start_guard_daemon(
             # handed_off is still False, so a retry can re-claim.
             return {
                 "started": False,
-                "reason": f"pidfile: {exc}",
+                "reason": (
+                    f"pidfile: {exc}"
+                    + (f"; guard PID {orphaned_guard_pid} may still be running"
+                       if orphaned_guard_pid is not None else "")
+                ),
                 "pid": None,
                 "pid_file": str(pid_path),
                 "log_file": None,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3188,9 +3188,14 @@ def read_armed(session_id: str | None, session_path: Path | None = None) -> dict
         armed = _json.loads(text) if text is not None else None
         if not isinstance(armed, dict):
             return None
-        for key in ("armed_at", "tier"):
-            if key in armed and not isinstance(armed[key], (int, float)):
+        for key in ("armed_at", "tier", "projected_pct"):
+            if key in armed and (
+                isinstance(armed[key], bool)
+                or not isinstance(armed[key], (int, float))
+            ):
                 armed.pop(key)
+        if "warned" in armed and not isinstance(armed["warned"], bool):
+            armed.pop("warned")
         return armed
     except Exception:
         return None
@@ -4251,7 +4256,11 @@ def reload_self_daemon(
     )
     result = start_guard_daemon(**daemon_args)
     orphaned_pid = result.get("orphaned_pid")
-    if not result.get("started") and not result.get("already_running"):
+    if (
+        not result.get("started")
+        and not result.get("already_running")
+        and orphaned_pid is None
+    ):
         time.sleep(1)
         # Only clear a pid file we know is stale (pointing at a dead pid).
         # Do NOT blindly unlink — a live concurrent daemon may have written it.

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3723,7 +3723,9 @@ def start_guard_daemon(
                 # spawn reservation and can be reclaimed safely.
                 tmp_path = pid_path.with_suffix(".pid.tmp")
                 from .spawn_lock import _FRESH_PIDFILE_SECONDS
-                if tmp_path.exists() and not tmp_path.is_symlink():
+                if tmp_path.is_symlink():
+                    tmp_path.unlink(missing_ok=True)
+                elif tmp_path.exists():
                     try:
                         if time.time() - tmp_path.stat().st_mtime >= _FRESH_PIDFILE_SECONDS:
                             tmp_path.unlink(missing_ok=True)
@@ -3817,10 +3819,14 @@ def start_guard_daemon(
                 try:
                     proc.terminate()
                     proc.wait(timeout=5)
+                except ProcessLookupError:
+                    pass
                 except subprocess.TimeoutExpired:
                     try:
                         proc.kill()
                         proc.wait(timeout=5)
+                    except ProcessLookupError:
+                        pass
                     except (AttributeError, OSError, subprocess.TimeoutExpired):
                         orphaned_guard_pid = proc.pid
                 except (AttributeError, OSError):

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3386,9 +3386,6 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
     except ValueError:
         # Invalid session_id shape — no daemon can exist for it.
         return None
-    if not pid_path.exists():
-        return None
-
     try:
         # Tolerant parse: handles both legacy 1-line and new 3-line
         # pidfile formats (PR #93 item #5). Returns 0 on garbled/empty
@@ -3399,13 +3396,16 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
         from .spawn_lock import _parse_pidfile_pid
         pid = _parse_pidfile_pid(pid_path)
         if pid <= 0:
-            # Pidfile contains a sentinel/placeholder — treat as stale.
-            # Guards against the PID-reuse footgun where os.kill(0, sig)
-            # broadcasts to the caller's process group rather than
-            # targeting a sentinel. Cross-process freshness for in-flight
-            # claims is enforced by DaemonSpawnClaim's O_CREAT|O_EXCL +
-            # _FRESH_PIDFILE_SECONDS gate, not by an in-process dict.
-            pid_path.unlink(missing_ok=True)
+            # A peer can have created the exclusive claim but not written
+            # its parent PID yet. Keep a fresh unreadable/empty claim so a
+            # concurrent probe cannot delete the peer's single-flight lock.
+            from .spawn_lock import _FRESH_PIDFILE_SECONDS
+            try:
+                age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
+            except OSError:
+                age = 0.0
+            if age >= _FRESH_PIDFILE_SECONDS:
+                pid_path.unlink(missing_ok=True)
             return None
         os.kill(pid, 0)
         # Verify the PID is actually our guard — defend against PID reuse.
@@ -3424,7 +3424,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
             # means (H1 fix — single source of truth).
             from .spawn_lock import _FRESH_PIDFILE_SECONDS
             try:
-                age = time.time() - pid_path.stat().st_mtime
+                age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
             except OSError:
                 age = 0.0
             if age >= _FRESH_PIDFILE_SECONDS:
@@ -3442,7 +3442,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
         # threshold as the holder-alive-but-not-guard branch above.
         from .spawn_lock import _FRESH_PIDFILE_SECONDS
         try:
-            age = time.time() - pid_path.stat().st_mtime
+            age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
         except OSError:
             age = 0.0
         if age >= _FRESH_PIDFILE_SECONDS:
@@ -3459,7 +3459,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
             raise
         from .spawn_lock import _FRESH_PIDFILE_SECONDS
         try:
-            age = time.time() - pid_path.stat().st_mtime
+            age = time.time() - os.stat(pid_path, follow_symlinks=False).st_mtime
         except OSError:
             age = 0.0
         if age >= _FRESH_PIDFILE_SECONDS:
@@ -3643,11 +3643,10 @@ def start_guard_daemon(
             "already_running": False,
         }
 
-    orphan_marker = pid_path.with_suffix(".orphan")
-
     def record_orphan(pid: int) -> None:
+        orphan_marker = pid_path.with_suffix(f".orphan.{pid}")
         fd, tmp_name = tempfile.mkstemp(
-            prefix=f".{orphan_marker.name}.", suffix=".tmp", dir=orphan_marker.parent
+            prefix=f"{orphan_marker.name}.", suffix=".tmp", dir=orphan_marker.parent
         )
         try:
             os.write(fd, f"{pid}\n".encode("ascii"))

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -3683,8 +3683,8 @@ def start_guard_daemon(
                     )
                 else:
                     popen_kwargs["start_new_session"] = True
-                # The exclusive PID claim above means any leftover publication
-                # temp belongs to a previous failed spawn, never a live peer.
+                # Reclaim only the legacy deterministic reservation name; the
+                # current mkstemp reservation below is unique per attempt.
                 stale_tmp_path = pid_path.with_suffix(".pid.tmp")
                 if stale_tmp_path.is_symlink() or stale_tmp_path.exists():
                     stale_tmp_path.unlink(missing_ok=True)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -770,8 +770,8 @@ def start_guard(
         claude_pid = find_claude_pid()
     # Record PID + start_time NOW — earliest point where both claude_pid and
     # session_id are known and Claude's identity is confirmed by find_claude_pid.
-    if claude_pid and session_id:
-        _record_claude_identity(session_id, claude_pid)
+    if claude_pid:
+        _record_claude_identity(sess["session_id"], claude_pid)
     claude_alive = True
 
     prune_count = 0
@@ -1017,7 +1017,7 @@ def start_guard(
                         # PID reuse (daemon started hours ago; original Claude exited and
                         # kernel recycled its PID to an unrelated process).
                         try:
-                            if not _pid_identity_match(claude_pid, session_id) \
+                            if not _pid_identity_match(claude_pid, sess["session_id"]) \
                                     or not _is_claude_process(claude_pid, session_path=session_path):
                                 claude_alive = False
                         except ProcessLookupError:
@@ -1025,8 +1025,7 @@ def start_guard(
                     if not claude_alive:
                         print(f"  [{_now()}] Claude process exited (PID {claude_pid}). Final checkpoint...")
                         # Clear start-time record: this session's Claude is gone.
-                        if session_id:
-                            _CLAUDE_IDENTITY.pop(session_id, None)
+                        _CLAUDE_IDENTITY.pop(sess["session_id"], None)
                         # Option (b) defense-in-depth: unlink pidfile IMMEDIATELY so a
                         # concurrent SessionStart for the new Claude doesn't see a stale
                         # transient-daemon slot. The finally-block call is a no-op after
@@ -3640,10 +3639,9 @@ def start_guard_daemon(
         # structured `{started: False, reason: ...}`. The claim's
         # __exit__ will unlink the PID file on exception, so a retry is
         # possible.
+        # Defense-in-depth: if the log file's parent dir was removed mid-spawn
+        # (race with operator cleanup, /tmp eviction, etc.), recreate it once.
         try:
-            # Defense-in-depth: if the log file's parent dir was removed
-            # mid-spawn (race with operator cleanup, /tmp eviction, etc.)
-            # recreate it once and retry the open.
             try:
                 lf = _open_guard_log(log_file)
             except FileNotFoundError:
@@ -3651,6 +3649,17 @@ def start_guard_daemon(
                 if log_dir:
                     os.makedirs(log_dir, exist_ok=True)
                 lf = _open_guard_log(log_file)
+        except OSError as exc:
+            return {
+                "started": False,
+                "reason": f"log file: {exc}",
+                "pid": None,
+                "pid_file": str(pid_path),
+                "log_file": None,
+                "already_running": False,
+            }
+
+        try:
 
             try:
                 from datetime import datetime

--- a/src/cozempic/overflow.py
+++ b/src/cozempic/overflow.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import sys
 import time
 from pathlib import Path
+
+from .helpers import atomic_write_text
 
 
 # ─── Circuit Breaker ─────────────────────────────────────────────────────────
@@ -55,7 +56,7 @@ class CircuitBreaker:
 
     def _save(self, records: list[dict]) -> None:
         try:
-            self.state_path.write_text(json.dumps(records), encoding="utf-8")
+            atomic_write_text(self.state_path, json.dumps(records))
         except OSError:
             pass
 

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -160,8 +160,8 @@ class ReloadLockHeld(Exception):
         )
 
 
-def _read_regular_text(path: Path) -> str | None:
-    """Read a small metadata file without following a symlink."""
+def _read_regular_metadata(path: Path) -> tuple[str, float] | None:
+    """Read small metadata and mtime without following a symlink."""
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -172,13 +172,20 @@ def _read_regular_text(path: Path) -> str | None:
     except OSError:
         return None
     try:
-        if not stat.S_ISREG(os.fstat(fd).st_mode):
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
             return None
-        return os.read(fd, 4096).decode("utf-8")
+        return os.read(fd, 4096).decode("utf-8"), file_stat.st_mtime
     except (OSError, UnicodeDecodeError):
         return None
     finally:
         os.close(fd)
+
+
+def _read_regular_text(path: Path) -> str | None:
+    """Read a small metadata file without following a symlink."""
+    metadata = _read_regular_metadata(path)
+    return metadata[0] if metadata is not None else None
 
 
 def _read_lock_metadata(lock_path: Path) -> tuple[int, str, Optional[float]]:
@@ -517,16 +524,13 @@ def _reload_sentinel_active(session_id: str) -> bool:
     verbose. The docstring makes the side-effect explicit.
     """
     sentinel_path = _reload_sentinel_path_for(session_id)
-    if not sentinel_path.exists():
+    metadata = _read_regular_metadata(sentinel_path)
+    if metadata is None:
         return False
 
     # Use mtime for freshness — tests can manipulate it via os.utime, and it's
     # set atomically by the OS on file write (no parse errors possible).
-    try:
-        age = time.time() - sentinel_path.stat().st_mtime
-    except OSError:
-        # File disappeared between exists() and stat() — treat as absent
-        return False
+    age = time.time() - metadata[1]
 
     if age >= SENTINEL_TTL_SECONDS:
         # Stale — GC it

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import os
 import re
+import stat
 import tempfile
 import time
 from pathlib import Path
@@ -159,16 +160,37 @@ class ReloadLockHeld(Exception):
         )
 
 
+def _read_regular_text(path: Path) -> str | None:
+    """Read a small metadata file without following a symlink."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    try:
+        fd = os.open(str(path), flags)
+    except OSError:
+        return None
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return None
+        return os.read(fd, 4096).decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    finally:
+        os.close(fd)
+
+
 def _read_lock_metadata(lock_path: Path) -> tuple[int, str, Optional[float]]:
     """Parse a lock file. Returns (pid, initiator, age_sec) — best effort.
 
     On any read/parse failure, returns (0, "unknown", None) so the caller
     can decide whether to treat as stale.
     """
-    try:
-        content = lock_path.read_text(encoding="utf-8").strip().split("\n")
-    except OSError:
+    text = _read_regular_text(lock_path)
+    if text is None:
         return 0, "unknown", None
+    content = text.strip().split("\n")
     pid = 0
     initiator = "unknown"
     age = None
@@ -382,10 +404,10 @@ def _read_sentinel_metadata(sentinel_path: Path) -> tuple[int, Optional[float]]:
     whether to treat as stale. Does NOT return the initiator field — callers
     only need pid and age for GC decisions.
     """
-    try:
-        content = sentinel_path.read_text(encoding="utf-8").strip().split("\n")
-    except OSError:
+    text = _read_regular_text(sentinel_path)
+    if text is None:
         return 0, None
+    content = text.strip().split("\n")
     pid = 0
     age = None
     if len(content) >= 1:

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -369,6 +369,12 @@ class DaemonSpawnClaim:
                 f"{INIT_SPAWN_PARENT}\n"
             )
             os.write(fd, payload.encode("utf-8"))
+        except Exception:
+            try:
+                self.pid_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
         finally:
             os.close(fd)
         self.owned = True

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -137,6 +137,17 @@ def _read_fresh_window_seconds() -> float:
 _FRESH_PIDFILE_SECONDS = _read_fresh_window_seconds()
 
 
+def pidfile_is_fresh(pid_file: Path) -> bool:
+    """Return whether a PID claim is still within its protected handoff window."""
+    try:
+        mtime = os.stat(pid_file, follow_symlinks=False).st_mtime
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return (time.time() - mtime) < _FRESH_PIDFILE_SECONDS
+
+
 # Initiator strings — mirrored from ``reload_lock.INIT_*`` conventions
 # for operator-triage parity. The parent-vs-daemon split is the only
 # meaningful distinction for spawn-claim payloads:
@@ -452,15 +463,7 @@ class DaemonSpawnClaim:
         Other OSErrors (ENOENT — file vanished between exists() and
         stat() — most likely) return False so we can re-claim cleanly.
         """
-        try:
-            mtime = os.stat(self.pid_file, follow_symlinks=False).st_mtime
-        except PermissionError:
-            # EACCES: can't read mtime → assume fresh (don't race a
-            # potentially-live peer claim).
-            return True
-        except OSError:
-            return False
-        return (time.time() - mtime) < _FRESH_PIDFILE_SECONDS
+        return pidfile_is_fresh(self.pid_file)
 
     def _read_existing_pid(self) -> int:
         """Best-effort read of the PID currently in the file.

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -411,7 +411,7 @@ class DaemonSpawnClaim:
                 f"{INIT_SPAWN_PARENT}\n"
             )
             os.write(fd, payload.encode("utf-8"))
-        except Exception:
+        except BaseException:
             try:
                 self.pid_file.unlink(missing_ok=True)
             except OSError:
@@ -485,4 +485,4 @@ def daemon_spawn_lock(session_id: str) -> Iterator[Path]:
         claim.__exit__(None, None, None)
 
 
-_HAVE_FCNTL = False  # exported for back-compat; we no longer use fcntl
+_HAVE_FCNTL = False  # exported for back-compat; primary claims do not use fcntl

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -30,8 +30,8 @@ reload-side single-flight.
 Lifecycle:
   - On claim (enter): ``O_CREAT|O_EXCL|O_NOFOLLOW`` on the PID file. Loser
     reads the file, returns ``DaemonAlreadyStarting(holder_pid=<read pid>)``.
-    Stale-holder detection: if the read PID is not alive (``kill(pid, 0)``
-    fails), unlink + retry once.
+    Stale-holder detection is serialized by a persistent companion lock before
+    it can unlink + retry, so two contenders cannot reclaim the same file.
   - Inside the claim: caller writes the real daemon PID atomically via
     temp-file + rename (``os.rename`` on same FS is POSIX-atomic). Readers
     transitioning between our parent-PID and the daemon PID observe the OLD
@@ -265,6 +265,42 @@ class DaemonAlreadyStarting(Exception):
         )
 
 
+@contextmanager
+def _stale_reclaim_lock(pid_file: Path) -> Iterator[None]:
+    """Serialize stale-claim replacement without unlinking the lock path."""
+    lock_path = pid_file.with_name(f"{pid_file.name}.reclaim-lock")
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    locked = False
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        locked = True
+        yield
+    finally:
+        if locked:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+        else:
+            os.close(fd)
+
+
 class DaemonSpawnClaim:
     """Atomic PID-file claim via O_CREAT|O_EXCL.
 
@@ -338,22 +374,24 @@ class DaemonSpawnClaim:
         try:
             fd = os.open(str(self.pid_file), flags, 0o600)
         except FileExistsError:
-            holder_pid = self._read_existing_pid()
-            holder_alive = holder_pid > 0 and _is_process_alive(holder_pid)
-            fresh = self._is_pidfile_fresh()
-            if holder_alive or fresh:
-                raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
-            # Stale (dead PID AND old file): unlink and retry exactly once.
-            try:
-                self.pid_file.unlink(missing_ok=True)
-            except OSError:
-                pass
-            try:
-                fd = os.open(str(self.pid_file), flags, 0o600)
-            except FileExistsError:
-                # A peer reclaimed between our unlink and our retry.
-                holder_pid = self._read_existing_pid()
-                raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
+            # A persistent companion lock serializes the stale inspection and
+            # replacement. Unlike the old flock sentinel, this lock path is
+            # never unlinked, so every contender locks the same inode.
+            with _stale_reclaim_lock(self.pid_file):
+                try:
+                    fd = os.open(str(self.pid_file), flags, 0o600)
+                except FileExistsError:
+                    holder_pid = self._read_existing_pid()
+                    holder_alive = holder_pid > 0 and _is_process_alive(holder_pid)
+                    fresh = self._is_pidfile_fresh()
+                    if holder_alive or fresh:
+                        raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
+                    self.pid_file.unlink()
+                    try:
+                        fd = os.open(str(self.pid_file), flags, 0o600)
+                    except FileExistsError:
+                        holder_pid = self._read_existing_pid()
+                        raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
 
         # Won the claim. Write our parent PID + timestamp + initiator
         # so concurrent readers see a real, alive PID (not a placeholder)

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -269,12 +269,16 @@ class DaemonAlreadyStarting(Exception):
 def _stale_reclaim_lock(pid_file: Path) -> Iterator[None]:
     """Serialize stale-claim replacement without unlinking the lock path."""
     lock_path = pid_file.with_name(f"{pid_file.name}.reclaim-lock")
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(lock_path), flags, 0o600)
     locked = False
     try:
         if os.name == "nt":
             import msvcrt
 
+            os.write(fd, b"\0")
             os.lseek(fd, 0, os.SEEK_SET)
             msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
         else:
@@ -386,7 +390,7 @@ class DaemonSpawnClaim:
                     fresh = self._is_pidfile_fresh()
                     if holder_alive or fresh:
                         raise DaemonAlreadyStarting(self.session_id, holder_pid=holder_pid)
-                    self.pid_file.unlink()
+                    self.pid_file.unlink(missing_ok=True)
                     try:
                         fd = os.open(str(self.pid_file), flags, 0o600)
                     except FileExistsError:

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 import math
 import os
 import re
+import stat
 import tempfile
 import time
 from contextlib import contextmanager
@@ -169,10 +170,23 @@ def _parse_pidfile_pid(pid_path: Path) -> int:
     only need line 1 and ``cat`` would feed multi-token output to
     ``kill -0``, which is undefined-behaviour across shells.
     """
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
     try:
-        content = pid_path.read_text()
+        fd = os.open(str(pid_path), flags)
     except OSError:
         return 0
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return 0
+        content = os.read(fd, 4096).decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+    finally:
+        os.close(fd)
     if not content:
         return 0
     lines = content.splitlines()
@@ -439,7 +453,7 @@ class DaemonSpawnClaim:
         stat() — most likely) return False so we can re-claim cleanly.
         """
         try:
-            mtime = self.pid_file.stat().st_mtime
+            mtime = os.stat(self.pid_file, follow_symlinks=False).st_mtime
         except PermissionError:
             # EACCES: can't read mtime → assume fresh (don't race a
             # potentially-live peer claim).

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -217,11 +217,10 @@ class GuardLoopHit:
 
 
 def _read_pid(pid_file: Path) -> int | None:
-    try:
-        first = pid_file.read_text(encoding="utf-8").strip().splitlines()[0]
-        return int(first.strip())
-    except (OSError, ValueError, IndexError):
-        return None
+    from .spawn_lock import _parse_pidfile_pid
+
+    pid = _parse_pidfile_pid(pid_file)
+    return pid if pid > 0 else None
 
 
 def scan_guard_logs(

--- a/src/cozempic/watchdog.py
+++ b/src/cozempic/watchdog.py
@@ -21,7 +21,9 @@ default and only terminates a confirmed-looping daemon under an explicit ``--fix
 
 from __future__ import annotations
 
+import os
 import re
+import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -223,6 +225,35 @@ def _read_pid(pid_file: Path) -> int | None:
     return pid if pid > 0 else None
 
 
+def _read_regular_log_tail(log_file: Path, max_tail_bytes: int) -> str | None:
+    """Read a bounded log tail without following symlinks or blocking on FIFOs."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    try:
+        fd = os.open(str(log_file), flags)
+    except OSError:
+        return None
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            return None
+        offset = max(0, file_stat.st_size - max_tail_bytes)
+        os.lseek(fd, offset, os.SEEK_SET)
+        text = os.read(fd, max_tail_bytes).decode("utf-8", "replace")
+        if offset:
+            _partial, separator, text = text.partition("\n")
+            if not separator:
+                return ""
+        return text
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
 def scan_guard_logs(
     log_dir: str | Path,
     loop_trip: int = LOOP_TRIP_DEFAULT,
@@ -239,14 +270,8 @@ def scan_guard_logs(
     if not log_dir.is_dir():
         return hits
     for log_file in sorted(log_dir.glob("cozempic_guard_*.log")):
-        try:
-            size = log_file.stat().st_size
-            with open(log_file, "r", encoding="utf-8", errors="replace") as fh:
-                if size > max_tail_bytes:
-                    fh.seek(size - max_tail_bytes)
-                    fh.readline()  # discard partial line
-                text = fh.read()
-        except OSError:
+        text = _read_regular_log_tail(log_file, max_tail_bytes)
+        if text is None:
             continue
         rep = scan_log_text(text, loop_trip=loop_trip)
         if not rep.looping:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -411,12 +411,22 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         fix_stale_tmp_artifacts()
         self.assertFalse(temp_path.exists())
 
-    def test_hook_lock_is_protected_when_not_held(self):
-        """A hook mutex remains protected between brief flock acquisitions."""
+    def test_pid_tmp_symlink_is_reported_and_removed(self):
+        victim = self.tmpdir / "victim.txt"
+        victim.write_text("keep")
+        temp_path = self.tmpdir / "cozempic_guard_symlink-04.pid.tmp"
+        os.symlink(victim, temp_path)
+        self.assertIn("pid.tmp", check_stale_tmp_artifacts().message)
+        fix_stale_tmp_artifacts()
+        self.assertFalse(temp_path.exists())
+        self.assertEqual(victim.read_text(), "keep")
+
+    def test_orphan_lock_is_stale_when_not_held(self):
+        """An unheld hook lock is an orphan that doctor may clean."""
         lock_path = self._make_lock_file("oldhook-05")
         with patch("cozempic.doctor._is_lock_held", return_value=False):
             result = check_stale_tmp_artifacts()
-        self.assertEqual(result.status, "ok")
+        self.assertIn(result.status, ("warning", "issue"))
         self.assertTrue(lock_path.exists())
 
     def test_held_lock_is_not_stale(self):
@@ -474,13 +484,11 @@ class TestStaleTmpArtifacts(unittest.TestCase):
             fix_stale_tmp_artifacts()
         self.assertTrue(lock_path.exists())
 
-    def test_fix_preserves_mutex_files(self):
-        hook_lock = self._make_lock_file("persistent-hook-22")
+    def test_fix_preserves_reclaim_lock(self):
         reclaim_lock = self.tmpdir / "cozempic_guard_persistent-22.pid.reclaim-lock"
         reclaim_lock.write_text("")
         with patch("cozempic.doctor._is_lock_held", return_value=False):
             fix_stale_tmp_artifacts()
-        self.assertTrue(hook_lock.exists())
         self.assertTrue(reclaim_lock.exists())
 
     def test_fix_preserves_global_files(self):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -411,13 +411,13 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         fix_stale_tmp_artifacts()
         self.assertFalse(temp_path.exists())
 
-    def test_orphan_lock_is_stale_when_not_held(self):
-        """A .lock file that can be acquired with LOCK_EX|LOCK_NB is orphaned."""
-        self._make_lock_file("oldhook-05")
+    def test_hook_lock_is_protected_when_not_held(self):
+        """A hook mutex remains protected between brief flock acquisitions."""
+        lock_path = self._make_lock_file("oldhook-05")
         with patch("cozempic.doctor._is_lock_held", return_value=False):
             result = check_stale_tmp_artifacts()
-        self.assertIn(result.status, ("warning", "issue"))
-        self.assertIn("lock", result.message.lower())
+        self.assertEqual(result.status, "ok")
+        self.assertTrue(lock_path.exists())
 
     def test_held_lock_is_not_stale(self):
         """A .lock file currently held by another process must be preserved."""
@@ -473,6 +473,15 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         with patch("cozempic.doctor._is_lock_held", return_value=True):
             fix_stale_tmp_artifacts()
         self.assertTrue(lock_path.exists())
+
+    def test_fix_preserves_mutex_files(self):
+        hook_lock = self._make_lock_file("persistent-hook-22")
+        reclaim_lock = self.tmpdir / "cozempic_guard_persistent-22.pid.reclaim-lock"
+        reclaim_lock.write_text("")
+        with patch("cozempic.doctor._is_lock_held", return_value=False):
+            fix_stale_tmp_artifacts()
+        self.assertTrue(hook_lock.exists())
+        self.assertTrue(reclaim_lock.exists())
 
     def test_fix_preserves_global_files(self):
         guard_log = self.tmpdir / "cozempic_guard.log"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -474,6 +474,14 @@ class TestStaleTmpArtifacts(unittest.TestCase):
             result = check_stale_tmp_artifacts()
         self.assertEqual(result.status, "ok")
 
+    def test_lock_probe_is_nonblocking(self):
+        from cozempic.doctor import _is_lock_held
+
+        lock_path = self._make_lock_file("nonblocking-06")
+        with patch("cozempic.doctor.os.open", wraps=os.open) as open_file:
+            _is_lock_held(lock_path)
+        self.assertTrue(open_file.call_args.args[1] & os.O_NONBLOCK)
+
     def test_orphan_marker_is_reported_and_removed_when_guard_is_dead(self):
         marker = self.tmpdir / "cozempic_guard_orphan-06.orphan"
         marker.write_text("999999\n")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -447,6 +447,21 @@ class TestStaleTmpArtifacts(unittest.TestCase):
             result = check_stale_tmp_artifacts()
         self.assertEqual(result.status, "ok")
 
+    def test_orphan_marker_is_reported_and_removed_when_guard_is_dead(self):
+        marker = self.tmpdir / "cozempic_guard_orphan-06.orphan"
+        marker.write_text("999999\n")
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=False):
+            self.assertIn("orphan guard marker", check_stale_tmp_artifacts().message)
+            fix_stale_tmp_artifacts()
+        self.assertFalse(marker.exists())
+
+    def test_orphan_marker_is_preserved_while_guard_is_live(self):
+        marker = self.tmpdir / "cozempic_guard_orphan-07.orphan"
+        marker.write_text("42\n")
+        with patch("cozempic.doctor._is_live_guard_pid", return_value=True):
+            fix_stale_tmp_artifacts()
+        self.assertTrue(marker.exists())
+
     def test_hook_lock_symlink_does_not_touch_its_target(self):
         victim = self.tmpdir / "victim.txt"
         lock_path = self.tmpdir / "cozempic_hook_symlink-06.lock"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -402,14 +402,25 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         self.assertIn("log", result.message.lower())
 
     def test_stale_pid_tmp_is_reported_and_removed(self):
+        from cozempic.doctor import _DOCTOR_PID_TMP_STALE_SECONDS
+
         temp_path = self.tmpdir / "cozempic_guard_staletmp-04.pid.tmp"
         temp_path.write_text("reserved\n")
-        stale_at = time.time() - 10
+        stale_at = time.time() - _DOCTOR_PID_TMP_STALE_SECONDS - 1
         os.utime(temp_path, (stale_at, stale_at))
         result = check_stale_tmp_artifacts()
         self.assertIn("pid.tmp", result.message)
         fix_stale_tmp_artifacts()
         self.assertFalse(temp_path.exists())
+
+    def test_recent_pid_tmp_is_not_reclaimed_during_doctor_fix(self):
+        temp_path = self.tmpdir / "cozempic_guard_slowspawn-04.pid.tmp"
+        temp_path.write_text("reserved\n")
+        stale_at = time.time() - 10
+        os.utime(temp_path, (stale_at, stale_at))
+        self.assertEqual(check_stale_tmp_artifacts().status, "ok")
+        fix_stale_tmp_artifacts()
+        self.assertTrue(temp_path.exists())
 
     def test_pid_tmp_symlink_is_reported_and_removed(self):
         victim = self.tmpdir / "victim.txt"
@@ -435,6 +446,15 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         with patch("cozempic.doctor._is_lock_held", return_value=True):
             result = check_stale_tmp_artifacts()
         self.assertEqual(result.status, "ok")
+
+    def test_hook_lock_symlink_does_not_touch_its_target(self):
+        victim = self.tmpdir / "victim.txt"
+        lock_path = self.tmpdir / "cozempic_hook_symlink-06.lock"
+        os.symlink(victim, lock_path)
+        self.assertEqual(check_stale_tmp_artifacts().status, "ok")
+        self.assertFalse(victim.exists())
+        fix_stale_tmp_artifacts()
+        self.assertTrue(lock_path.is_symlink())
 
     def test_garbage_pid_content_is_treated_as_stale(self):
         """Non-integer .pid file content must not crash — treat as stale."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -462,6 +462,17 @@ class TestStaleTmpArtifacts(unittest.TestCase):
             fix_stale_tmp_artifacts()
         self.assertTrue(marker.exists())
 
+    def test_orphan_marker_symlink_is_removed_without_touching_target(self):
+        victim = self.tmpdir / "victim.txt"
+        victim.write_text("keep")
+        marker = self.tmpdir / "cozempic_guard_orphan-08.orphan.42"
+        os.symlink(victim, marker)
+
+        self.assertIn("orphan guard marker", check_stale_tmp_artifacts().message)
+        fix_stale_tmp_artifacts()
+        self.assertFalse(marker.exists())
+        self.assertEqual(victim.read_text(), "keep")
+
     def test_hook_lock_symlink_does_not_touch_its_target(self):
         victim = self.tmpdir / "victim.txt"
         lock_path = self.tmpdir / "cozempic_hook_symlink-06.lock"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -398,6 +400,16 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         result = check_stale_tmp_artifacts()
         self.assertIn(result.status, ("warning", "issue"))
         self.assertIn("log", result.message.lower())
+
+    def test_stale_pid_tmp_is_reported_and_removed(self):
+        temp_path = self.tmpdir / "cozempic_guard_staletmp-04.pid.tmp"
+        temp_path.write_text("reserved\n")
+        stale_at = time.time() - 10
+        os.utime(temp_path, (stale_at, stale_at))
+        result = check_stale_tmp_artifacts()
+        self.assertIn("pid.tmp", result.message)
+        fix_stale_tmp_artifacts()
+        self.assertFalse(temp_path.exists())
 
     def test_orphan_lock_is_stale_when_not_held(self):
         """A .lock file that can be acquired with LOCK_EX|LOCK_NB is orphaned."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -486,8 +486,17 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         """Non-integer .pid file content must not crash — treat as stale."""
         pid_path = self.tmpdir / "cozempic_guard_badcontent-07.pid"
         pid_path.write_text("not-an-integer")
+        stale_at = time.time() - 61
+        os.utime(pid_path, (stale_at, stale_at))
         result = check_stale_tmp_artifacts()
         self.assertIn(result.status, ("warning", "issue"))
+
+    def test_fresh_empty_pidfile_is_not_reclaimed(self):
+        pid_path = self.tmpdir / "cozempic_guard_fresh-empty.pid"
+        pid_path.touch()
+        self.assertEqual(check_stale_tmp_artifacts().status, "ok")
+        fix_stale_tmp_artifacts()
+        self.assertTrue(pid_path.exists())
 
     def test_threshold_escalation_to_issue(self):
         """Many stale artifacts escalate status from warning to issue."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -413,6 +413,20 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         fix_stale_tmp_artifacts()
         self.assertFalse(temp_path.exists())
 
+    def test_randomized_pid_tmp_is_reported_and_removed(self):
+        from cozempic.doctor import _DOCTOR_PID_TMP_STALE_SECONDS
+
+        fd, tmp_name = tempfile.mkstemp(
+            prefix="cozempic_guard_staletmp-04.pid.", suffix=".tmp", dir=self.tmpdir
+        )
+        os.close(fd)
+        temp_path = Path(tmp_name)
+        stale_at = time.time() - _DOCTOR_PID_TMP_STALE_SECONDS - 1
+        os.utime(temp_path, (stale_at, stale_at))
+        self.assertIn("pid.tmp", check_stale_tmp_artifacts().message)
+        fix_stale_tmp_artifacts()
+        self.assertFalse(temp_path.exists())
+
     def test_recent_pid_tmp_is_not_reclaimed_during_doctor_fix(self):
         temp_path = self.tmpdir / "cozempic_guard_slowspawn-04.pid.tmp"
         temp_path.write_text("reserved\n")
@@ -451,9 +465,16 @@ class TestStaleTmpArtifacts(unittest.TestCase):
         marker = self.tmpdir / "cozempic_guard_orphan-06.orphan"
         marker.write_text("999999\n")
         with patch("cozempic.doctor._is_live_guard_pid", return_value=False):
-            self.assertIn("orphan guard marker", check_stale_tmp_artifacts().message)
+            self.assertIn("PIDs: 999999", check_stale_tmp_artifacts().message)
             fix_stale_tmp_artifacts()
         self.assertFalse(marker.exists())
+
+    def test_zero_pid_is_not_probed_as_a_process_group(self):
+        from cozempic.doctor import _is_live_guard_pid
+
+        with patch("cozempic.doctor.os.kill") as kill:
+            self.assertFalse(_is_live_guard_pid(0))
+        kill.assert_not_called()
 
     def test_orphan_marker_is_preserved_while_guard_is_live(self):
         marker = self.tmpdir / "cozempic_guard_orphan-07.orphan"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -386,6 +386,19 @@ class TestStaleTmpArtifacts(unittest.TestCase):
             result = check_stale_tmp_artifacts()
         self.assertEqual(result.status, "ok")
 
+    def test_daemon_check_uses_runtime_tmpdir(self):
+        """The daemon status check must use the same platform temp root as guards."""
+        from cozempic.doctor import check_cozempic_daemon_running
+
+        self._make_pid_file("livesess-12", 42)
+        with (
+            patch("cozempic.doctor.os.kill"),
+            patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+        ):
+            result = check_cozempic_daemon_running()
+        self.assertEqual(result.status, "ok")
+        self.assertIn("PIDs: 42", result.message)
+
     def test_dead_pid_file_is_stale(self):
         """A .pid file whose PID is no longer a running cozempic guard is stale."""
         self._make_pid_file("deadsess-01", 999999)

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -1468,20 +1468,20 @@ class TestR3_1_PlaceholderPidZeroNeverSignaled(unittest.TestCase):
             f"before the liveness probe.",
         )
 
-    def test_returns_none_and_unlinks_on_placeholder(self):
-        """Positive regression: even after the fix, a placeholder-valued pidfile
-        must still resolve to `None` and be cleaned up."""
+    def test_returns_none_without_unlinking_placeholder(self):
+        """The read-only probe must leave cleanup to DaemonSpawnClaim."""
         from cozempic.guard import _is_guard_running_for_session
 
-        # No mocks — exercise the real path. Must return None AND clean up.
+        # No mocks — exercise the real path. A concurrent claimant may create
+        # the path between the probe and cleanup, so this helper must not unlink.
         result = _is_guard_running_for_session(self.session_id)
         self.assertIsNone(
             result,
             f"placeholder pidfile not resolved to None: {result!r}",
         )
-        self.assertFalse(
+        self.assertTrue(
             self.pid_path.exists(),
-            "placeholder pidfile must be unlinked after read",
+            "read-only probe must not unlink a placeholder pidfile",
         )
 
 

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -100,6 +100,19 @@ class TestG1_CleanupLegacyPidRequiresArgvVerify(unittest.TestCase):
                 "Legacy cleanup failed to SIGTERM a verified guard PID",
             )
 
+    def test_does_not_follow_legacy_pidfile_symlink(self):
+        from cozempic.guard import _cleanup_legacy_pid
+
+        legacy = self._write_legacy_pidfile(0)
+        target = Path(self.tmpdir) / "target.pid"
+        target.write_text("42000")
+        legacy.unlink()
+        legacy.symlink_to(target)
+        with patch("cozempic.guard._is_cozempic_guard_process") as confirmed, patch("cozempic.guard.os.kill") as kill:
+            _cleanup_legacy_pid(self.cwd)
+        confirmed.assert_not_called()
+        kill.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # BUG-G2 — _cleanup_stale_watchers must NOT signal substring-only pgrep matches
@@ -903,35 +916,29 @@ class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def _run_with_os_open_raising(self, errno_code: int):
-        """Invoke start_guard_daemon with a mocked pidfile-write path that
+    def _run_with_reservation_raising(self, errno_code: int):
+        """Invoke start_guard_daemon with a mocked pidfile reservation that
         raises OSError with the given errno. Returns result dict OR
         `{'_raised': exc}` if uncaught.
 
-        After the round-3 rework (C1 fix) the pidfile is written via
-        ``os.open(<pid>.tmp, O_CREAT|O_EXCL|O_NOFOLLOW)`` then
-        ``os.rename``, replacing the prior ``Path.write_text``. The intent
-        of this test is unchanged (graceful surface on any OSError) —
-        only the mock surface moves to the new ``os.open`` call. We have
-        to filter on the .pid.tmp suffix because DaemonSpawnClaim also
-        uses os.open on the pid_path itself; only the post-Popen
-        atomic-rename open should fail.
+        The current publication path reserves a unique tempfile with
+        ``mkstemp`` before the atomic replacement. The test targets that
+        reservation rather than the claim's separate pidfile open.
         """
         from cozempic.guard import start_guard_daemon
 
-        tmp_pidfile_str = str(self.pid_path.with_suffix(".pid.tmp"))
-        real_os_open = os.open
+        real_mkstemp = tempfile.mkstemp
 
-        def fake_os_open(path, flags, *args, **kwargs):
-            if str(path) == tmp_pidfile_str:
+        def fake_mkstemp(*args, **kwargs):
+            if kwargs.get("prefix") == f"{self.pid_path.name}." and kwargs.get("suffix") == ".tmp":
                 raise OSError(errno_code, os.strerror(errno_code))
-            return real_os_open(path, flags, *args, **kwargs)
+            return real_mkstemp(*args, **kwargs)
 
         with (
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard.find_claude_pid", return_value=7777),
             patch("cozempic.guard.subprocess.Popen") as mock_popen,
-            patch("cozempic.guard.os.open", side_effect=fake_os_open),
+            patch("cozempic.guard.tempfile.mkstemp", side_effect=fake_mkstemp),
         ):
             mock_popen.return_value = MagicMock(pid=9999)
             try:
@@ -946,7 +953,7 @@ class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
     def test_enospc_does_not_crash_hook(self):
         """ENOSPC must NOT propagate — return {started: False, reason: ...}."""
         import errno as _errno_mod
-        result = self._run_with_os_open_raising(_errno_mod.ENOSPC)
+        result = self._run_with_reservation_raising(_errno_mod.ENOSPC)
         self.assertNotIn(
             "_raised", result,
             f"ENOSPC propagated uncaught: {result.get('_raised')!r}. "
@@ -965,7 +972,7 @@ class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
     def test_erofs_does_not_crash_hook(self):
         """EROFS (/tmp read-only) must NOT propagate."""
         import errno as _errno_mod
-        result = self._run_with_os_open_raising(_errno_mod.EROFS)
+        result = self._run_with_reservation_raising(_errno_mod.EROFS)
         self.assertNotIn(
             "_raised", result,
             f"EROFS propagated uncaught: {result.get('_raised')!r}",
@@ -976,7 +983,7 @@ class TestNF4_AtomicClaimHandlesNonExistsOsError(unittest.TestCase):
     def test_eacces_does_not_crash_hook(self):
         """EACCES (permission denied) must NOT propagate."""
         import errno as _errno_mod
-        result = self._run_with_os_open_raising(_errno_mod.EACCES)
+        result = self._run_with_reservation_raising(_errno_mod.EACCES)
         self.assertNotIn(
             "_raised", result,
             f"EACCES propagated uncaught: {result.get('_raised')!r}",
@@ -1334,35 +1341,29 @@ class TestDiffCoverage_AtomicPidfile_AllErrnos(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def _run_with_os_open_raising(self, exc: Exception):
-        """Invoke start_guard_daemon with a mocked pidfile-write path that
+    def _run_with_reservation_raising(self, exc: Exception):
+        """Invoke start_guard_daemon with a mocked pidfile reservation that
         raises the given exception. Returns result dict OR `{'_raised': exc}`
         if uncaught.
 
-        After the round-3 rework (C1 fix) the pidfile is written via
-        ``os.open(<pid>.tmp, O_CREAT|O_EXCL|O_NOFOLLOW)`` then
-        ``os.rename``, replacing the prior ``Path.write_text``. The intent
-        of this test is unchanged (graceful surface on any OSError) —
-        only the mock surface moves to the new ``os.open`` call. We have
-        to filter on the .pid.tmp suffix because DaemonSpawnClaim also
-        uses os.open on the pid_path itself; only the post-Popen
-        atomic-rename open should fail.
+        The current publication path reserves a unique tempfile with
+        ``mkstemp`` before the atomic replacement. The test targets that
+        reservation rather than the claim's separate pidfile open.
         """
         from cozempic.guard import start_guard_daemon
 
-        tmp_pidfile_str = str(self.pid_path.with_suffix(".pid.tmp"))
-        real_os_open = os.open
+        real_mkstemp = tempfile.mkstemp
 
-        def fake_os_open(path, flags, *args, **kwargs):
-            if str(path) == tmp_pidfile_str:
+        def fake_mkstemp(*args, **kwargs):
+            if kwargs.get("prefix") == f"{self.pid_path.name}." and kwargs.get("suffix") == ".tmp":
                 raise exc
-            return real_os_open(path, flags, *args, **kwargs)
+            return real_mkstemp(*args, **kwargs)
 
         with (
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard.find_claude_pid", return_value=7777),
             patch("cozempic.guard.subprocess.Popen") as mock_popen,
-            patch("cozempic.guard.os.open", side_effect=fake_os_open),
+            patch("cozempic.guard.tempfile.mkstemp", side_effect=fake_mkstemp),
         ):
             mock_popen.return_value = MagicMock(pid=9999)
             try:
@@ -1392,35 +1393,35 @@ class TestDiffCoverage_AtomicPidfile_AllErrnos(unittest.TestCase):
     def test_enospc_graceful(self):
         import errno as _errno_mod
         exc = OSError(_errno_mod.ENOSPC, os.strerror(_errno_mod.ENOSPC))
-        self._assert_graceful(self._run_with_os_open_raising(exc), "ENOSPC")
+        self._assert_graceful(self._run_with_reservation_raising(exc), "ENOSPC")
 
     def test_erofs_graceful(self):
         import errno as _errno_mod
         exc = OSError(_errno_mod.EROFS, os.strerror(_errno_mod.EROFS))
-        self._assert_graceful(self._run_with_os_open_raising(exc), "EROFS")
+        self._assert_graceful(self._run_with_reservation_raising(exc), "EROFS")
 
     def test_eacces_graceful(self):
         import errno as _errno_mod
         exc = OSError(_errno_mod.EACCES, os.strerror(_errno_mod.EACCES))
-        self._assert_graceful(self._run_with_os_open_raising(exc), "EACCES")
+        self._assert_graceful(self._run_with_reservation_raising(exc), "EACCES")
 
     def test_ebusy_graceful(self):
         import errno as _errno_mod
         exc = OSError(_errno_mod.EBUSY, os.strerror(_errno_mod.EBUSY))
-        self._assert_graceful(self._run_with_os_open_raising(exc), "EBUSY")
+        self._assert_graceful(self._run_with_reservation_raising(exc), "EBUSY")
 
     def test_emfile_graceful(self):
         """EMFILE: file descriptor exhaustion — real-world limit under load."""
         import errno as _errno_mod
         exc = OSError(_errno_mod.EMFILE, os.strerror(_errno_mod.EMFILE))
-        self._assert_graceful(self._run_with_os_open_raising(exc), "EMFILE")
+        self._assert_graceful(self._run_with_reservation_raising(exc), "EMFILE")
 
     def test_generic_oserror_with_custom_strerror(self):
         """OSError with an unconventional errno (e.g., from a mounted FS with
         custom errors) must still flow through the graceful branch."""
         exc = OSError(999, "custom filesystem error — quota drift")
         self._assert_graceful(
-            self._run_with_os_open_raising(exc),
+            self._run_with_reservation_raising(exc),
             "OSError(999)",
         )
 

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -243,6 +243,16 @@ class TestG3_IsGuardRunningForSessionVerifiesPidOwnership(unittest.TestCase):
                 "Failed to report a legitimate running guard PID",
             )
 
+    def test_permission_error_still_verifies_pid_ownership(self):
+        """An inaccessible recycled PID must not suppress guard startup."""
+        from cozempic.guard import _is_guard_running_for_session
+
+        with (
+            patch("cozempic.guard.os.kill", side_effect=PermissionError),
+            patch("cozempic.guard._is_cozempic_guard_process", return_value=False),
+        ):
+            self.assertIsNone(_is_guard_running_for_session(self.session_id))
+
 
 # ---------------------------------------------------------------------------
 # BUG-G4 — PID file creation must be atomic (no TOCTOU race)

--- a/tests/test_guard_pid_recycling.py
+++ b/tests/test_guard_pid_recycling.py
@@ -272,6 +272,41 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
         self.assertEqual(len(calls), 1, "_record_claude_identity must be called exactly once")
         self.assertEqual(calls[0], (fake_session_id, fake_pid))
 
+    def test_auto_detected_session_id_is_recorded(self):
+        import cozempic.guard as g
+
+        fake_pid = 12345
+        fake_session_id = "auto1234-5678-9abc-def0-2026051811ee"
+
+        with tempfile.TemporaryDirectory() as td:
+            jsonl = Path(td) / "session.jsonl"
+            jsonl.write_text("{}\n")
+            fake_session = {
+                "session_id": fake_session_id,
+                "session_path": str(jsonl),
+                "path": jsonl,
+                "project_dir": td,
+            }
+            calls = []
+
+            with patch("cozempic.guard.find_current_session", return_value=fake_session), \
+                 patch("cozempic.guard._record_claude_identity", side_effect=lambda sid, pid: calls.append((sid, pid))), \
+                 patch("cozempic.guard.load_messages", return_value=[]), \
+                 patch("cozempic.tokens.detect_context_window", return_value=200000), \
+                 patch("cozempic.tokens.default_token_thresholds_4tier", return_value=(50000, 110000, 160000)), \
+                 patch("cozempic.session.record_session"), \
+                 patch("cozempic.guard._cleanup_stale_watchers"), \
+                 patch("cozempic.guard.ping_install_if_new"), \
+                 patch("cozempic.guard.maybe_auto_update"), \
+                 patch("cozempic.guard.checkpoint_team"), \
+                 patch("cozempic.guard.time.sleep", side_effect=RuntimeError("stop loop")):
+                try:
+                    g.start_guard(session_id=None, claude_pid=fake_pid)
+                except (RuntimeError, SystemExit):
+                    pass
+
+        self.assertEqual(calls, [(fake_session_id, fake_pid)])
+
 
 # ---------------------------------------------------------------------------
 # Test 5 — Linux /proc backend (skipUnless Linux)

--- a/tests/test_guard_pid_recycling.py
+++ b/tests/test_guard_pid_recycling.py
@@ -245,8 +245,8 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
 
             calls = []
 
-            def fake_record(sid, pid):
-                calls.append((sid, pid))
+            def fake_record(sid, pid, session_path=None):
+                calls.append((sid, pid, session_path))
 
             # start_guard calls _resolve_session_by_id (not find_current_session)
             # when session_id is passed, then load_messages, detect_context_window,
@@ -270,7 +270,7 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
                     pass
 
         self.assertEqual(len(calls), 1, "_record_claude_identity must be called exactly once")
-        self.assertEqual(calls[0], (fake_session_id, fake_pid))
+        self.assertEqual(calls[0], (fake_session_id, fake_pid, jsonl))
 
     def test_auto_detected_session_id_is_recorded(self):
         import cozempic.guard as g
@@ -290,7 +290,7 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
             calls = []
 
             with patch("cozempic.guard.find_current_session", return_value=fake_session), \
-                 patch("cozempic.guard._record_claude_identity", side_effect=lambda sid, pid: calls.append((sid, pid))), \
+                 patch("cozempic.guard._record_claude_identity", side_effect=lambda sid, pid, session_path=None: calls.append((sid, pid, session_path))), \
                  patch("cozempic.guard.load_messages", return_value=[]), \
                  patch("cozempic.tokens.detect_context_window", return_value=200000), \
                  patch("cozempic.tokens.default_token_thresholds_4tier", return_value=(50000, 110000, 160000)), \
@@ -305,7 +305,16 @@ class TestRecordClaudeIdentityOnStartGuard(unittest.TestCase):
                 except (RuntimeError, SystemExit):
                     pass
 
-        self.assertEqual(calls, [(fake_session_id, fake_pid)])
+        self.assertEqual(calls, [(fake_session_id, fake_pid, jsonl)])
+
+    def test_identity_recording_forwards_session_path(self):
+        import cozempic.guard as g
+
+        session_path = Path("/tmp/session.jsonl")
+        with patch("cozempic.guard._is_claude_process", return_value=False) as is_claude:
+            g._record_claude_identity("a" * 32, 12345, session_path=session_path)
+
+        is_claude.assert_called_once_with(12345, session_path=session_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -688,9 +688,7 @@ class TestPolishPR93_PidfileEACCES(unittest.TestCase):
 
         claim = DaemonSpawnClaim("any-session-12345", Path("/tmp/x.pid"))
 
-        with _patch.object(
-            Path, "stat", side_effect=PermissionError("EACCES")
-        ):
+        with _patch("cozempic.spawn_lock.os.stat", side_effect=PermissionError("EACCES")):
             result = claim._is_pidfile_fresh()
         self.assertTrue(
             result,

--- a/tests/test_guard_polish_pr93.py
+++ b/tests/test_guard_polish_pr93.py
@@ -66,11 +66,9 @@ class TestPolishPR93_SpawnLocksDictRemoved(unittest.TestCase):
         )
 
 
-class TestPolishPR93_PlaceholderPidIsUnlinked(unittest.TestCase):
-    """Regression test: even after the dead consumer branch is removed,
-    a placeholder-valued pidfile (pid <= 0) must still resolve to None
-    AND be unlinked. Mirrors TestR3_1 pattern but exercises the path
-    that survives the deletion."""
+class TestPolishPR93_PlaceholderPidProbe(unittest.TestCase):
+    """Regression test: a placeholder pidfile resolves to None without
+    pre-claim cleanup. DaemonSpawnClaim owns serialized stale recovery."""
 
     SESSION_ID = "pr93pl00-0000-0000-0000-000000000093"
 
@@ -82,19 +80,19 @@ class TestPolishPR93_PlaceholderPidIsUnlinked(unittest.TestCase):
     def tearDown(self):
         self.pid_path.unlink(missing_ok=True)
 
-    def test_zero_pid_resolves_to_none_and_unlinks(self):
+    def test_zero_pid_resolves_to_none_without_unlinking(self):
         from cozempic.guard import _is_guard_running_for_session
         self.pid_path.write_text("0\n")
         result = _is_guard_running_for_session(self.SESSION_ID)
         self.assertIsNone(result, "placeholder pid 0 must resolve to None")
-        self.assertFalse(self.pid_path.exists(), "placeholder pidfile must be unlinked")
+        self.assertTrue(self.pid_path.exists(), "probe must not unlink pidfile")
 
-    def test_negative_pid_resolves_to_none_and_unlinks(self):
+    def test_negative_pid_resolves_to_none_without_unlinking(self):
         from cozempic.guard import _is_guard_running_for_session
         self.pid_path.write_text("-1\n")
         result = _is_guard_running_for_session(self.SESSION_ID)
         self.assertIsNone(result, "negative pid must resolve to None")
-        self.assertFalse(self.pid_path.exists(), "placeholder pidfile must be unlinked")
+        self.assertTrue(self.pid_path.exists(), "probe must not unlink pidfile")
 
 
 # ─── Item #3 — Pidfile unlinked on ALL daemon-exit paths ────────────────────

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -192,6 +192,9 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
             if p.is_alive():
                 p.terminate()
                 p.join(timeout=2.0)
+                if p.is_alive():
+                    p.kill()
+                    p.join(timeout=2.0)
 
         return results
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -147,20 +147,22 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
             self.pid_path.with_suffix(".log"),
             self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
         )
-        for path in self.paths:
-            path.unlink(missing_ok=True)
+        self._clean_paths()
         self.log_path = self.pid_path.with_suffix(".log")
 
-    def tearDown(self):
-        for path in self.paths:
+    def _clean_paths(self):
+        for path in (*self.paths, *self.pid_path.parent.glob(f"{self.pid_path.name}.*.tmp")):
             path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        self._clean_paths()
 
     def _race_once(self) -> list[dict]:
         """Spawn two processes, sync at a barrier, collect results."""
         # On macOS the default start method is spawn; force it explicitly so
         # the test is platform-deterministic.
         ctx = mp.get_context("spawn")
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+        self._clean_paths()
 
         barrier = ctx.Barrier(2)
         result_queue = ctx.Queue()
@@ -195,6 +197,7 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
                 if p.is_alive():
                     p.kill()
                     p.join(timeout=2.0)
+            self.assertFalse(p.is_alive(), f"worker {p.name} survived cleanup")
 
         return results
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -196,18 +196,19 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
             )
             for i in range(2)
         ]
-        for p in procs:
-            p.start()
-
-        # Collect both results
         results = []
-        for _ in range(2):
-            try:
-                results.append(result_queue.get(timeout=10.0))
-            except Exception as e:
-                results.append({"error": f"queue.get failed: {e!r}"})
+        try:
+            for p in procs:
+                p.start()
 
-        lingering = _reap_processes(procs)
+            # Collect both results
+            for _ in range(2):
+                try:
+                    results.append(result_queue.get(timeout=10.0))
+                except Exception as e:
+                    results.append({"error": f"queue.get failed: {e!r}"})
+        finally:
+            lingering = _reap_processes(procs)
         if lingering:
             results.append({"error": f"workers survived cleanup: {lingering}"})
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -105,7 +105,7 @@ def _race_worker(
     ):
         # Barrier sync: both children pile up here and release at the same instant
         try:
-            barrier_handle.wait(timeout=5.0)
+            barrier_handle.wait(timeout=10.0)
         except Exception as e:  # BrokenBarrierError or timeout
             result_queue.put(
                 {"error": f"barrier failed: {e!r}", "worker": worker_index}
@@ -143,11 +143,13 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
 
         self.pid_path = _pid_file_for_session(self.SESSION_ID)
         self.pid_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path = self.pid_path.with_suffix(".log")
         self.log_path.unlink(missing_ok=True)
 
     def tearDown(self):
         self.pid_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path.unlink(missing_ok=True)
 
     def _race_once(self) -> list[dict]:
@@ -155,6 +157,7 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
         # On macOS the default start method is spawn; force it explicitly so
         # the test is platform-deterministic.
         ctx = mp.get_context("spawn")
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
 
         barrier = ctx.Barrier(2)
         result_queue = ctx.Queue()
@@ -205,6 +208,7 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
         for it in range(self.ITERATIONS):
             # Clean state before each race
             self.pid_path.unlink(missing_ok=True)
+            self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
             self.log_path.unlink(missing_ok=True)
 
             results = self._race_once()

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -88,12 +88,20 @@ def _race_worker(
         fake_pid = 900_000 + worker_index
         return _DummyProc(fake_pid)
 
+    def _fake_is_process_alive(pid: int) -> bool:
+        """Model the spawned fake guard as alive for the contention check."""
+        return pid > 0
+
     # Mock subprocess.Popen so no real daemon is spawned, and mock
     # find_claude_pid so we don't fail when no Claude is running.
     with (
         _patch("cozempic.guard.subprocess.Popen", side_effect=_fake_popen),
         _patch("cozempic.guard.find_claude_pid", return_value=12345),
         _patch("cozempic.guard._cleanup_legacy_pid"),
+        _patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+        _patch(
+            "cozempic.spawn_lock._is_process_alive", side_effect=_fake_is_process_alive
+        ),
     ):
         # Barrier sync: both children pile up here and release at the same instant
         try:

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -128,15 +128,18 @@ def _race_worker(
 def _reap_processes(procs) -> list[str]:
     lingering = []
     for proc in procs:
-        proc.join(timeout=5.0)
-        if proc.is_alive():
-            proc.terminate()
-            proc.join(timeout=2.0)
-        if proc.is_alive():
-            proc.kill()
-            proc.join(timeout=2.0)
-        if proc.is_alive():
-            lingering.append(proc.name)
+        try:
+            proc.join(timeout=5.0)
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=2.0)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=2.0)
+            if proc.is_alive():
+                lingering.append(proc.name)
+        except Exception as exc:
+            lingering.append(f"{proc.name}: {exc!r}")
     return lingering
 
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -125,6 +125,21 @@ def _race_worker(
         result_queue.put(r)
 
 
+def _reap_processes(procs) -> list[str]:
+    lingering = []
+    for proc in procs:
+        proc.join(timeout=5.0)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=2.0)
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=2.0)
+        if proc.is_alive():
+            lingering.append(proc.name)
+    return lingering
+
+
 class TestR1_DaemonProcessRace(unittest.TestCase):
     """Process-vs-process race on start_guard_daemon for the same session UUID.
 
@@ -189,15 +204,9 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
             except Exception as e:
                 results.append({"error": f"queue.get failed: {e!r}"})
 
-        for p in procs:
-            p.join(timeout=5.0)
-            if p.is_alive():
-                p.terminate()
-                p.join(timeout=2.0)
-                if p.is_alive():
-                    p.kill()
-                    p.join(timeout=2.0)
-            self.assertFalse(p.is_alive(), f"worker {p.name} survived cleanup")
+        lingering = _reap_processes(procs)
+        if lingering:
+            results.append({"error": f"workers survived cleanup: {lingering}"})
 
         return results
 

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -162,8 +162,7 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
         barrier = ctx.Barrier(2)
         result_queue = ctx.Queue()
 
-        # Fresh cwd per iteration so the legacy-pid cleanup path doesn't
-        # interfere across iterations.
+        # The shared cwd is enough; pidfile and log cleanup isolate iterations.
         cwd = os.getcwd()
 
         procs = [

--- a/tests/test_guard_race_2026_05_18.py
+++ b/tests/test_guard_race_2026_05_18.py
@@ -37,8 +37,8 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import sys
-import time
 import unittest
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -133,24 +133,27 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
     O_CREAT|O_EXCL claim path holds across process boundaries.
     """
 
-    # Must match _SESSION_ID_RE = ^[0-9a-f][0-9a-f-]{11,}$  (hex chars + dashes only)
-    SESSION_ID = "abcd1234-5678-9abc-def0-2026051811aa"
     ITERATIONS = 50
 
     def setUp(self):
         # Compute and pre-clean the pidfile + log file for our session.
         from cozempic.guard import _pid_file_for_session
 
-        self.pid_path = _pid_file_for_session(self.SESSION_ID)
-        self.pid_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+        self.session_id = uuid.uuid4().hex
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.paths = (
+            self.pid_path,
+            self.pid_path.with_suffix(".pid.tmp"),
+            self.pid_path.with_suffix(".log"),
+            self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
+        )
+        for path in self.paths:
+            path.unlink(missing_ok=True)
         self.log_path = self.pid_path.with_suffix(".log")
-        self.log_path.unlink(missing_ok=True)
 
     def tearDown(self):
-        self.pid_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
-        self.log_path.unlink(missing_ok=True)
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def _race_once(self) -> list[dict]:
         """Spawn two processes, sync at a barrier, collect results."""
@@ -168,7 +171,7 @@ class TestR1_DaemonProcessRace(unittest.TestCase):
         procs = [
             ctx.Process(
                 target=_race_worker,
-                args=(barrier, result_queue, self.SESSION_ID, cwd, i),
+                args=(barrier, result_queue, self.session_id, cwd, i),
                 name=f"race-child-{i}",
             )
             for i in range(2)

--- a/tests/test_guard_reload_loop_fix.py
+++ b/tests/test_guard_reload_loop_fix.py
@@ -17,6 +17,7 @@ ledger never leaks into the shared /tmp (which would make order/timing-dependent
 flakes across runs).
 """
 
+import os
 import shutil
 import tempfile
 import unittest
@@ -103,6 +104,21 @@ class TestPostPruneTokenProgressGate(unittest.TestCase):
 
 
 class TestReloadRateLedger(unittest.TestCase):
+    def test_ledger_write_replaces_symlink_without_touching_target(self):
+        from cozempic.guard import _reload_rate_exceeded
+
+        d = Path(tempfile.mkdtemp(prefix="cozempic_ledger_"))
+        try:
+            victim = d / "victim"
+            victim.write_text("keep")
+            ledger = d / "h.json"
+            os.symlink(victim, ledger)
+            _reload_rate_exceeded(ledger, now=1000.0)
+            self.assertFalse(ledger.is_symlink())
+            self.assertEqual(victim.read_text(), "keep")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
     def test_helper_caps_after_max_in_window(self):
         from cozempic.guard import _reload_rate_exceeded
         d = Path(tempfile.mkdtemp(prefix="cozempic_ledger_"))

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -71,6 +71,15 @@ class TestReloadStateRegularFiles(unittest.TestCase):
             with patch("cozempic.guard._reload_armed_path", return_value=sentinel):
                 self.assertIsNone(read_armed("test-session"))
 
+    def test_read_armed_ignores_non_object_json(self):
+        from cozempic.guard import read_armed
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sentinel = Path(tmpdir) / "armed.json"
+            sentinel.write_text("[]")
+            with patch("cozempic.guard._reload_armed_path", return_value=sentinel):
+                self.assertIsNone(read_armed("test-session"))
+
     @unittest.skipUnless(hasattr(os, "mkfifo"), "requires mkfifo")
     def test_reload_ledger_ignores_fifo_without_blocking(self):
         from cozempic.guard import _reload_rate_exceeded

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -156,6 +156,91 @@ class TestReloadSelfDaemon(unittest.TestCase):
         self.assertEqual(result["orphaned_pid"], 111)
         start.assert_called_once()
 
+    def test_refuses_reload_when_existing_daemon_cannot_be_signaled(self):
+        from cozempic.guard import reload_self_daemon
+
+        session_id = "11111111-2222-3333-4444-555555555555"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = Path(tmpdir) / "guard.pid"
+            pid_path.write_text("123\n")
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=123),
+                patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+                patch("cozempic.guard._pid_file_for_session", return_value=pid_path),
+                patch("cozempic.guard.os.kill", side_effect=PermissionError),
+                patch("cozempic.guard.start_guard_daemon") as start,
+            ):
+                result = reload_self_daemon(cwd=tmpdir, session_id=session_id)
+                pidfile_preserved = pid_path.exists()
+
+        self.assertFalse(result["reloaded"])
+        self.assertIn("cannot be signaled", result["reason"])
+        self.assertTrue(pidfile_preserved)
+        start.assert_not_called()
+
+    def test_refuses_reload_when_daemon_survives_sigkill(self):
+        from cozempic.guard import reload_self_daemon
+
+        session_id = "11111111-2222-3333-4444-555555555555"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = Path(tmpdir) / "guard.pid"
+            pid_path.write_text("123\n")
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=123),
+                patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+                patch("cozempic.guard._pid_file_for_session", return_value=pid_path),
+                patch("cozempic.guard._wait_for_exit", return_value=False),
+                patch("cozempic.guard.os.kill") as kill,
+                patch("cozempic.guard.start_guard_daemon") as start,
+            ):
+                result = reload_self_daemon(cwd=tmpdir, session_id=session_id)
+                pidfile_preserved = pid_path.exists()
+
+        self.assertFalse(result["reloaded"])
+        self.assertIn("did not exit after SIGKILL", result["reason"])
+        self.assertTrue(pidfile_preserved)
+        self.assertEqual(kill.call_count, 2)
+        start.assert_not_called()
+
+    def test_orphan_marker_blocks_a_later_daemon_start(self):
+        from cozempic import guard
+
+        session_id = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            original_replace = os.replace
+
+            class DummyProc:
+                pid = 4242
+
+                def terminate(self):
+                    raise OSError("cannot terminate")
+
+            def fail_pid_replace(source, destination):
+                if Path(destination) == pid_path:
+                    raise OSError("cannot publish pid")
+                return original_replace(source, destination)
+
+            with (
+                patch("cozempic.guard._guard_tmp_root", return_value=root),
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+                patch("cozempic.guard._pid_is_alive", return_value=True),
+                patch("cozempic.guard.find_claude_pid", return_value=9999),
+                patch("cozempic.guard.subprocess.Popen", return_value=DummyProc()) as popen,
+            ):
+                pid_path = guard._pid_file_for_session(session_id)
+                with patch("cozempic.guard.os.replace", side_effect=fail_pid_replace):
+                    first = guard.start_guard_daemon(cwd=tmpdir, session_id=session_id)
+                    second = guard.start_guard_daemon(cwd=tmpdir, session_id=session_id)
+
+        self.assertEqual(first["orphaned_pid"], 4242)
+        self.assertFalse(second["started"])
+        self.assertTrue(second["already_running"])
+        self.assertEqual(second["pid"], 4242)
+        popen.assert_called_once()
+
 
 class TestGuardDaemonPidHandoff(unittest.TestCase):
     def test_start_guard_daemon_passes_explicit_claude_pid_to_child(self):

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -12,6 +12,18 @@ class TestGuardSignalHandling(unittest.TestCase):
         self.assertTrue(hasattr(signal, 'SIGTERM'))
 
 
+class TestGuardLogEncoding(unittest.TestCase):
+    def test_guard_log_preserves_surrogateescaped_path_bytes(self):
+        from cozempic.guard import _open_guard_log
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "guard.log"
+            with _open_guard_log(log_path) as log:
+                log.write("CWD: bad" + chr(0xDCFF) + "\n")
+
+            self.assertEqual(log_path.read_bytes(), b"CWD: bad\xff\n")
+
+
 class TestBackupCleanupIntegration(unittest.TestCase):
     def test_cleanup_old_backups_importable(self):
         """cleanup_old_backups can be imported from session module."""

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -133,14 +133,13 @@ class TestReloadSelfDaemon(unittest.TestCase):
         self.assertIsNone(result.get("new_pid"))
         self.assertIn("no daemon", result["reason"].lower())
 
-    def test_retry_preserves_orphaned_pid_from_first_spawn(self):
+    def test_orphaned_spawn_is_not_retried(self):
         from cozempic.guard import reload_self_daemon
 
         session_id = "11111111-2222-3333-4444-555555555555"
         with tempfile.TemporaryDirectory() as tmpdir:
             pid_path = Path(tmpdir) / "guard.pid"
             first = {"started": False, "already_running": False, "orphaned_pid": 111}
-            second = {"started": True, "already_running": False, "pid": 222, "log_file": "guard.log"}
             with (
                 patch("cozempic.guard._is_guard_running_for_session", return_value=123),
                 patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
@@ -148,13 +147,14 @@ class TestReloadSelfDaemon(unittest.TestCase):
                 patch("cozempic.guard._wait_for_exit", return_value=True),
                 patch("cozempic.guard.os.kill"),
                 patch("cozempic.guard.time.sleep"),
-                patch("cozempic.guard.start_guard_daemon", side_effect=[first, second]),
+                patch("cozempic.guard.start_guard_daemon", return_value=first) as start,
             ):
                 result = reload_self_daemon(cwd=tmpdir, session_id=session_id)
 
-        self.assertTrue(result["reloaded"])
-        self.assertEqual(result["new_pid"], 222)
+        self.assertFalse(result["reloaded"])
+        self.assertIsNone(result["new_pid"])
         self.assertEqual(result["orphaned_pid"], 111)
+        start.assert_called_once()
 
 
 class TestGuardDaemonPidHandoff(unittest.TestCase):

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -1,4 +1,5 @@
 """Tests for guard daemon robustness improvements."""
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -22,6 +23,74 @@ class TestGuardLogEncoding(unittest.TestCase):
                 log.write("CWD: bad" + chr(0xDCFF) + "\n")
 
             self.assertEqual(log_path.read_bytes(), b"CWD: bad\xff\n")
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires mkfifo")
+    def test_guard_log_fifo_is_rejected_without_blocking(self):
+        from cozempic.guard import _open_guard_log
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "guard.log"
+            os.mkfifo(log_path)
+            with self.assertRaises(OSError):
+                _open_guard_log(log_path)
+
+    @unittest.skipUnless(hasattr(os, "O_NOFOLLOW"), "requires O_NOFOLLOW")
+    def test_guard_log_symlink_is_rejected(self):
+        from cozempic.guard import _open_guard_log
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.log"
+            target.write_text("keep")
+            log_path = Path(tmpdir) / "guard.log"
+            log_path.symlink_to(target)
+            with self.assertRaises(OSError):
+                _open_guard_log(log_path)
+            self.assertEqual(target.read_text(), "keep")
+
+
+class TestReloadStateRegularFiles(unittest.TestCase):
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires mkfifo")
+    def test_read_armed_ignores_fifo_without_blocking(self):
+        from cozempic.guard import read_armed
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sentinel = Path(tmpdir) / "armed.json"
+            os.mkfifo(sentinel)
+            with patch("cozempic.guard._reload_armed_path", return_value=sentinel):
+                self.assertIsNone(read_armed("test-session"))
+
+    @unittest.skipUnless(hasattr(os, "O_NOFOLLOW"), "requires O_NOFOLLOW")
+    def test_read_armed_ignores_symlink(self):
+        from cozempic.guard import read_armed
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.json"
+            target.write_text('{"warned": true}')
+            sentinel = Path(tmpdir) / "armed.json"
+            sentinel.symlink_to(target)
+            with patch("cozempic.guard._reload_armed_path", return_value=sentinel):
+                self.assertIsNone(read_armed("test-session"))
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires mkfifo")
+    def test_reload_ledger_ignores_fifo_without_blocking(self):
+        from cozempic.guard import _reload_rate_exceeded
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = Path(tmpdir) / "reload.history"
+            os.mkfifo(ledger)
+            self.assertEqual(_reload_rate_exceeded(ledger, now=1000.0), (False, 1))
+
+    @unittest.skipUnless(hasattr(os, "O_NOFOLLOW"), "requires O_NOFOLLOW")
+    def test_reload_ledger_ignores_symlink(self):
+        from cozempic.guard import _reload_rate_exceeded
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.history"
+            target.write_text("[]")
+            ledger = Path(tmpdir) / "reload.history"
+            ledger.symlink_to(target)
+            self.assertEqual(_reload_rate_exceeded(ledger, now=1000.0), (False, 1))
+            self.assertEqual(target.read_text(), "[]")
 
 
 class TestBackupCleanupIntegration(unittest.TestCase):

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -132,6 +132,26 @@ class TestGuardDaemonPidHandoff(unittest.TestCase):
             self.assertTrue(result["started"])
             self.assertFalse(tmp_path.exists())
 
+    def test_start_guard_daemon_labels_subprocess_errors(self):
+        from cozempic.guard import start_guard_daemon
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch("cozempic.guard._guard_tmp_root", return_value=Path(tmpdir)),
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard.find_claude_pid", return_value=9999),
+                patch("cozempic.guard.subprocess.Popen", side_effect=OSError("no slots")),
+            ):
+                result = start_guard_daemon(
+                    cwd=tmpdir,
+                    session_id="ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb",
+                    threshold_tokens=123,
+                )
+
+        self.assertFalse(result["started"])
+        self.assertTrue(result["reason"].startswith("guard subprocess:"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_guard_robustness.py
+++ b/tests/test_guard_robustness.py
@@ -43,6 +43,29 @@ class TestReloadSelfDaemon(unittest.TestCase):
         self.assertIsNone(result.get("new_pid"))
         self.assertIn("no daemon", result["reason"].lower())
 
+    def test_retry_preserves_orphaned_pid_from_first_spawn(self):
+        from cozempic.guard import reload_self_daemon
+
+        session_id = "11111111-2222-3333-4444-555555555555"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = Path(tmpdir) / "guard.pid"
+            first = {"started": False, "already_running": False, "orphaned_pid": 111}
+            second = {"started": True, "already_running": False, "pid": 222, "log_file": "guard.log"}
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=123),
+                patch("cozempic.guard._is_cozempic_guard_process", return_value=True),
+                patch("cozempic.guard._pid_file_for_session", return_value=pid_path),
+                patch("cozempic.guard._wait_for_exit", return_value=True),
+                patch("cozempic.guard.os.kill"),
+                patch("cozempic.guard.time.sleep"),
+                patch("cozempic.guard.start_guard_daemon", side_effect=[first, second]),
+            ):
+                result = reload_self_daemon(cwd=tmpdir, session_id=session_id)
+
+        self.assertTrue(result["reloaded"])
+        self.assertEqual(result["new_pid"], 222)
+        self.assertEqual(result["orphaned_pid"], 111)
+
 
 class TestGuardDaemonPidHandoff(unittest.TestCase):
     def test_start_guard_daemon_passes_explicit_claude_pid_to_child(self):
@@ -83,6 +106,31 @@ class TestGuardDaemonPidHandoff(unittest.TestCase):
             self.assertTrue(result["started"])
             self.assertIn("--claude-pid", captured["cmd_parts"])
             self.assertIn("9999", captured["cmd_parts"])
+
+    def test_start_guard_daemon_reclaims_fresh_leftover_publication_temp(self):
+        from cozempic import guard
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_id = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
+            tmp = Path(tmpdir)
+
+            class DummyProc:
+                pid = 4242
+
+            with (
+                patch("cozempic.guard._guard_tmp_root", return_value=tmp),
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard.find_claude_pid", return_value=9999),
+                patch("cozempic.guard.subprocess.Popen", return_value=DummyProc()),
+            ):
+                pid_path = guard._pid_file_for_session(session_id)
+                tmp_path = pid_path.with_suffix(".pid.tmp")
+                tmp_path.write_text("leftover reservation")
+                result = guard.start_guard_daemon(cwd=tmpdir, session_id=session_id)
+
+            self.assertTrue(result["started"])
+            self.assertFalse(tmp_path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -187,6 +187,13 @@ class TestScanGuardLogs(unittest.TestCase):
         self.assertEqual(len(hits), 1)
         self.assertFalse(hits[0].pid_alive)
 
+    def test_symlinked_pid_is_not_read(self):
+        self._write("symlink", _respawn_storm())
+        target = self.dir / "target.pid"
+        target.write_text("4242", encoding="utf-8")
+        (self.dir / "cozempic_guard_symlink.pid").symlink_to(target)
+        self.assertIsNone(scan_guard_logs(self.dir)[0].pid)
+
     def test_healthy_not_in_hits(self):
         self._write("ccc", _daemon_start() + "".join(_good_cycle(n=i) for i in range(40)), pid=123)
         self.assertEqual(scan_guard_logs(self.dir), [])

--- a/tests/test_guard_watchdog.py
+++ b/tests/test_guard_watchdog.py
@@ -15,6 +15,7 @@ assumed it was — exactly the synthetic-vs-real trap). The true signal is
 futile-churn DOMINANCE, exit or no exit.
 """
 
+import os
 import signal
 import unittest
 from pathlib import Path
@@ -193,6 +194,17 @@ class TestScanGuardLogs(unittest.TestCase):
         target.write_text("4242", encoding="utf-8")
         (self.dir / "cozempic_guard_symlink.pid").symlink_to(target)
         self.assertIsNone(scan_guard_logs(self.dir)[0].pid)
+
+    def test_symlinked_log_is_not_read(self):
+        target = self.dir / "target.log"
+        target.write_text(_respawn_storm(), encoding="utf-8")
+        (self.dir / "cozempic_guard_symlink.log").symlink_to(target)
+        self.assertEqual(scan_guard_logs(self.dir), [])
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires mkfifo")
+    def test_fifo_log_is_skipped_without_blocking(self):
+        os.mkfifo(self.dir / "cozempic_guard_fifo.log")
+        self.assertEqual(scan_guard_logs(self.dir), [])
 
     def test_healthy_not_in_hits(self):
         self._write("ccc", _daemon_start() + "".join(_good_cycle(n=i) for i in range(40)), pid=123)

--- a/tests/test_interactive_guard.py
+++ b/tests/test_interactive_guard.py
@@ -189,6 +189,19 @@ class TestArmNudgeFromResult(unittest.TestCase):
 
         self.assertEqual(armed, {})
 
+    def test_read_armed_drops_nonfinite_fields(self):
+        from cozempic import guard
+
+        with patch("cozempic.guard._guard_tmp_root", return_value=self.scratch):
+            path = guard._reload_armed_path("sess-nonfinite", None)
+            path.write_text(
+                '{"armed_at": -Infinity, "tier": Infinity, '
+                '"projected_pct": NaN, "warned": "no"}'
+            )
+            armed = guard.read_armed("sess-nonfinite", None)
+
+        self.assertEqual(armed, {})
+
     def test_mark_armed_warned_upserts(self):
         # The nudge can warn before the daemon arms — mark must CREATE the sentinel.
         from cozempic import guard

--- a/tests/test_interactive_guard.py
+++ b/tests/test_interactive_guard.py
@@ -176,12 +176,15 @@ class TestArmNudgeFromResult(unittest.TestCase):
 
         self.assertEqual(armed["projected_pct"], 0.0)
 
-    def test_read_armed_drops_nonnumeric_grace_fields(self):
+    def test_read_armed_drops_invalid_fields(self):
         from cozempic import guard
 
         with patch("cozempic.guard._guard_tmp_root", return_value=self.scratch):
             path = guard._reload_armed_path("sess-malformed", None)
-            path.write_text('{"armed_at": "later", "tier": "hard"}')
+            path.write_text(
+                '{"armed_at": true, "tier": "hard", '
+                '"projected_pct": "unknown", "warned": "yes"}'
+            )
             armed = guard.read_armed("sess-malformed", None)
 
         self.assertEqual(armed, {})

--- a/tests/test_interactive_guard.py
+++ b/tests/test_interactive_guard.py
@@ -176,6 +176,16 @@ class TestArmNudgeFromResult(unittest.TestCase):
 
         self.assertEqual(armed["projected_pct"], 0.0)
 
+    def test_read_armed_drops_nonnumeric_grace_fields(self):
+        from cozempic import guard
+
+        with patch("cozempic.guard._guard_tmp_root", return_value=self.scratch):
+            path = guard._reload_armed_path("sess-malformed", None)
+            path.write_text('{"armed_at": "later", "tier": "hard"}')
+            armed = guard.read_armed("sess-malformed", None)
+
+        self.assertEqual(armed, {})
+
     def test_mark_armed_warned_upserts(self):
         # The nudge can warn before the daemon arms — mark must CREATE the sentinel.
         from cozempic import guard

--- a/tests/test_interactive_guard.py
+++ b/tests/test_interactive_guard.py
@@ -160,11 +160,21 @@ class TestArmNudgeFromResult(unittest.TestCase):
             a1 = guard.read_armed("sess-at", None)
             self.assertIn("armed_at", a1)
             guard.mark_armed_warned("sess-at", None)
-            guard.write_armed("sess-at", None, 55, 0.0)  # re-arm same tier, no proj
+            guard.write_armed("sess-at", None, 55, None)  # re-arm same tier, no new projection
             a2 = guard.read_armed("sess-at", None)
         self.assertEqual(a1["armed_at"], a2["armed_at"], "grace clock preserved on re-arm")
         self.assertTrue(a2["warned"], "warned preserved on same-tier re-arm")
         self.assertEqual(a2["projected_pct"], 30.0, "projection preserved when re-arm has none")
+
+    def test_write_armed_overwrites_projection_with_zero(self):
+        from cozempic import guard
+
+        with patch("cozempic.guard._guard_tmp_root", return_value=self.scratch):
+            guard.write_armed("sess-zero", None, 55, 30.0)
+            guard.write_armed("sess-zero", None, 55, 0.0)
+            armed = guard.read_armed("sess-zero", None)
+
+        self.assertEqual(armed["projected_pct"], 0.0)
 
     def test_mark_armed_warned_upserts(self):
         # The nudge can warn before the daemon arms — mark must CREATE the sentinel.

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -113,6 +113,19 @@ class TestCircuitBreaker(unittest.TestCase):
         self.assertTrue(self.breaker.can_recover())
         self.assertEqual(self.breaker.recovery_count(), 0)
 
+    def test_save_replaces_symlink_without_touching_target(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            victim = Path(tmp.name)
+        try:
+            victim.write_text("keep")
+            self.breaker.state_path.unlink(missing_ok=True)
+            os.symlink(victim, self.breaker.state_path)
+            self.breaker._save([])
+            self.assertFalse(self.breaker.state_path.is_symlink())
+            self.assertEqual(victim.read_text(), "keep")
+        finally:
+            victim.unlink(missing_ok=True)
+
 
 class TestOverflowDetection(unittest.TestCase):
 

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -52,6 +52,24 @@ class TestReloadLockAcquireRelease(unittest.TestCase):
         finally:
             lock_path.unlink(missing_ok=True)
 
+    @unittest.skipUnless(hasattr(os, "O_NOFOLLOW"), "requires O_NOFOLLOW")
+    def test_symlinked_non_utf8_lock_is_not_followed(self):
+        from cozempic.reload_lock import _ReloadLock, ReloadLockHeld, _read_lock_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            target = tmp / "non-utf8"
+            lock_path = tmp / "reload.lock"
+            target.write_bytes(b"\xff")
+            lock_path.symlink_to(target)
+
+            self.assertEqual(_read_lock_metadata(lock_path), (0, "unknown", None))
+            lock = _ReloadLock("test-symlinked-lock")
+            lock._lock_path = lock_path
+            with self.assertRaises(ReloadLockHeld) as held:
+                lock.__enter__()
+            self.assertEqual(held.exception.holder_pid, 0)
+
 
 # ─── Single-flight: two acquirers race ───────────────────────────────────────
 

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -70,6 +70,24 @@ class TestReloadLockAcquireRelease(unittest.TestCase):
                 lock.__enter__()
             self.assertEqual(held.exception.holder_pid, 0)
 
+    @unittest.skipUnless(hasattr(os, "O_NOFOLLOW"), "requires O_NOFOLLOW")
+    def test_symlinked_fresh_sentinel_is_not_active(self):
+        from cozempic.reload_lock import _reload_sentinel_active
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            target = tmp / "fresh-sentinel"
+            sentinel_path = tmp / "reload.in-flight"
+            target.write_text("123\\n")
+            sentinel_path.symlink_to(target)
+
+            with patch(
+                "cozempic.reload_lock._reload_sentinel_path_for",
+                return_value=sentinel_path,
+            ):
+                self.assertFalse(_reload_sentinel_active("test-sentinel"))
+            self.assertTrue(sentinel_path.is_symlink())
+
 
 # ─── Single-flight: two acquirers race ───────────────────────────────────────
 

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -109,13 +109,14 @@ class TestThreeProcessContention(unittest.TestCase):
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.session_id = f"race3-{uuid.uuid4()}"
+        self.session_id = uuid.uuid4().hex
         self.pid_path = _pid_file_for_session(self.session_id)
+        self.log_path = self.pid_path.with_suffix(".log")
         self.paths = (
             self.pid_path,
-            self.pid_path.with_suffix(".log"),
+            self.log_path,
             self.pid_path.with_suffix(".pid.tmp"),
-            self.pid_path.with_suffix(".reclaim-lock"),
+            self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
         )
         for path in self.paths:
             path.unlink(missing_ok=True)
@@ -196,13 +197,13 @@ class TestV4TenProcessContention(unittest.TestCase):
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.session_id = f"race10-{uuid.uuid4()}"
+        self.session_id = uuid.uuid4().hex
         self.pid_path = _pid_file_for_session(self.session_id)
         self.paths = (
             self.pid_path,
             self.pid_path.with_suffix(".log"),
             self.pid_path.with_suffix(".pid.tmp"),
-            self.pid_path.with_suffix(".reclaim-lock"),
+            self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
         )
         for path in self.paths:
             path.unlink(missing_ok=True)
@@ -280,20 +281,23 @@ class TestNoPlaceholderPidVisible(unittest.TestCase):
     only "no file" or "file with real PID > 0" should ever be observable.
     """
 
-    SESSION_ID = "babe1234-5678-9abc-def0-2026051811dd"
-
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.pid_path = _pid_file_for_session(self.SESSION_ID)
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path = self.pid_path.with_suffix(".log")
-        self.log_path.unlink(missing_ok=True)
+        self.session_id = uuid.uuid4().hex
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.paths = (
+            self.pid_path,
+            self.pid_path.with_suffix(".log"),
+            self.pid_path.with_suffix(".pid.tmp"),
+            self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
+        )
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def tearDown(self):
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def test_no_placeholder_pid_ever_visible(self):
         """Run start_guard_daemon while a tight reader loop observes the
@@ -324,7 +328,7 @@ class TestNoPlaceholderPidVisible(unittest.TestCase):
             mock_popen.return_value.pid = 88888
             result = start_guard_daemon(
                 cwd=os.getcwd(),
-                session_id=self.SESSION_ID,
+                session_id=self.session_id,
                 threshold_tokens=1000,
             )
 
@@ -532,7 +536,7 @@ class TestFreshClaimProtection(unittest.TestCase):
         from cozempic import spawn_lock
         from cozempic.guard import _pid_file_for_session, start_guard_daemon
 
-        session_id = "beef1234-5678-9abc-def0-2026051811aa"
+        session_id = uuid.uuid4().hex
         pid_path = _pid_file_for_session(session_id)
         tmp_path = pid_path.with_suffix(".pid.tmp")
         pid_path.unlink(missing_ok=True)
@@ -621,12 +625,11 @@ class TestSymlinkDefense(unittest.TestCase):
       - leaves the symlink target untouched
     """
 
-    SESSION_ID = "ca7ec0de-1234-5678-9abc-2026051811f0"
-
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.pid_path = _pid_file_for_session(self.SESSION_ID)
+        self.session_id = uuid.uuid4().hex
+        self.pid_path = _pid_file_for_session(self.session_id)
         self.tmp_pid_path = self.pid_path.with_suffix(".pid.tmp")
         self.log_path = self.pid_path.with_suffix(".log")
         # Clean slate
@@ -682,7 +685,7 @@ class TestSymlinkDefense(unittest.TestCase):
         ):
             result = start_guard_daemon(
                 cwd=str(self.tmpdir),
-                session_id=self.SESSION_ID,
+                session_id=self.session_id,
                 threshold_tokens=1000,
             )
 
@@ -720,7 +723,7 @@ class TestSymlinkDefense(unittest.TestCase):
         ):
             result = start_guard_daemon(
                 cwd=str(self.tmpdir),
-                session_id=self.SESSION_ID,
+                session_id=self.session_id,
                 threshold_tokens=1000,
             )
 
@@ -742,20 +745,24 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
     """If the log file's parent dir vanishes mid-spawn, the daemon must
     recover with one retry — not crash the SessionStart hook."""
 
-    SESSION_ID = "feed1234-5678-9abc-def0-2026051811ee"
-
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.pid_path = _pid_file_for_session(self.SESSION_ID)
-        self.pid_path.unlink(missing_ok=True)
+        self.session_id = uuid.uuid4().hex
+        self.pid_path = _pid_file_for_session(self.session_id)
         self.log_path = self.pid_path.with_suffix(".log")
-        self.log_path.unlink(missing_ok=True)
+        self.paths = (
+            self.pid_path,
+            self.log_path,
+            self.pid_path.with_suffix(".pid.tmp"),
+            self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
+        )
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def tearDown(self):
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def test_filenotfounderror_recovery(self):
         """First log open raises FileNotFoundError, second succeeds."""
@@ -784,7 +791,7 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
             mock_popen.return_value.pid = 77777
             result = start_guard_daemon(
                 cwd=os.getcwd(),
-                session_id=self.SESSION_ID,
+                session_id=self.session_id,
                 threshold_tokens=1000,
             )
 
@@ -808,7 +815,7 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
             patch("cozempic.guard._cleanup_legacy_pid"),
             patch("cozempic.guard._open_guard_log", side_effect=OSError("permission denied")),
         ):
-            result = start_guard_daemon(cwd=os.getcwd(), session_id=self.SESSION_ID)
+            result = start_guard_daemon(cwd=os.getcwd(), session_id=self.session_id)
 
         self.assertFalse(result["started"])
         self.assertIn("log file: permission denied", result["reason"])

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -520,34 +520,8 @@ class TestFreshClaimProtection(unittest.TestCase):
         self.assertFalse(result["started"])
         self.assertIn("pidfile claim", result["reason"])
 
-    def test_pid_tmp_conflict_prevents_spawn(self):
-        """A stale publication temp file must fail before creating a child."""
-        from cozempic.guard import _pid_file_for_session, start_guard_daemon
-
-        session_id = "deed1234-5678-9abc-def0-2026051811aa"
-        pid_path = _pid_file_for_session(session_id)
-        tmp_path = pid_path.with_suffix(".pid.tmp")
-        pid_path.unlink(missing_ok=True)
-        tmp_path.write_text("stale\n", encoding="utf-8")
-        try:
-            with (
-                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
-                patch("cozempic.guard._cleanup_legacy_pid"),
-                patch("cozempic.guard.find_claude_pid", return_value=12345),
-                patch("cozempic.guard.subprocess.Popen") as popen,
-            ):
-                result = start_guard_daemon(
-                    cwd=tempfile.gettempdir(), session_id=session_id, threshold_tokens=1000
-                )
-            self.assertFalse(result["started"])
-            self.assertIn("pidfile", result["reason"])
-            popen.assert_not_called()
-        finally:
-            pid_path.unlink(missing_ok=True)
-            tmp_path.unlink(missing_ok=True)
-
-    def test_stale_pid_tmp_is_reclaimed_before_spawn(self):
-        """A reservation left by a killed parent must not block restart forever."""
+    def _start_with_pid_tmp(self, *, stale: bool):
+        """Start against a fresh or stale publication reservation."""
         from cozempic import spawn_lock
         from cozempic.guard import _pid_file_for_session, start_guard_daemon
 
@@ -556,8 +530,9 @@ class TestFreshClaimProtection(unittest.TestCase):
         tmp_path = pid_path.with_suffix(".pid.tmp")
         pid_path.unlink(missing_ok=True)
         tmp_path.write_text("stale\n", encoding="utf-8")
-        stale_at = time.time() - spawn_lock._FRESH_PIDFILE_SECONDS - 1
-        os.utime(tmp_path, (stale_at, stale_at))
+        if stale:
+            stale_at = time.time() - spawn_lock._FRESH_PIDFILE_SECONDS - 1
+            os.utime(tmp_path, (stale_at, stale_at))
 
         class _DummyProc:
             pid = 987654
@@ -572,11 +547,23 @@ class TestFreshClaimProtection(unittest.TestCase):
                 result = start_guard_daemon(
                     cwd=tempfile.gettempdir(), session_id=session_id, threshold_tokens=1000
                 )
-            self.assertTrue(result["started"])
-            popen.assert_called_once()
+            return result, popen
         finally:
             pid_path.unlink(missing_ok=True)
             tmp_path.unlink(missing_ok=True)
+
+    def test_pid_tmp_conflict_prevents_spawn(self):
+        """A fresh publication temp file must fail before creating a child."""
+        result, popen = self._start_with_pid_tmp(stale=False)
+        self.assertFalse(result["started"])
+        self.assertIn("pidfile", result["reason"])
+        popen.assert_not_called()
+
+    def test_stale_pid_tmp_is_reclaimed_before_spawn(self):
+        """A reservation left by a killed parent must not block restart forever."""
+        result, popen = self._start_with_pid_tmp(stale=True)
+        self.assertTrue(result["started"])
+        popen.assert_called_once()
 
 
 class TestStaleClaimContention(unittest.TestCase):

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import time
 import unittest
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -105,19 +106,23 @@ def _stale_claim_worker(barrier_handle, result_queue, pid_file: str, worker_inde
 class TestThreeProcessContention(unittest.TestCase):
     """Three processes race for the same session — exactly ONE must win."""
 
-    SESSION_ID = "fade1234-5678-9abc-def0-2026051811cc"
-
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.pid_path = _pid_file_for_session(self.SESSION_ID)
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path = self.pid_path.with_suffix(".log")
-        self.log_path.unlink(missing_ok=True)
+        self.session_id = f"race3-{uuid.uuid4()}"
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.paths = (
+            self.pid_path,
+            self.pid_path.with_suffix(".log"),
+            self.pid_path.with_suffix(".pid.tmp"),
+            self.pid_path.with_suffix(".reclaim-lock"),
+        )
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def tearDown(self):
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path.unlink(missing_ok=True)
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def test_three_process_contention(self):
 
@@ -128,15 +133,15 @@ class TestThreeProcessContention(unittest.TestCase):
 
         failures = []
         for it in range(ITERATIONS):
-            self.pid_path.unlink(missing_ok=True)
-            self.log_path.unlink(missing_ok=True)
+            for path in self.paths:
+                path.unlink(missing_ok=True)
 
             barrier = ctx.Barrier(N)
             queue = ctx.Queue()
             procs = [
                 ctx.Process(
                     target=_race_worker,
-                    args=(barrier, queue, self.SESSION_ID, cwd, i),
+                    args=(barrier, queue, self.session_id, cwd, i),
                     name=f"race-3-{i}",
                 )
                 for i in range(N)
@@ -185,22 +190,26 @@ class TestV4TenProcessContention(unittest.TestCase):
     gate for any change to spawn_lock.py or start_guard_daemon.
     """
 
-    SESSION_ID = "feedbeef-1234-5678-9abc-2026051811ff"
     N = 10
     ITERATIONS = 30
 
     def setUp(self):
         from cozempic.guard import _pid_file_for_session
 
-        self.pid_path = _pid_file_for_session(self.SESSION_ID)
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path = self.pid_path.with_suffix(".log")
-        self.log_path.unlink(missing_ok=True)
+        self.session_id = f"race10-{uuid.uuid4()}"
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.paths = (
+            self.pid_path,
+            self.pid_path.with_suffix(".log"),
+            self.pid_path.with_suffix(".pid.tmp"),
+            self.pid_path.with_suffix(".reclaim-lock"),
+        )
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def tearDown(self):
-        self.pid_path.unlink(missing_ok=True)
-        self.log_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
+        for path in self.paths:
+            path.unlink(missing_ok=True)
 
     def test_ten_process_contention_30x(self):
         ctx = mp.get_context("spawn")
@@ -208,15 +217,15 @@ class TestV4TenProcessContention(unittest.TestCase):
 
         failures = []
         for it in range(self.ITERATIONS):
-            self.pid_path.unlink(missing_ok=True)
-            self.log_path.unlink(missing_ok=True)
+            for path in self.paths:
+                path.unlink(missing_ok=True)
 
             barrier = ctx.Barrier(self.N)
             queue = ctx.Queue()
             procs = [
                 ctx.Process(
                     target=_race_worker,
-                    args=(barrier, queue, self.SESSION_ID, cwd, i),
+                    args=(barrier, queue, self.session_id, cwd, i),
                     name=f"v4-{i}",
                 )
                 for i in range(self.N)

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -118,12 +118,14 @@ class TestThreeProcessContention(unittest.TestCase):
             self.pid_path.with_suffix(".pid.tmp"),
             self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
         )
-        for path in self.paths:
+        self._clean_paths()
+
+    def _clean_paths(self):
+        for path in (*self.paths, *self.pid_path.parent.glob(f"{self.pid_path.name}.*.tmp")):
             path.unlink(missing_ok=True)
 
     def tearDown(self):
-        for path in self.paths:
-            path.unlink(missing_ok=True)
+        self._clean_paths()
 
     def test_three_process_contention(self):
 
@@ -134,8 +136,7 @@ class TestThreeProcessContention(unittest.TestCase):
 
         failures = []
         for it in range(ITERATIONS):
-            for path in self.paths:
-                path.unlink(missing_ok=True)
+            self._clean_paths()
 
             barrier = ctx.Barrier(N)
             queue = ctx.Queue()
@@ -164,6 +165,7 @@ class TestThreeProcessContention(unittest.TestCase):
                     if p.is_alive():
                         p.kill()
                         p.join(timeout=2.0)
+                self.assertFalse(p.is_alive(), f"worker {p.name} survived cleanup")
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -208,12 +210,14 @@ class TestV4TenProcessContention(unittest.TestCase):
             self.pid_path.with_suffix(".pid.tmp"),
             self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
         )
-        for path in self.paths:
+        self._clean_paths()
+
+    def _clean_paths(self):
+        for path in (*self.paths, *self.pid_path.parent.glob(f"{self.pid_path.name}.*.tmp")):
             path.unlink(missing_ok=True)
 
     def tearDown(self):
-        for path in self.paths:
-            path.unlink(missing_ok=True)
+        self._clean_paths()
 
     def test_ten_process_contention_30x(self):
         ctx = mp.get_context("spawn")
@@ -221,8 +225,7 @@ class TestV4TenProcessContention(unittest.TestCase):
 
         failures = []
         for it in range(self.ITERATIONS):
-            for path in self.paths:
-                path.unlink(missing_ok=True)
+            self._clean_paths()
 
             barrier = ctx.Barrier(self.N)
             queue = ctx.Queue()
@@ -251,6 +254,7 @@ class TestV4TenProcessContention(unittest.TestCase):
                     if p.is_alive():
                         p.kill()
                         p.join(timeout=2.0)
+                self.assertFalse(p.is_alive(), f"worker {p.name} survived cleanup")
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -612,6 +616,7 @@ class TestStaleClaimContention(unittest.TestCase):
                         if proc.is_alive():
                             proc.kill()
                             proc.join(timeout=2.0)
+                    self.assertFalse(proc.is_alive(), f"worker {proc.name} survived cleanup")
                 self.assertFalse([result for result in results if "error" in result], results)
                 self.assertEqual(sum(result["claimed"] for result in results), 1, results)
                 pid_file.unlink(missing_ok=True)
@@ -834,10 +839,10 @@ class TestDaemonSpawnLockUnit(unittest.TestCase):
     """Direct contract tests on the spawn_lock module."""
 
     def setUp(self):
-        from cozempic.guard import _pid_file_for_session
+        from cozempic.spawn_lock import _spawn_lock_path
 
         self.session_id = uuid.uuid4().hex
-        self.pid_path = _pid_file_for_session(self.session_id)
+        self.pid_path = _spawn_lock_path(self.session_id)
         self.paths = (
             self.pid_path,
             self.pid_path.with_suffix(".pid.tmp"),

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -698,6 +698,26 @@ class TestSymlinkDefense(unittest.TestCase):
                 pass
         self.assertEqual(self.victim.read_text(encoding="utf-8"), "ORIGINAL\n")
 
+    def test_log_write_rejects_symlink(self):
+        """The deterministic guard log path must not follow a symlink."""
+        if not hasattr(os, "O_NOFOLLOW"):
+            self.skipTest("platform has no O_NOFOLLOW")
+        from cozempic.guard import start_guard_daemon
+
+        os.symlink(str(self.victim), str(self.log_path))
+        with (
+            patch("cozempic.guard.find_claude_pid", return_value=12345),
+            patch("cozempic.guard._cleanup_legacy_pid"),
+        ):
+            result = start_guard_daemon(
+                cwd=str(self.tmpdir),
+                session_id=self.SESSION_ID,
+                threshold_tokens=1000,
+            )
+
+        self.assertFalse(result["started"])
+        self.assertEqual(self.victim.read_text(encoding="utf-8"), "ORIGINAL\n")
+
     def test_pidfile_parse_rejects_symlink(self):
         """PID readers must not follow a symlink planted at the claim path."""
         if not hasattr(os, "O_NOFOLLOW"):
@@ -729,27 +749,27 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
         self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
 
     def test_filenotfounderror_recovery(self):
-        """First open(log_file) raises FileNotFoundError, second succeeds."""
+        """First log open raises FileNotFoundError, second succeeds."""
+        from cozempic import guard
         from cozempic.guard import start_guard_daemon
 
-        # We track open() calls on the log_file path; the FIRST call raises,
-        # the rest are passed through. Mock os.makedirs to confirm the retry
-        # path is taken.
-        real_open = open
+        # We track the safe log opener; the FIRST call raises, the rest pass
+        # through. Mock os.makedirs to confirm the retry path is taken.
+        real_open = guard._open_guard_log
         call_state = {"n": 0}
 
-        def fake_open(path, *args, **kwargs):
+        def fake_open(path):
             if str(path) == str(self.log_path):
                 call_state["n"] += 1
                 if call_state["n"] == 1:
                     raise FileNotFoundError(2, "No such file or directory", str(path))
-            return real_open(path, *args, **kwargs)
+            return real_open(path)
 
         with (
             patch("cozempic.guard.subprocess.Popen") as mock_popen,
             patch("cozempic.guard.find_claude_pid", return_value=12345),
             patch("cozempic.guard._cleanup_legacy_pid"),
-            patch("builtins.open", side_effect=fake_open),
+            patch("cozempic.guard._open_guard_log", side_effect=fake_open),
             patch("cozempic.guard.os.makedirs") as mock_makedirs,
         ):
             mock_popen.return_value.pid = 77777
@@ -766,7 +786,7 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
         self.assertEqual(
             call_state["n"],
             2,
-            "Expected exactly 2 open() calls on log file (1 fail + 1 retry); "
+            "Expected exactly 2 log-open calls (1 fail + 1 retry); "
             f"got {call_state['n']}.",
         )
         mock_makedirs.assert_called_once()

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -451,6 +451,17 @@ class TestFreshWindowEnvVarClamping(unittest.TestCase):
 class TestFreshClaimProtection(unittest.TestCase):
     """The race fixtures must not be the only coverage of fresh claims."""
 
+    def test_fresh_empty_pidfile_is_not_unlinked_by_guard_probe(self):
+        """A probe must not delete a peer's not-yet-written exclusive claim."""
+        from cozempic import guard
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pid_file = Path(tmp_dir) / "guard.pid"
+            pid_file.touch()
+            with patch.object(guard, "_pid_file_for_session", return_value=pid_file):
+                self.assertIsNone(guard._is_guard_running_for_session("test-session"))
+            self.assertTrue(pid_file.exists())
+
     def test_fresh_dead_pid_is_not_reclaimed(self):
         """A freshly written dead PID is a peer claim, not stale state."""
         from cozempic import spawn_lock
@@ -685,6 +696,16 @@ class TestSymlinkDefense(unittest.TestCase):
         with self.assertRaises(OSError):
             with _stale_reclaim_lock(self.pid_path):
                 pass
+        self.assertEqual(self.victim.read_text(encoding="utf-8"), "ORIGINAL\n")
+
+    def test_pidfile_parse_rejects_symlink(self):
+        """PID readers must not follow a symlink planted at the claim path."""
+        if not hasattr(os, "O_NOFOLLOW"):
+            self.skipTest("platform has no O_NOFOLLOW")
+        from cozempic.spawn_lock import _parse_pidfile_pid
+
+        os.symlink(str(self.victim), str(self.pid_path))
+        self.assertEqual(_parse_pidfile_pid(self.pid_path), 0)
         self.assertEqual(self.victim.read_text(encoding="utf-8"), "ORIGINAL\n")
 
 

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -824,14 +824,30 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
 class TestDaemonSpawnLockUnit(unittest.TestCase):
     """Direct contract tests on the spawn_lock module."""
 
+    def setUp(self):
+        from cozempic.guard import _pid_file_for_session
+
+        self.session_id = uuid.uuid4().hex
+        self.pid_path = _pid_file_for_session(self.session_id)
+        self.paths = (
+            self.pid_path,
+            self.pid_path.with_suffix(".pid.tmp"),
+            self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock"),
+        )
+        for path in self.paths:
+            path.unlink(missing_ok=True)
+
+    def tearDown(self):
+        for path in self.paths:
+            path.unlink(missing_ok=True)
+
     def test_lock_yields_path(self):
         """Post-V4-rework: the spawn claim writes to the .pid file directly
         (the PID file IS the lock, no separate sentinel). This pins that
         contract."""
         from cozempic.spawn_lock import daemon_spawn_lock
 
-        sid = "deadbeef-1234-5678-9abc-de00deadbeef"
-        with daemon_spawn_lock(sid) as lock_path:
+        with daemon_spawn_lock(self.session_id) as lock_path:
             self.assertIsInstance(lock_path, Path)
             self.assertIn("cozempic_guard_", lock_path.name)
             self.assertTrue(
@@ -843,21 +859,19 @@ class TestDaemonSpawnLockUnit(unittest.TestCase):
         """A second concurrent acquire MUST raise DaemonAlreadyStarting."""
         from cozempic.spawn_lock import DaemonAlreadyStarting, daemon_spawn_lock
 
-        sid = "deadbeef-1234-5678-9abc-de00cafebabe"
-        with daemon_spawn_lock(sid):
+        with daemon_spawn_lock(self.session_id):
             with self.assertRaises(DaemonAlreadyStarting):
-                with daemon_spawn_lock(sid):
+                with daemon_spawn_lock(self.session_id):
                     pass
 
     def test_release_allows_reacquire(self):
         """After the first lock exits, a fresh acquire succeeds."""
         from cozempic.spawn_lock import daemon_spawn_lock
 
-        sid = "deadbeef-1234-5678-9abc-de00f00dbabe"
-        with daemon_spawn_lock(sid):
+        with daemon_spawn_lock(self.session_id):
             pass
         # Should not raise
-        with daemon_spawn_lock(sid):
+        with daemon_spawn_lock(self.session_id):
             pass
 
 

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import sys
+import tempfile
 import time
 import unittest
 from pathlib import Path
@@ -62,10 +63,18 @@ def _race_worker(
             return _DummyProc(900_000 + worker_index)
         return _real_popen(cmd_parts, **kwargs)
 
+    def _fake_is_process_alive(pid: int) -> bool:
+        """Model the spawned fake guard as alive for the contention check."""
+        return pid > 0
+
     with (
         _patch("cozempic.guard.subprocess.Popen", side_effect=_fake_popen),
         _patch("cozempic.guard.find_claude_pid", return_value=12345),
         _patch("cozempic.guard._cleanup_legacy_pid"),
+        _patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+        _patch(
+            "cozempic.spawn_lock._is_process_alive", side_effect=_fake_is_process_alive
+        ),
     ):
         try:
             barrier_handle.wait(timeout=10.0)
@@ -431,6 +440,29 @@ class TestFreshWindowEnvVarClamping(unittest.TestCase):
         from cozempic.spawn_lock import _DEFAULT_FRESH
 
         self.assertEqual(self._reload_with_env(None), _DEFAULT_FRESH)
+
+
+class TestFreshClaimProtection(unittest.TestCase):
+    """The race fixtures must not be the only coverage of fresh claims."""
+
+    def test_fresh_dead_pid_is_not_reclaimed(self):
+        """A freshly written dead PID is a peer claim, not stale state."""
+        from cozempic.spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pid_file = Path(tmp_dir) / "guard.pid"
+            pid_file.write_text("900000\n", encoding="utf-8")
+            fresh_now = pid_file.stat().st_mtime + 1.0
+
+            with (
+                patch("cozempic.spawn_lock._is_process_alive", return_value=False),
+                patch("cozempic.spawn_lock.time.time", return_value=fresh_now),
+                self.assertRaises(DaemonAlreadyStarting) as raised,
+            ):
+                with DaemonSpawnClaim("test-session", pid_file):
+                    self.fail("fresh dead PID file was reclaimed")
+
+        self.assertEqual(raised.exception.holder_pid, 900000)
 
 
 class TestSymlinkDefense(unittest.TestCase):

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -791,6 +791,19 @@ class TestFileNotFoundErrorRecovery(unittest.TestCase):
         )
         mock_makedirs.assert_called_once()
 
+    def test_log_open_error_is_reported_as_log_failure(self):
+        from cozempic.guard import start_guard_daemon
+
+        with (
+            patch("cozempic.guard.find_claude_pid", return_value=12345),
+            patch("cozempic.guard._cleanup_legacy_pid"),
+            patch("cozempic.guard._open_guard_log", side_effect=OSError("permission denied")),
+        ):
+            result = start_guard_daemon(cwd=os.getcwd(), session_id=self.SESSION_ID)
+
+        self.assertFalse(result["started"])
+        self.assertIn("log file: permission denied", result["reason"])
+
 
 class TestDaemonSpawnLockUnit(unittest.TestCase):
     """Direct contract tests on the spawn_lock module."""

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -508,7 +508,7 @@ class TestFreshClaimProtection(unittest.TestCase):
         self.assertIn("pidfile claim", result["reason"])
 
     def _start_with_pid_tmp(self, *, stale: bool):
-        """Start against a fresh or stale publication reservation."""
+        """Start against a fresh or stale leftover publication reservation."""
         from cozempic import spawn_lock
         from cozempic.guard import _pid_file_for_session, start_guard_daemon
 
@@ -539,12 +539,11 @@ class TestFreshClaimProtection(unittest.TestCase):
             pid_path.unlink(missing_ok=True)
             tmp_path.unlink(missing_ok=True)
 
-    def test_pid_tmp_conflict_prevents_spawn(self):
-        """A fresh publication temp file must fail before creating a child."""
+    def test_fresh_pid_tmp_is_reclaimed_after_exclusive_claim(self):
+        """An exclusive PID claimant may reclaim any leftover publication temp."""
         result, popen = self._start_with_pid_tmp(stale=False)
-        self.assertFalse(result["started"])
-        self.assertIn("pidfile", result["reason"])
-        popen.assert_not_called()
+        self.assertTrue(result["started"])
+        popen.assert_called_once()
 
     def test_stale_pid_tmp_is_reclaimed_before_spawn(self):
         """A reservation left by a killed parent must not block restart forever."""
@@ -597,9 +596,9 @@ class TestSymlinkDefense(unittest.TestCase):
     which:
       - rejects symlinks with ``OSError`` (ELOOP on Linux, EEXIST on macOS
         since O_EXCL fires first when the path exists at all)
-      - rejects pre-existing regular files too (orphan ``.pid.tmp`` from
-        a crashed prior spawn)
-      - leaves the victim file untouched in both cases
+      - reclaims a pre-existing regular publication temp only after winning
+        the exclusive PID claim
+      - leaves the symlink target untouched
     """
 
     SESSION_ID = "ca7ec0de-1234-5678-9abc-2026051811f0"

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -103,6 +103,21 @@ def _stale_claim_worker(barrier_handle, result_queue, pid_file: str, worker_inde
         result_queue.put({"error": repr(exc), "worker": worker_index})
 
 
+def _reap_processes(procs) -> list[str]:
+    lingering = []
+    for proc in procs:
+        proc.join(timeout=5.0)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=2.0)
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=2.0)
+        if proc.is_alive():
+            lingering.append(proc.name)
+    return lingering
+
+
 class TestThreeProcessContention(unittest.TestCase):
     """Three processes race for the same session — exactly ONE must win."""
 
@@ -157,21 +172,13 @@ class TestThreeProcessContention(unittest.TestCase):
                     results.append(queue.get(timeout=15.0))
                 except Exception as e:
                     results.append({"error": f"queue.get failed: {e!r}"})
-            for p in procs:
-                p.join(timeout=5.0)
-                if p.is_alive():
-                    p.terminate()
-                    p.join(timeout=2.0)
-                    if p.is_alive():
-                        p.kill()
-                        p.join(timeout=2.0)
-                self.assertFalse(p.is_alive(), f"worker {p.name} survived cleanup")
+            lingering = _reap_processes(procs)
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
 
-            if len(started) != 1 or len(already) != (N - 1):
-                failures.append({"iteration": it, "results": results})
+            if len(started) != 1 or len(already) != (N - 1) or lingering:
+                failures.append({"iteration": it, "results": results, "lingering": lingering})
 
         if failures:
             self.fail(
@@ -246,15 +253,7 @@ class TestV4TenProcessContention(unittest.TestCase):
                     results.append(queue.get(timeout=20.0))
                 except Exception as e:
                     results.append({"error": f"queue.get: {e!r}"})
-            for p in procs:
-                p.join(timeout=5.0)
-                if p.is_alive():
-                    p.terminate()
-                    p.join(timeout=2.0)
-                    if p.is_alive():
-                        p.kill()
-                        p.join(timeout=2.0)
-                self.assertFalse(p.is_alive(), f"worker {p.name} survived cleanup")
+            lingering = _reap_processes(procs)
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -264,7 +263,7 @@ class TestV4TenProcessContention(unittest.TestCase):
                 if r.get("started") is not True and r.get("already_running") is not True
             ]
 
-            if len(started) != 1 or len(already) != (self.N - 1) or undefined:
+            if len(started) != 1 or len(already) != (self.N - 1) or undefined or lingering:
                 failures.append(
                     {
                         "iter": it,
@@ -608,15 +607,8 @@ class TestStaleClaimContention(unittest.TestCase):
                 for proc in procs:
                     proc.start()
                 results = [queue.get(timeout=10.0) for _ in procs]
-                for proc in procs:
-                    proc.join(timeout=5.0)
-                    if proc.is_alive():
-                        proc.terminate()
-                        proc.join(timeout=2.0)
-                        if proc.is_alive():
-                            proc.kill()
-                            proc.join(timeout=2.0)
-                    self.assertFalse(proc.is_alive(), f"worker {proc.name} survived cleanup")
+                lingering = _reap_processes(procs)
+                self.assertFalse(lingering, f"workers survived cleanup: {lingering}")
                 self.assertFalse([result for result in results if "error" in result], results)
                 self.assertEqual(sum(result["claimed"] for result in results), 1, results)
                 pid_file.unlink(missing_ok=True)

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -546,6 +546,38 @@ class TestFreshClaimProtection(unittest.TestCase):
             pid_path.unlink(missing_ok=True)
             tmp_path.unlink(missing_ok=True)
 
+    def test_stale_pid_tmp_is_reclaimed_before_spawn(self):
+        """A reservation left by a killed parent must not block restart forever."""
+        from cozempic import spawn_lock
+        from cozempic.guard import _pid_file_for_session, start_guard_daemon
+
+        session_id = "beef1234-5678-9abc-def0-2026051811aa"
+        pid_path = _pid_file_for_session(session_id)
+        tmp_path = pid_path.with_suffix(".pid.tmp")
+        pid_path.unlink(missing_ok=True)
+        tmp_path.write_text("stale\n", encoding="utf-8")
+        stale_at = time.time() - spawn_lock._FRESH_PIDFILE_SECONDS - 1
+        os.utime(tmp_path, (stale_at, stale_at))
+
+        class _DummyProc:
+            pid = 987654
+
+        try:
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch("cozempic.guard.find_claude_pid", return_value=12345),
+                patch("cozempic.guard.subprocess.Popen", return_value=_DummyProc()) as popen,
+            ):
+                result = start_guard_daemon(
+                    cwd=tempfile.gettempdir(), session_id=session_id, threshold_tokens=1000
+                )
+            self.assertTrue(result["started"])
+            popen.assert_called_once()
+        finally:
+            pid_path.unlink(missing_ok=True)
+            tmp_path.unlink(missing_ok=True)
+
 
 class TestStaleClaimContention(unittest.TestCase):
     """A stale PID file still admits exactly one cross-process claimant."""

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -161,6 +161,9 @@ class TestThreeProcessContention(unittest.TestCase):
                 if p.is_alive():
                     p.terminate()
                     p.join(timeout=2.0)
+                    if p.is_alive():
+                        p.kill()
+                        p.join(timeout=2.0)
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -245,6 +248,9 @@ class TestV4TenProcessContention(unittest.TestCase):
                 if p.is_alive():
                     p.terminate()
                     p.join(timeout=2.0)
+                    if p.is_alive():
+                        p.kill()
+                        p.join(timeout=2.0)
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -603,6 +609,9 @@ class TestStaleClaimContention(unittest.TestCase):
                     if proc.is_alive():
                         proc.terminate()
                         proc.join(timeout=2.0)
+                        if proc.is_alive():
+                            proc.kill()
+                            proc.join(timeout=2.0)
                 self.assertFalse([result for result in results if "error" in result], results)
                 self.assertEqual(sum(result["claimed"] for result in results), 1, results)
                 pid_file.unlink(missing_ok=True)

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -48,13 +48,8 @@ def _race_worker(
 
     def _fake_popen(cmd_parts, **kwargs):
         # Fake ONLY the daemon-spawn Popen (python -m cozempic.cli guard).
-        # Every other subprocess use — notably the `ps` identity probe inside
-        # _is_cozempic_guard_process, which subprocess.run drives via
-        # `with Popen(...) as p: p.communicate()` — must run for real; the
-        # global Popen patch otherwise hands `ps` a _DummyProc with no
-        # __enter__/communicate, raising AttributeError and turning every
-        # loser worker into an 'undefined' outcome (the deterministically-dead
-        # gate this test is supposed to be).
+        # Every other subprocess use must run for real. This is defensive
+        # against future changes that remove the current identity-probe mocks.
         parts = cmd_parts if isinstance(cmd_parts, (list, tuple)) else [cmd_parts]
         is_daemon_spawn = any("cozempic.cli" in str(p) for p in parts) or (
             any("cozempic" in str(p) for p in parts) and any(str(p) == "guard" for p in parts)
@@ -106,11 +101,13 @@ class TestThreeProcessContention(unittest.TestCase):
 
         self.pid_path = _pid_file_for_session(self.SESSION_ID)
         self.pid_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path = self.pid_path.with_suffix(".log")
         self.log_path.unlink(missing_ok=True)
 
     def tearDown(self):
         self.pid_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path.unlink(missing_ok=True)
 
     def test_three_process_contention(self):
@@ -123,6 +120,7 @@ class TestThreeProcessContention(unittest.TestCase):
         failures = []
         for it in range(ITERATIONS):
             self.pid_path.unlink(missing_ok=True)
+            self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
             self.log_path.unlink(missing_ok=True)
 
             barrier = ctx.Barrier(N)
@@ -188,6 +186,7 @@ class TestV4TenProcessContention(unittest.TestCase):
 
         self.pid_path = _pid_file_for_session(self.SESSION_ID)
         self.pid_path.unlink(missing_ok=True)
+        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path = self.pid_path.with_suffix(".log")
         self.log_path.unlink(missing_ok=True)
 
@@ -203,6 +202,7 @@ class TestV4TenProcessContention(unittest.TestCase):
         failures = []
         for it in range(self.ITERATIONS):
             self.pid_path.unlink(missing_ok=True)
+            self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
             self.log_path.unlink(missing_ok=True)
 
             barrier = ctx.Barrier(self.N)
@@ -465,6 +465,41 @@ class TestFreshClaimProtection(unittest.TestCase):
                 claim.__enter__()
 
         self.assertEqual(raised.exception.holder_pid, 900000)
+
+    def test_write_failure_removes_claim_file(self):
+        """A failed claim write cannot strand a fresh-looking pidfile."""
+        from cozempic.spawn_lock import DaemonSpawnClaim
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pid_file = Path(tmp_dir) / "guard.pid"
+            claim = DaemonSpawnClaim("test-session", pid_file)
+            with (
+                patch("cozempic.spawn_lock.os.write", side_effect=OSError("disk full")),
+                self.assertRaises(OSError),
+            ):
+                claim.__enter__()
+            self.assertFalse(pid_file.exists())
+
+    def test_guard_returns_claim_oserror_without_crashing(self):
+        """A claim I/O failure is a failed start, not a SessionStart traceback."""
+        from cozempic.guard import start_guard_daemon
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch(
+                    "cozempic.spawn_lock.DaemonSpawnClaim.__enter__",
+                    side_effect=OSError("disk full"),
+                ),
+            ):
+                result = start_guard_daemon(
+                    cwd=tmp_dir,
+                    session_id="abcd1234-5678-9abc-def0-2026051811aa",
+                    threshold_tokens=1000,
+                )
+        self.assertFalse(result["started"])
+        self.assertIn("pidfile claim", result["reason"])
 
 
 class TestSymlinkDefense(unittest.TestCase):
@@ -734,8 +769,7 @@ class TestC2_SlugConvergence(unittest.TestCase):
         name = p.name
         prefix = "cozempic_guard_"
         suffix = ".pid"
-        self_assert_invariant = name.startswith(prefix) and name.endswith(suffix)
-        assert self_assert_invariant, f"unexpected pid path shape: {name!r}"
+        assert name.startswith(prefix) and name.endswith(suffix), f"unexpected pid path shape: {name!r}"
         return name[len(prefix) : -len(suffix)]
 
     # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -637,8 +637,7 @@ class TestSymlinkDefense(unittest.TestCase):
 
     def test_pid_tmp_write_rejects_symlink(self):
         """Attacker pre-plants .pid.tmp as a symlink to a victim file.
-        The post-Popen atomic-rename write path MUST refuse it and leave
-        the victim untouched."""
+        The reservation is removed safely and the victim remains untouched."""
         from unittest.mock import patch
 
         from cozempic.guard import start_guard_daemon
@@ -668,26 +667,12 @@ class TestSymlinkDefense(unittest.TestCase):
                 threshold_tokens=1000,
             )
 
-        # The spawn body raised OSError on the os.open(O_EXCL|O_NOFOLLOW)
-        # and surfaced a structured failure (started=False, reason="pidfile:
-        # ..."). The DaemonSpawnClaim's __exit__ unlinked the parent-PID
-        # claim file we wrote at _claim time (handed_off=False).
-        self.assertFalse(
-            result.get("started"),
-            f"Spawn should have FAILED — symlink defense breached. " f"Got: {result!r}",
-        )
-        self.assertIn(
-            "reason",
-            result,
-            f"Failure path must carry a structured reason; got {result!r}",
-        )
+        self.assertTrue(result.get("started"), f"Spawn did not reclaim the symlink: {result!r}")
         # CRITICAL: the victim file must be untouched.
         self.assertEqual(
             self.victim.read_text(encoding="utf-8"),
             "ORIGINAL\n",
-            "Victim file was overwritten — C1 symlink TOCTOU regression. "
-            "The .pid.tmp write must use O_NOFOLLOW (or fail closed on "
-            "EEXIST when the path already exists, which O_EXCL guarantees).",
+            "Victim file was overwritten while reclaiming the reservation.",
         )
 
     def test_reclaim_lock_rejects_symlink(self):

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -447,20 +447,22 @@ class TestFreshClaimProtection(unittest.TestCase):
 
     def test_fresh_dead_pid_is_not_reclaimed(self):
         """A freshly written dead PID is a peer claim, not stale state."""
+        from cozempic import spawn_lock
         from cozempic.spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             pid_file = Path(tmp_dir) / "guard.pid"
             pid_file.write_text("900000\n", encoding="utf-8")
-            fresh_now = pid_file.stat().st_mtime + 1.0
+            fresh_window = spawn_lock._FRESH_PIDFILE_SECONDS
+            fresh_now = pid_file.stat().st_mtime + fresh_window / 2
+            claim = DaemonSpawnClaim("test-session", pid_file)
 
             with (
                 patch("cozempic.spawn_lock._is_process_alive", return_value=False),
                 patch("cozempic.spawn_lock.time.time", return_value=fresh_now),
                 self.assertRaises(DaemonAlreadyStarting) as raised,
             ):
-                with DaemonSpawnClaim("test-session", pid_file):
-                    self.fail("fresh dead PID file was reclaimed")
+                claim.__enter__()
 
         self.assertEqual(raised.exception.holder_pid, 900000)
 

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -91,6 +91,25 @@ def _race_worker(
         result_queue.put(r)
 
 
+def _stale_claim_worker(barrier_handle, result_queue, pid_file: str, worker_index: int):
+    """Race stale-claim recovery without spawning a real guard."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+    from cozempic.spawn_lock import DaemonAlreadyStarting, DaemonSpawnClaim
+
+    try:
+        barrier_handle.wait(timeout=10.0)
+        claim = DaemonSpawnClaim("stale-claim-test", Path(pid_file))
+        claim.__enter__()
+        claim.handed_off = True
+        result_queue.put({"claimed": True, "worker": worker_index})
+        time.sleep(0.1)
+        claim.__exit__(None, None, None)
+    except DaemonAlreadyStarting as exc:
+        result_queue.put({"claimed": False, "holder_pid": exc.holder_pid, "worker": worker_index})
+    except Exception as exc:
+        result_queue.put({"error": repr(exc), "worker": worker_index})
+
+
 class TestThreeProcessContention(unittest.TestCase):
     """Three processes race for the same session — exactly ONE must win."""
 
@@ -495,11 +514,69 @@ class TestFreshClaimProtection(unittest.TestCase):
             ):
                 result = start_guard_daemon(
                     cwd=tmp_dir,
-                    session_id="abcd1234-5678-9abc-def0-2026051811aa",
+                    session_id="bead1234-5678-9abc-def0-2026051811aa",
                     threshold_tokens=1000,
                 )
         self.assertFalse(result["started"])
         self.assertIn("pidfile claim", result["reason"])
+
+    def test_pid_tmp_conflict_prevents_spawn(self):
+        """A stale publication temp file must fail before creating a child."""
+        from cozempic.guard import _pid_file_for_session, start_guard_daemon
+
+        session_id = "deed1234-5678-9abc-def0-2026051811aa"
+        pid_path = _pid_file_for_session(session_id)
+        tmp_path = pid_path.with_suffix(".pid.tmp")
+        pid_path.unlink(missing_ok=True)
+        tmp_path.write_text("stale\n", encoding="utf-8")
+        try:
+            with (
+                patch("cozempic.guard._is_guard_running_for_session", return_value=None),
+                patch("cozempic.guard._cleanup_legacy_pid"),
+                patch("cozempic.guard.find_claude_pid", return_value=12345),
+                patch("cozempic.guard.subprocess.Popen") as popen,
+            ):
+                result = start_guard_daemon(
+                    cwd=tempfile.gettempdir(), session_id=session_id, threshold_tokens=1000
+                )
+            self.assertFalse(result["started"])
+            self.assertIn("pidfile", result["reason"])
+            popen.assert_not_called()
+        finally:
+            pid_path.unlink(missing_ok=True)
+            tmp_path.unlink(missing_ok=True)
+
+
+class TestStaleClaimContention(unittest.TestCase):
+    """A stale PID file still admits exactly one cross-process claimant."""
+
+    def test_two_processes_one_reclaimer(self):
+        from cozempic import spawn_lock
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pid_file = Path(tmp_dir) / "guard.pid"
+            ctx = mp.get_context("spawn")
+            for _ in range(10):
+                pid_file.write_text("999999999\n", encoding="utf-8")
+                stale_at = time.time() - spawn_lock._FRESH_PIDFILE_SECONDS - 1
+                os.utime(pid_file, (stale_at, stale_at))
+                barrier = ctx.Barrier(2)
+                queue = ctx.Queue()
+                procs = [
+                    ctx.Process(target=_stale_claim_worker, args=(barrier, queue, str(pid_file), i))
+                    for i in range(2)
+                ]
+                for proc in procs:
+                    proc.start()
+                results = [queue.get(timeout=10.0) for _ in procs]
+                for proc in procs:
+                    proc.join(timeout=5.0)
+                    if proc.is_alive():
+                        proc.terminate()
+                        proc.join(timeout=2.0)
+                self.assertFalse([result for result in results if "error" in result], results)
+                self.assertEqual(1, sum(result["claimed"] for result in results), results)
+                pid_file.unlink(missing_ok=True)
 
 
 class TestSymlinkDefense(unittest.TestCase):

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -166,16 +166,17 @@ class TestThreeProcessContention(unittest.TestCase):
                 )
                 for i in range(N)
             ]
-            for p in procs:
-                p.start()
-
             results = []
-            for _ in range(N):
-                try:
-                    results.append(queue.get(timeout=15.0))
-                except Exception as e:
-                    results.append({"error": f"queue.get failed: {e!r}"})
-            lingering = _reap_processes(procs)
+            try:
+                for p in procs:
+                    p.start()
+                for _ in range(N):
+                    try:
+                        results.append(queue.get(timeout=15.0))
+                    except Exception as e:
+                        results.append({"error": f"queue.get failed: {e!r}"})
+            finally:
+                lingering = _reap_processes(procs)
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -247,16 +248,17 @@ class TestV4TenProcessContention(unittest.TestCase):
                 )
                 for i in range(self.N)
             ]
-            for p in procs:
-                p.start()
-
             results = []
-            for _ in range(self.N):
-                try:
-                    results.append(queue.get(timeout=20.0))
-                except Exception as e:
-                    results.append({"error": f"queue.get: {e!r}"})
-            lingering = _reap_processes(procs)
+            try:
+                for p in procs:
+                    p.start()
+                for _ in range(self.N):
+                    try:
+                        results.append(queue.get(timeout=20.0))
+                    except Exception as e:
+                        results.append({"error": f"queue.get: {e!r}"})
+            finally:
+                lingering = _reap_processes(procs)
 
             started = [r for r in results if r.get("started") is True]
             already = [r for r in results if r.get("already_running") is True]
@@ -608,10 +610,10 @@ class TestStaleClaimContention(unittest.TestCase):
                     ctx.Process(target=_stale_claim_worker, args=(barrier, queue, str(pid_file), i))
                     for i in range(2)
                 ]
-                for proc in procs:
-                    proc.start()
                 results = []
                 try:
+                    for proc in procs:
+                        proc.start()
                     for _ in procs:
                         try:
                             results.append(queue.get(timeout=10.0))

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -106,15 +106,18 @@ def _stale_claim_worker(barrier_handle, result_queue, pid_file: str, worker_inde
 def _reap_processes(procs) -> list[str]:
     lingering = []
     for proc in procs:
-        proc.join(timeout=5.0)
-        if proc.is_alive():
-            proc.terminate()
-            proc.join(timeout=2.0)
-        if proc.is_alive():
-            proc.kill()
-            proc.join(timeout=2.0)
-        if proc.is_alive():
-            lingering.append(proc.name)
+        try:
+            proc.join(timeout=5.0)
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=2.0)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=2.0)
+            if proc.is_alive():
+                lingering.append(proc.name)
+        except Exception as exc:
+            lingering.append(f"{proc.name}: {exc!r}")
     return lingering
 
 
@@ -271,6 +274,7 @@ class TestV4TenProcessContention(unittest.TestCase):
                         "already_count": len(already),
                         "undefined_count": len(undefined),
                         "started_workers": [r.get("worker") for r in started],
+                        "lingering": lingering,
                         "first_undefined": undefined[0] if undefined else None,
                     }
                 )
@@ -606,8 +610,15 @@ class TestStaleClaimContention(unittest.TestCase):
                 ]
                 for proc in procs:
                     proc.start()
-                results = [queue.get(timeout=10.0) for _ in procs]
-                lingering = _reap_processes(procs)
+                results = []
+                try:
+                    for _ in procs:
+                        try:
+                            results.append(queue.get(timeout=10.0))
+                        except Exception as exc:
+                            results.append({"error": repr(exc)})
+                finally:
+                    lingering = _reap_processes(procs)
                 self.assertFalse(lingering, f"workers survived cleanup: {lingering}")
                 self.assertFalse([result for result in results if "error" in result], results)
                 self.assertEqual(sum(result["claimed"] for result in results), 1, results)

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -622,7 +622,8 @@ class TestSymlinkDefense(unittest.TestCase):
         import shutil
 
         shutil.rmtree(self.tmpdir, ignore_errors=True)
-        for p in (self.pid_path, self.tmp_pid_path, self.log_path):
+        reclaim_lock = self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock")
+        for p in (self.pid_path, self.tmp_pid_path, self.log_path, reclaim_lock):
             try:
                 p.unlink()
             except (FileNotFoundError, OSError):
@@ -682,6 +683,19 @@ class TestSymlinkDefense(unittest.TestCase):
             "The .pid.tmp write must use O_NOFOLLOW (or fail closed on "
             "EEXIST when the path already exists, which O_EXCL guarantees).",
         )
+
+    def test_reclaim_lock_rejects_symlink(self):
+        """The persistent stale-reclaim lock must not follow a symlink."""
+        if not hasattr(os, "O_NOFOLLOW"):
+            self.skipTest("platform has no O_NOFOLLOW")
+        from cozempic.spawn_lock import _stale_reclaim_lock
+
+        lock_path = self.pid_path.with_name(f"{self.pid_path.name}.reclaim-lock")
+        os.symlink(str(self.victim), str(lock_path))
+        with self.assertRaises(OSError):
+            with _stale_reclaim_lock(self.pid_path):
+                pass
+        self.assertEqual(self.victim.read_text(encoding="utf-8"), "ORIGINAL\n")
 
 
 class TestFileNotFoundErrorRecovery(unittest.TestCase):

--- a/tests/test_spawn_lock.py
+++ b/tests/test_spawn_lock.py
@@ -58,18 +58,10 @@ def _race_worker(
             return _DummyProc(900_000 + worker_index)
         return _real_popen(cmd_parts, **kwargs)
 
-    def _fake_is_process_alive(pid: int) -> bool:
-        """Model the spawned fake guard as alive for the contention check."""
-        return pid > 0
-
     with (
         _patch("cozempic.guard.subprocess.Popen", side_effect=_fake_popen),
         _patch("cozempic.guard.find_claude_pid", return_value=12345),
         _patch("cozempic.guard._cleanup_legacy_pid"),
-        _patch("cozempic.guard._is_guard_running_for_session", return_value=None),
-        _patch(
-            "cozempic.spawn_lock._is_process_alive", side_effect=_fake_is_process_alive
-        ),
     ):
         try:
             barrier_handle.wait(timeout=10.0)
@@ -120,13 +112,11 @@ class TestThreeProcessContention(unittest.TestCase):
 
         self.pid_path = _pid_file_for_session(self.SESSION_ID)
         self.pid_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path = self.pid_path.with_suffix(".log")
         self.log_path.unlink(missing_ok=True)
 
     def tearDown(self):
         self.pid_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path.unlink(missing_ok=True)
 
     def test_three_process_contention(self):
@@ -139,7 +129,6 @@ class TestThreeProcessContention(unittest.TestCase):
         failures = []
         for it in range(ITERATIONS):
             self.pid_path.unlink(missing_ok=True)
-            self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
             self.log_path.unlink(missing_ok=True)
 
             barrier = ctx.Barrier(N)
@@ -205,7 +194,6 @@ class TestV4TenProcessContention(unittest.TestCase):
 
         self.pid_path = _pid_file_for_session(self.SESSION_ID)
         self.pid_path.unlink(missing_ok=True)
-        self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
         self.log_path = self.pid_path.with_suffix(".log")
         self.log_path.unlink(missing_ok=True)
 
@@ -221,7 +209,6 @@ class TestV4TenProcessContention(unittest.TestCase):
         failures = []
         for it in range(self.ITERATIONS):
             self.pid_path.unlink(missing_ok=True)
-            self.pid_path.with_suffix(".pid.tmp").unlink(missing_ok=True)
             self.log_path.unlink(missing_ok=True)
 
             barrier = ctx.Barrier(self.N)
@@ -594,7 +581,7 @@ class TestStaleClaimContention(unittest.TestCase):
                         proc.terminate()
                         proc.join(timeout=2.0)
                 self.assertFalse([result for result in results if "error" in result], results)
-                self.assertEqual(1, sum(result["claimed"] for result in results), results)
+                self.assertEqual(sum(result["claimed"] for result in results), 1, results)
                 pid_file.unlink(missing_ok=True)
 
 


### PR DESCRIPTION
## Summary
- model mocked guard processes as live in claim-focused contention tests
- keep fresh dead-PID protection covered by a deterministic unit test

## Verification
- `uv run --frozen --with pytest pytest tests/test_guard_race_2026_05_18.py::TestR1_DaemonProcessRace::test_two_processes_one_winner tests/test_spawn_lock.py::TestThreeProcessContention::test_three_process_contention tests/test_spawn_lock.py::TestV4TenProcessContention::test_ten_process_contention_30x tests/test_spawn_lock.py::TestFreshClaimProtection::test_fresh_dead_pid_is_not_reclaimed -q`

## Review

Required review tiers: tier-1,tier-2,tier-3

Approval authority: requester
