### PR TITLE
fix(windows): eliminate console-window flashing from guard daemon & subprocess calls

### DIFF
--- a/src/cozempic/_subprocess.py
+++ b/src/cozempic/_subprocess.py
@@ -1,0 +1,59 @@
+"""Windows-quiet subprocess wrappers.
+
+On Windows, a console program (``ps``, ``taskkill``, ``git``, ``uv``, the
+guard-daemon relaunch, …) spawned by a GUI or detached parent *without* the
+``CREATE_NO_WINDOW`` creation flag briefly allocates a console host window — a
+visible flash. cozempic shells out ~two dozen times, so running each of those
+through ``subprocess`` directly makes a window flash on every guard spawn, PID
+lookup, auto-update check, etc. These thin wrappers inject ``CREATE_NO_WINDOW``
+by default so the child stays windowless.
+
+Everything here is a no-op on POSIX: ``CREATE_NO_WINDOW`` doesn't exist there
+(``getattr`` resolves to 0), and ``creationflags`` is a documented ``Popen``
+keyword on all platforms that must be 0 on POSIX — which is exactly what
+``_quiet_flags`` returns off Windows.
+
+Use these in place of ``subprocess.run`` / ``.Popen`` / ``.call``. Callers that
+genuinely want a visible console can pass ``creationflags=subprocess.CREATE_NEW_CONSOLE``
+and it is honored (the two flags are mutually exclusive, so we don't add
+CREATE_NO_WINDOW on top).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+_CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+_CREATE_NEW_CONSOLE = getattr(subprocess, "CREATE_NEW_CONSOLE", 0)
+
+
+def _quiet_flags(creationflags: int = 0) -> int:
+    """Return ``creationflags`` with CREATE_NO_WINDOW OR-ed in on Windows.
+
+    No-op on POSIX. Left unchanged when the caller explicitly requested a new
+    console (CREATE_NEW_CONSOLE), since that is mutually exclusive with
+    CREATE_NO_WINDOW.
+    """
+    if os.name != "nt":
+        return creationflags
+    if creationflags & _CREATE_NEW_CONSOLE:
+        return creationflags
+    return creationflags | _CREATE_NO_WINDOW
+
+
+def run(*args, **kwargs):
+    """``subprocess.run`` that is windowless-by-default on Windows."""
+    kwargs["creationflags"] = _quiet_flags(kwargs.get("creationflags", 0))
+    return subprocess.run(*args, **kwargs)
+
+
+def popen(*args, **kwargs):
+    """``subprocess.Popen`` that is windowless-by-default on Windows."""
+    kwargs["creationflags"] = _quiet_flags(kwargs.get("creationflags", 0))
+    return subprocess.Popen(*args, **kwargs)
+
+
+def call(*args, **kwargs):
+    """``subprocess.call`` that is windowless-by-default on Windows."""
+    kwargs["creationflags"] = _quiet_flags(kwargs.get("creationflags", 0))
+    return subprocess.call(*args, **kwargs)

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import _subprocess as _sp
 from .config import load_config
 from .diagnosis import diagnose_session
 from .doctor import run_doctor
@@ -904,14 +905,12 @@ def cmd_reload(args):
 
         if term_env == "tmux":
             pane = os.environ.get("TMUX_PANE", "")
-            import subprocess as sp
-            sp.run(["tmux", "send-keys", *(["-t", pane] if pane else []), "/exit", "Enter"],
+            _sp.run(["tmux", "send-keys", *(["-t", pane] if pane else []), "/exit", "Enter"],
                    capture_output=True, timeout=5)
             print(f"  Resuming with optimized context...")
         elif term_env == "screen":
             screen_session = os.environ.get("STY", "")
-            import subprocess as sp
-            sp.run(["screen", "-S", screen_session, "-X", "stuff", "/exit\n"],
+            _sp.run(["screen", "-S", screen_session, "-X", "stuff", "/exit\n"],
                    capture_output=True, timeout=5)
             print(f"  Resuming with optimized context...")
         else:
@@ -973,7 +972,7 @@ def _spawn_watcher(claude_pid: int, project_dir: str, recap_path: Path | None = 
         f"echo \"$(date): Cozempic resumed Claude in {project_dir}\" >> /tmp/cozempic_reload.log"
     )
 
-    subprocess.Popen(
+    _sp.popen(
         ["bash", "-c", watcher_script],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -28,6 +28,8 @@ import threading
 import time
 from pathlib import Path
 
+from . import _subprocess as _sp
+
 # P0-B: imported at module level so guard_prune_cycle can catch the exception
 # without an inner try/except that masks import errors during testing.
 # safety.py is a new module (this PR); the import is always available once
@@ -1415,7 +1417,7 @@ def _detect_interactive(claude_pid: int | None) -> bool:
     if not claude_pid:
         return True
     try:
-        out = subprocess.run(
+        out = _sp.run(
             ["ps", "-o", "tty=", "-p", str(claude_pid)],
             capture_output=True, text=True, timeout=3,
         ).stdout.strip()
@@ -2033,7 +2035,7 @@ def _is_cozempic_watcher_process(pid: int) -> bool:
     Guards against false positives from pgrep substring matching.
     """
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["ps", "-p", str(pid), "-o", "args="],
             capture_output=True, text=True, timeout=3, check=False,
         )
@@ -2053,7 +2055,7 @@ def _cleanup_stale_watchers() -> None:
     detection. They linger as zombie processes waiting for Claude to exit.
     """
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["pgrep", "-f", "cozempic.*resumed Claude"],
             capture_output=True, text=True, timeout=5,
         )
@@ -2098,7 +2100,7 @@ def _detect_claude_flags(pid: int) -> str:
     # Fallback: ps -o args= + shlex.split (loses space-boundary info on macOS).
     if not parts:
         try:
-            result = subprocess.run(
+            result = _sp.run(
                 ["ps", "-p", str(pid), "-o", "args="],
                 capture_output=True, text=True, timeout=5,
             )
@@ -2294,7 +2296,7 @@ def _terminate_and_resume(
         print(f"  tmux detected — sending /exit and auto-resuming in same pane...")
 
         # Send /exit to Claude
-        subprocess.run(
+        _sp.run(
             ["tmux", "send-keys", *(["-t", pane] if pane else []), "/exit", "Enter"],
             capture_output=True, timeout=5,
         )
@@ -2315,7 +2317,7 @@ def _terminate_and_resume(
             write_pruned()
 
         # Resume in same pane
-        subprocess.run(
+        _sp.run(
             ["tmux", "send-keys", *(["-t", pane] if pane else []),
              f"cd {shell_quote(project_dir)} && {resume_cmd}", "Enter"],
             capture_output=True, timeout=5,
@@ -2344,7 +2346,7 @@ def _terminate_and_resume(
         screen_session = os.environ.get("STY", "")
         print(f"  screen detected — sending /exit and auto-resuming...")
 
-        subprocess.run(
+        _sp.run(
             ["screen", "-S", screen_session, "-X", "stuff", "/exit\n"],
             capture_output=True, timeout=5,
         )
@@ -2360,7 +2362,7 @@ def _terminate_and_resume(
         if write_pruned is not None and not _pid_is_alive(claude_pid):
             write_pruned()
 
-        subprocess.run(
+        _sp.run(
             ["screen", "-S", screen_session, "-X", "stuff",
              f"cd {shell_quote(project_dir)} && {resume_cmd}\n"],
             capture_output=True, timeout=5,
@@ -2378,7 +2380,7 @@ def _terminate_and_resume(
     try:
         if system == "Windows":
             if _is_claude_process(claude_pid, session_path=session_path):
-                subprocess.call(["taskkill", "/PID", str(claude_pid)],
+                _sp.call(["taskkill", "/PID", str(claude_pid)],
                                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         else:
             if _is_claude_process(claude_pid, session_path=session_path):
@@ -2390,7 +2392,7 @@ def _terminate_and_resume(
         try:
             if system == "Windows":
                 if _is_claude_process(claude_pid, session_path=session_path):
-                    subprocess.call(["taskkill", "/F", "/PID", str(claude_pid)],
+                    _sp.call(["taskkill", "/F", "/PID", str(claude_pid)],
                                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             else:
                 if _is_claude_process(claude_pid, session_path=session_path):
@@ -2592,12 +2594,15 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
 
     if system == "Windows":
         # PowerShell-native watcher (the bash watcher_script above is POSIX-only
-        # and would never run on Windows). DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP
-        # so it outlives this process; no start_new_session (POSIX-only kwarg).
+        # and would never run on Windows). CREATE_NEW_PROCESS_GROUP so it outlives
+        # this process; no start_new_session (POSIX-only kwarg). We do NOT pass
+        # DETACHED_PROCESS: it is mutually exclusive with the CREATE_NO_WINDOW
+        # that _sp.popen adds, and combining them makes a console window flash.
+        # CREATE_NEW_PROCESS_GROUP + non-inheritable DEVNULL stdio is enough to
+        # detach the watcher.
         _flags = 0
-        _flags |= getattr(subprocess, "DETACHED_PROCESS", 0)
         _flags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        subprocess.Popen(
+        _sp.popen(
             ["powershell", "-NoProfile", "-NonInteractive", "-Command", windows_ps_script],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -2605,7 +2610,7 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
             creationflags=_flags,
         )
     else:
-        subprocess.Popen(
+        _sp.popen(
             ["bash", "-c", watcher_script],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -3706,14 +3711,16 @@ def start_guard_daemon(
                     "env": env,
                 }
                 if os.name == "nt":
-                    popen_kwargs["creationflags"] = (
-                        subprocess.DETACHED_PROCESS
-                        | subprocess.CREATE_NEW_PROCESS_GROUP
-                        | subprocess.CREATE_NO_WINDOW
-                    )
+                    # DETACHED_PROCESS and CREATE_NO_WINDOW are mutually exclusive
+                    # (Win32); passing both makes a console window flash. Use
+                    # CREATE_NEW_PROCESS_GROUP only here — _sp.popen adds
+                    # CREATE_NO_WINDOW — which, with non-inheritable stdio (the log
+                    # file / DEVNULL), still detaches the daemon so it outlives the
+                    # parent.
+                    popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
                 else:
                     popen_kwargs["start_new_session"] = True
-                proc = subprocess.Popen(cmd_parts, **popen_kwargs)
+                proc = _sp.popen(cmd_parts, **popen_kwargs)
             finally:
                 lf.close()
 
@@ -3842,7 +3849,7 @@ def _is_cozempic_guard_process(pid: int) -> bool:
     match unrelated things like `vim /tmp/cozempic_guard_notes.md`.
     """
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["ps", "-p", str(pid), "-o", "args="],
             capture_output=True, text=True, timeout=3, check=False,
         )
@@ -3872,7 +3879,7 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         # no daemon), which is strictly safer than signaling the wrong one.
         # TypeError covers the test-only case where a Popen mock returns a
         # bare object that doesn't support the ctx-manager protocol
-        # subprocess.run uses internally; production callers never hit it,
+        # _sp.run uses internally; production callers never hit it,
         # but any unhandled exception here would propagate to the
         # non-interactive SessionStart hook surface — fail closed.
         return False
@@ -3915,7 +3922,7 @@ def _get_pid_start_time_linux(pid: int) -> float | None:
 def _get_pid_start_time_macos(pid: int) -> float | None:
     """macOS: parse ps -o lstart= output. 1-second resolution; LC_ALL=C for locale safety."""
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["ps", "-p", str(pid), "-o", "lstart="],
             capture_output=True, text=True, timeout=2.0, check=False,
             env={**os.environ, "LC_ALL": "C"},
@@ -4038,7 +4045,7 @@ def _is_claude_process(pid: int, session_path: Path | None = None) -> bool:
     if platform.system() == "Windows":
         return _is_claude_process_windows(pid)
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["ps", "-p", str(pid), "-o", "args="],
             capture_output=True, text=True, timeout=3, check=False,
         )
@@ -4076,7 +4083,7 @@ def _is_claude_process(pid: int, session_path: Path | None = None) -> bool:
 def _is_claude_process_windows(pid: int) -> bool:
     """Windows-specific helper: probe via tasklist /FO CSV."""
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
             capture_output=True, text=True, timeout=5, check=False,
         )

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
+from . import _subprocess as _sp
 from .helpers import _pid_is_alive as _pid_alive
 from .types import Message
 
@@ -302,7 +303,7 @@ def find_claude_pid() -> int | None:
     try:
         pid = os.getpid()
         for _ in range(10):
-            result = subprocess.run(
+            result = _sp.run(
                 ["ps", "-o", "ppid=,comm=", "-p", str(pid)],
                 capture_output=True, text=True,
             )
@@ -335,7 +336,7 @@ def _session_id_from_process() -> str | None:
         return None
 
     try:
-        result = subprocess.run(
+        result = _sp.run(
             ["lsof", "-p", str(claude_pid)],
             capture_output=True, text=True, timeout=5,
         )

--- a/src/cozempic/updater.py
+++ b/src/cozempic/updater.py
@@ -6,7 +6,6 @@ import json
 import os
 import re
 import shutil
-import subprocess
 import sys
 import time
 from pathlib import Path

--- a/src/cozempic/updater.py
+++ b/src/cozempic/updater.py
@@ -14,6 +14,7 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from . import __version__
+from . import _subprocess as _sp
 
 _PYPI_URL = "https://pypi.org/pypi/cozempic/json"
 _COUNTER_URL = "https://cozempic-counters.counterapi-ruya.workers.dev/counter/auto_updates/up"
@@ -106,7 +107,7 @@ def _do_upgrade(latest: str) -> bool:
     if method == "uv-tool":
         if shutil.which("uv"):
             try:
-                r = subprocess.run(["uv", "tool", "upgrade", "cozempic"],
+                r = _sp.run(["uv", "tool", "upgrade", "cozempic"],
                                    capture_output=True, timeout=120)
                 if r.returncode == 0:
                     return True
@@ -116,7 +117,7 @@ def _do_upgrade(latest: str) -> bool:
     if method == "pipx":
         if shutil.which("pipx"):
             try:
-                r = subprocess.run(["pipx", "upgrade", "cozempic"],
+                r = _sp.run(["pipx", "upgrade", "cozempic"],
                                    capture_output=True, timeout=120)
                 if r.returncode == 0:
                     return True
@@ -127,7 +128,7 @@ def _do_upgrade(latest: str) -> bool:
     # Try uv pip install first (works in uv-managed environments)
     if shutil.which("uv"):
         try:
-            result = subprocess.run(
+            result = _sp.run(
                 ["uv", "pip", "install", f"cozempic=={latest}", "--quiet"],
                 capture_output=True,
                 timeout=60,
@@ -139,7 +140,7 @@ def _do_upgrade(latest: str) -> bool:
 
     # Try pip via sys.executable (works in pip-managed venvs)
     try:
-        result = subprocess.run(
+        result = _sp.run(
             [sys.executable, "-m", "pip", "install", f"cozempic=={latest}",
              "--quiet", "--disable-pip-version-check"],
             capture_output=True,
@@ -153,7 +154,7 @@ def _do_upgrade(latest: str) -> bool:
     # Try bare pip (works when pip is on PATH but not in current venv)
     if shutil.which("pip"):
         try:
-            result = subprocess.run(
+            result = _sp.run(
                 ["pip", "install", f"cozempic=={latest}",
                  "--quiet", "--disable-pip-version-check"],
                 capture_output=True,

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -180,7 +180,7 @@ class TestDoUpgradeDispatch(unittest.TestCase):
     def test_brew_never_autoruns(self):
         from cozempic import updater
         with patch.object(updater, "_install_method", return_value="brew"), \
-             patch("cozempic.updater.subprocess.run") as run:
+             patch("cozempic.updater._sp.run") as run:
             self.assertFalse(updater._do_upgrade("9.9.9"))
             run.assert_not_called()
 
@@ -188,7 +188,7 @@ class TestDoUpgradeDispatch(unittest.TestCase):
         from cozempic import updater
         with patch.object(updater, "_install_method", return_value="uv-tool"), \
              patch("cozempic.updater.shutil.which", return_value="/usr/bin/uv"), \
-             patch("cozempic.updater.subprocess.run",
+             patch("cozempic.updater._sp.run",
                    return_value=MagicMock(returncode=0)) as run:
             self.assertTrue(updater._do_upgrade("9.9.9"))
             self.assertEqual(run.call_args[0][0], ["uv", "tool", "upgrade", "cozempic"])
@@ -197,7 +197,7 @@ class TestDoUpgradeDispatch(unittest.TestCase):
         from cozempic import updater
         with patch.object(updater, "_install_method", return_value="pip"), \
              patch("cozempic.updater.shutil.which", return_value=None), \
-             patch("cozempic.updater.subprocess.run",
+             patch("cozempic.updater._sp.run",
                    return_value=MagicMock(returncode=0)) as run:
             self.assertTrue(updater._do_upgrade("9.9.9"))
             # first attempt is `pip install cozempic==…` via sys.executable


### PR DESCRIPTION
## Problem

On Windows, starting a Claude Code session with the cozempic guard hook active makes a burst of console (command-prompt) windows flash in and out — on every session start, and again on guard spawns / PID lookups during a session. It's disruptive: the flashes can steal focus from whatever you're typing in another window.

## Root cause

cozempic shells out ~28 times (`ps`, `taskkill`, `git`, `uv`, the guard-daemon relaunch, the reload watcher, …). Two Win32 issues make those flash:

1. **Missing `CREATE_NO_WINDOW`.** A console program spawned by a GUI/detached parent without this flag briefly allocates a console host window. None of the ~28 call sites passed it.
2. **`DETACHED_PROCESS | CREATE_NO_WINDOW` are mutually exclusive.** `start_guard_daemon` and the reload watcher combined them; per the Win32 docs these flags conflict, and combining them *materializes* a console window instead of suppressing it.

## Fix

- Add `cozempic/_subprocess.py` — thin `run` / `Popen` / `call` wrappers that OR `CREATE_NO_WINDOW` into `creationflags` on Windows (and honor an explicit `CREATE_NEW_CONSOLE`, since that's the mutually-exclusive opposite). All execution call sites route through it, so no site can silently miss the flag.
- Drop `DETACHED_PROCESS` from the two Windows spawns; keep `CREATE_NEW_PROCESS_GROUP`. With non-inheritable stdio (the log file / `DEVNULL`), the daemon still outlives the parent — verified the daemon persists across parent exit.

## Cross-platform safety

No-op on POSIX by construction:

- `CREATE_NO_WINDOW` / `DETACHED_PROCESS` don't exist off Windows; they're read via `getattr(subprocess, "...", 0)` → `0`.
- `creationflags` is a documented `Popen` keyword on all platforms and must be `0` on POSIX — exactly what the helper returns off Windows.
- The POSIX detachment path (`start_new_session=True`) is unchanged.

## Testing

- Full test suite: identical results before and after this change (same pre-existing platform-specific failures, same passes) — the change is behavior-neutral except for the intended flag/subprocess fix.
- Manual: on Windows, the SessionStart hook that used to flash a burst of console windows now runs with **zero** flashes; the guard daemon still starts and runs windowless.

## Repro (before this change)

On a Windows machine, start a Claude Code session with the cozempic guard hook wired — a burst of console windows flashes as the guard spawns and probes the process tree. With this change: none.
