### PR TITLE
fix(windows): guard daemons never exit and duplicate — POSIX-only lifecycle probes

### DIFF
--- a/src/cozempic/doctor.py
+++ b/src/cozempic/doctor.py
@@ -261,13 +261,12 @@ def _is_live_guard_pid(pid: int) -> bool:
     Delegates process-argv verification to the canonical helper in guard.py
     (`_is_cozempic_guard_process`) so PID-reuse defense stays in one place.
     """
-    import os as _os
+    from .guard import _is_cozempic_guard_process, _kill0_probe
 
     try:
-        _os.kill(pid, 0)
+        _kill0_probe(pid)
     except (ProcessLookupError, PermissionError, OSError):
         return False
-    from .guard import _is_cozempic_guard_process
     return _is_cozempic_guard_process(pid)
 
 
@@ -1143,8 +1142,8 @@ def check_cozempic_daemon_running() -> CheckResult:
     stranger process doesn't produce a false-positive "daemon running".
     """
     from pathlib import Path as _Path
-    import os as _os, glob as _glob
-    from .guard import _is_cozempic_guard_process
+    import glob as _glob
+    from .guard import _is_cozempic_guard_process, _kill0_probe
     from .spawn_lock import _parse_pidfile_pid
     pids_alive: list[int] = []
     for pidf in _glob.glob("/tmp/cozempic_guard_*.pid"):
@@ -1154,7 +1153,7 @@ def check_cozempic_daemon_running() -> CheckResult:
         if pid <= 0:
             continue
         try:
-            _os.kill(pid, 0)
+            _kill0_probe(pid)
         except OSError:
             continue
         # Verify this PID is actually our guard (not a PID-reused stranger)

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -104,6 +104,48 @@ def _read_hard_exit_threshold() -> int:
 
 HARD_LOOP_HARD_EXIT_THRESHOLD = _read_hard_exit_threshold()
 
+
+# ── Orphan backstop: exit when there is no Claude PID to watch ───────────────
+# The Claude-exit watchdog only works when the daemon knows Claude's PID. When
+# resolution fails (claude_pid is None — historically ALWAYS on Windows, where
+# the ps-based ancestry walk silently returned None), a guard on a normal-size
+# session has NO exit path at all and outlives Claude indefinitely. The
+# backstop: if claude_pid is None AND the transcript has not been written for
+# this many seconds, assume the session ended and exit cleanly. Set to 0 to
+# disable. Read EXACTLY ONCE at module import time (same convention as
+# COZEMPIC_GUARD_HARD_EXIT_K) — restart the daemon to apply a new value.
+#
+# Default 2 hours: long enough that a thinking/idle-but-attended session is
+# never abandoned prematurely (and with claude_pid resolvable the backstop is
+# dormant anyway), short enough that leaked daemons drain the same day instead
+# of accumulating across desktop restarts.
+_DEFAULT_ORPHAN_EXIT_SECONDS = 7200.0
+_ORPHAN_EXIT_MAX = 7 * 24 * 3600.0
+
+
+def _read_orphan_exit_seconds() -> float:
+    """Read COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS. Clamps to [0, 7 days].
+
+    0 disables the backstop entirely (operator opt-out). Invalid values
+    (non-numeric, NaN, inf, negative, > 7 days) fall back to the default —
+    keeps the daemon working rather than failing at startup over a
+    misconfigured env var (sister precedent: _read_hard_exit_threshold,
+    spawn_lock._read_fresh_window_seconds).
+    """
+    raw = os.environ.get("COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS")
+    if raw is None:
+        return _DEFAULT_ORPHAN_EXIT_SECONDS
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_ORPHAN_EXIT_SECONDS
+    if not math.isfinite(val) or val < 0 or val > _ORPHAN_EXIT_MAX:
+        return _DEFAULT_ORPHAN_EXIT_SECONDS
+    return val
+
+
+GUARD_ORPHAN_EXIT_SECONDS = _read_orphan_exit_seconds()
+
 # ── Watcher poll constants (GAP-B) ───────────────────────────────────────────
 # After osascript fires, the watcher polls for a new claude process for up to
 # RELOAD_WATCHER_POLL_TIMEOUT_SECONDS. 30s matches acquire_with_wait default.
@@ -1007,11 +1049,20 @@ def start_guard(
 
                 # Watchdog: detect Claude exit (workaround for Stop hook not firing)
                 if claude_pid and claude_alive:
-                    try:
-                        os.kill(claude_pid, 0)
-                    except (ProcessLookupError, PermissionError):
-                        claude_alive = False
+                    if os.name == "nt":
+                        # os.kill(pid, 0) is not a liveness probe on Windows
+                        # (signal 0 = CTRL_C_EVENT, a console-group broadcast
+                        # — see helpers._pid_is_alive_windows). Use the native
+                        # OpenProcess probe; the raw os.kill below stays the
+                        # POSIX path so its semantics are untouched.
+                        if not _pid_is_alive(claude_pid):
+                            claude_alive = False
                     else:
+                        try:
+                            os.kill(claude_pid, 0)
+                        except (ProcessLookupError, PermissionError):
+                            claude_alive = False
+                    if claude_alive:
                         # Liveness confirmed — also verify PID identity to guard against
                         # PID reuse (daemon started hours ago; original Claude exited and
                         # kernel recycled its PID to an unrelated process).
@@ -1033,6 +1084,34 @@ def start_guard(
                         _safe_unlink_session_pidfile(sess.get("session_id"))
                         checkpoint_team(session_path=session_path, quiet=False)
                         print(f"  Guard stopping (Claude exited).")
+                        break
+
+                # Orphan backstop: when the Claude PID could never be resolved
+                # (claude_pid is None — historically ALWAYS the case on
+                # Windows, where the ps-based walk silently failed), the
+                # watchdog above is disarmed and the daemon has NO exit path
+                # for a normal-size session: it outlives Claude Code, the
+                # desktop app, and the workday (observed: 10-30 immortal
+                # pythonw daemons accumulating across restarts). If nothing
+                # has written the transcript for GUARD_ORPHAN_EXIT_SECONDS,
+                # assume the session is over and exit cleanly. Dormant
+                # whenever claude_pid is known — the watchdog owns that case.
+                if claude_pid is None and GUARD_ORPHAN_EXIT_SECONDS > 0:
+                    try:
+                        _transcript_idle_s = time.time() - session_path.stat().st_mtime
+                    except OSError:
+                        _transcript_idle_s = 0.0
+                    if _transcript_idle_s > GUARD_ORPHAN_EXIT_SECONDS:
+                        print(
+                            f"  [{_now()}] No Claude PID to watch and the transcript "
+                            f"has been idle {int(_transcript_idle_s / 60)} min "
+                            f"(> {int(GUARD_ORPHAN_EXIT_SECONDS / 60)} min orphan "
+                            f"threshold, COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS to tune). "
+                            f"Assuming the session ended. Final checkpoint..."
+                        )
+                        _safe_unlink_session_pidfile(sess.get("session_id"))
+                        checkpoint_team(session_path=session_path, quiet=False)
+                        print(f"  Guard stopping (orphaned — no watchable Claude PID).")
                         break
 
                 current_size = session_path.stat().st_size
@@ -2186,11 +2265,17 @@ def _detect_terminal_env() -> str:
 
 
 def _wait_for_exit(pid: int, timeout: float = 5.0) -> bool:
-    """Wait for a process to exit. Returns True if exited, False if still alive."""
+    """Wait for a process to exit. Returns True if exited, False if still alive.
+
+    Uses ``_kill0_probe`` (not raw ``os.kill(pid, 0)``): on Windows the raw
+    probe raises OSError for LIVE processes, which made this function report
+    a still-running Claude as exited and let the terminate-and-resume path
+    proceed against a live client.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            os.kill(pid, 0)
+            _kill0_probe(pid)
             time.sleep(0.2)
         except (ProcessLookupError, PermissionError, OSError):
             return True
@@ -3316,7 +3401,7 @@ def _cleanup_legacy_pid(cwd: str) -> None:
     if legacy.exists():
         try:
             pid = int(legacy.read_text().strip())
-            os.kill(pid, 0)
+            _kill0_probe(pid)
             # Only SIGTERM if we can confirm this is actually our daemon.
             if _is_cozempic_guard_process(pid):
                 os.kill(pid, signal.SIGTERM)
@@ -3401,7 +3486,7 @@ def _is_guard_running_for_session(session_id: str) -> int | None:
             # _FRESH_PIDFILE_SECONDS gate, not by an in-process dict.
             pid_path.unlink(missing_ok=True)
             return None
-        os.kill(pid, 0)
+        _kill0_probe(pid)
         # Verify the PID is actually our guard — defend against PID reuse.
         if not _is_cozempic_guard_process(pid):
             # Don't eagerly unlink a fresh-looking pidfile here. A peer
@@ -3840,7 +3925,15 @@ def _is_cozempic_guard_process(pid: int) -> bool:
     our spawn pattern in start_guard_daemon) OR the explicit entry-point
     "cozempic guard" — not just substring "cozempic" + "guard" which could
     match unrelated things like `vim /tmp/cozempic_guard_notes.md`.
+
+    On Windows, ``ps`` is unavailable (the run below always errored, so
+    every live guard read as "not a guard" and the freshness-gated pidfile
+    cleanup in ``_is_guard_running_for_session`` destroyed live claims —
+    one source of the duplicate-daemon leak). Read the command line natively
+    via NtQueryInformationProcess instead and apply the same token rules.
     """
+    if os.name == "nt":
+        return _is_cozempic_guard_process_windows(pid)
     try:
         result = subprocess.run(
             ["ps", "-p", str(pid), "-o", "args="],
@@ -3876,6 +3969,55 @@ def _is_cozempic_guard_process(pid: int) -> bool:
         # but any unhandled exception here would propagate to the
         # non-interactive SessionStart hook surface — fail closed.
         return False
+
+
+def _split_windows_cmdline(cmdline: str) -> tuple[str, list[str]]:
+    """Split a raw Windows command line into (argv0, remaining tokens).
+
+    Windows stores the command line as one string, with argv[0] quoted when
+    the interpreter path contains spaces (e.g. ``"C:\\Program Files\\..."``).
+    A naive ``.split()`` would truncate such an argv[0] at the first space
+    and fail the interpreter-name gate for legitimate guards. Only argv[0]
+    needs quote-aware handling — the token checks below look for exact
+    argument words (``cozempic.cli``, ``guard``), which whitespace split
+    preserves.
+    """
+    cmdline = cmdline.strip()
+    if cmdline.startswith('"'):
+        end = cmdline.find('"', 1)
+        if end > 0:
+            return cmdline[1:end], cmdline[end + 1:].split()
+        return cmdline.strip('"'), []
+    argv0, _, rest = cmdline.partition(" ")
+    return argv0, rest.split()
+
+
+def _is_cozempic_guard_process_windows(pid: int) -> bool:
+    """Windows twin of the ps-based argv check: same token rules, applied to
+    the command line read natively via NtQueryInformationProcess (no
+    subprocess, no console window). Fail-closed on any read failure, exactly
+    like the ps-error path — never signal a process we could not verify.
+    """
+    from .helpers import _windows_process_cmdline
+    if not _pid_is_alive(pid):
+        return False
+    cmdline = _windows_process_cmdline(pid)
+    if not cmdline:
+        return False
+    argv0, tokens = _split_windows_cmdline(cmdline)
+    binary = Path(argv0).name.lower()
+    # python/pythonw with optional version and .exe (pythonw is how the
+    # Windows daemon avoids a console); or the cozempic entry-point exe.
+    if not (
+        re.fullmatch(r"pythonw?(\d+(\.\d+)*)?(\.exe)?", binary)
+        or binary in ("cozempic", "cozempic.exe")
+    ):
+        return False
+    if "cozempic.cli" in tokens and "guard" in tokens:
+        return True
+    if tokens and binary.startswith("cozempic") and tokens[0] == "guard":
+        return True
+    return False
 
 
 _MTIME_LIVENESS_WINDOW_SEC = 60
@@ -4016,6 +4158,27 @@ def _pid_identity_match(pid: int, session_id: str | None) -> bool:
 # module-level alias so callers in this module and tests that patch
 # ``guard._pid_is_alive`` continue to work without a wrapper call.
 _pid_is_alive = _pid_is_alive_canonical
+
+
+def _kill0_probe(pid: int) -> None:
+    """Sig-0-style probe: return None if ``pid`` is alive, raise
+    ``ProcessLookupError`` if it is not.
+
+    Drop-in replacement for the raw ``os.kill(pid, 0)`` probes scattered
+    through the daemon-lifecycle paths, so their existing except-clauses
+    keep working unchanged. On POSIX it IS ``os.kill(pid, 0)``. On Windows
+    ``os.kill(pid, 0)`` is CTRL_C_EVENT delivery, not a probe — it raised
+    OSError for LIVE detached daemons, which made ``_is_guard_running_for_
+    session`` / ``_cleanup_legacy_pid`` / ``reload_self_daemon`` classify
+    live pidfiles as stale, unlink them, and spawn duplicate daemons (and
+    made ``_wait_for_exit`` report a live Claude as already exited). Use
+    the native OpenProcess probe there instead.
+    """
+    if os.name == "nt":
+        if not _pid_is_alive(pid):
+            raise ProcessLookupError(f"no such process: {pid}")
+        return
+    os.kill(pid, 0)
 
 
 def _is_claude_process(pid: int, session_path: Path | None = None) -> bool:
@@ -4236,7 +4399,7 @@ def reload_self_daemon(
                     stale_pid = 0
                 try:
                     if stale_pid > 0:
-                        os.kill(stale_pid, 0)
+                        _kill0_probe(stale_pid)
                     # Still alive — leave the pid file alone and let
                     # start_guard_daemon below return already_running.
                 except (ProcessLookupError, PermissionError):

--- a/src/cozempic/helpers.py
+++ b/src/cozempic/helpers.py
@@ -42,6 +42,12 @@ def _pid_is_alive_windows(pid: int) -> bool:
     STILL_ACTIVE = 259
     ERROR_ACCESS_DENIED = 5
 
+    if pid > 0xFFFFFFFF:
+        # Windows PIDs are DWORDs. A larger value (malformed --claude-pid,
+        # garbled pidfile) cannot name a process — and would raise
+        # ctypes.ArgumentError out of OpenProcess instead of reading as dead.
+        return False
+
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
@@ -79,6 +85,9 @@ def _windows_process_cmdline(pid: int) -> str | None:
 
     PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
     ProcessCommandLineInformation = 60
+
+    if pid <= 0 or pid > 0xFFFFFFFF:
+        return None  # not a valid Windows PID (DWORD range)
 
     class UNICODE_STRING(ctypes.Structure):
         _fields_ = [

--- a/src/cozempic/helpers.py
+++ b/src/cozempic/helpers.py
@@ -13,13 +13,113 @@ _SAVINGS_FILE = _Path.home() / ".cozempic_savings.json"
 
 # ── Process-liveness probe ──────────────────────────────────────────────────
 
+def _pid_is_alive_windows(pid: int) -> bool:
+    """Windows liveness probe via ``OpenProcess`` + ``GetExitCodeProcess``.
+
+    ``os.kill(pid, 0)`` is NOT a liveness probe on Windows: signal 0 is
+    ``CTRL_C_EVENT``, which CPython forwards to ``GenerateConsoleCtrlEvent``
+    — a console-group broadcast whose success depends on the caller's and
+    target's console topology, not on whether the PID exists. Observed on
+    Windows 11 (the duplicate-daemon bug this fixes): a LIVE detached
+    pythonw guard daemon probed from a SessionStart hook subprocess raises
+    OSError [WinError 87] and reads as dead, so ``DaemonSpawnClaim``
+    classified the live peer's pidfile as stale, unlinked it, and spawned
+    a second daemon for the same session.
+
+    ``OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)`` answers existence
+    directly: a handle means the PID slot is valid; ERROR_INVALID_PARAMETER
+    means no such process. ERROR_ACCESS_DENIED means the process exists but
+    is protected (elevated/another user) — alive, mirroring the POSIX
+    EPERM→alive convention below. ``GetExitCodeProcess`` filters the
+    already-exited-but-handle-still-open case (returns the exit code, not
+    STILL_ACTIVE). Known Win32 caveat: a process that genuinely exited
+    with code 259 (STILL_ACTIVE) reads as alive — vanishingly rare and
+    fail-open, the safe direction for every caller.
+    """
+    import ctypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        # ERROR_INVALID_PARAMETER (87): no such PID. ERROR_ACCESS_DENIED (5):
+        # exists but protected — alive. Anything else: fail-closed (dead) —
+        # a probe that can't even open a query-limited handle to a same-user
+        # cozempic daemon is answering "no such process" in practice.
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        exit_code = ctypes.c_ulong(0)
+        if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return exit_code.value == STILL_ACTIVE
+        return True  # handle opened but query failed — fail-open (alive)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _windows_process_cmdline(pid: int) -> str | None:
+    """Read a process's command line on Windows via NtQueryInformationProcess.
+
+    The POSIX identity checks (``_is_cozempic_guard_process``,
+    ``_is_claude_process``) inspect argv via ``ps -o args=``, which does not
+    exist on Windows — so every identity gate failed closed there and
+    freshness-based pidfile cleanup treated live daemons as strangers.
+    ``ProcessCommandLineInformation`` (info class 60, Windows 8.1+) returns
+    the target's command line through a query-limited handle — no subprocess,
+    no console window, no elevated rights for same-user processes.
+
+    Returns None when the process is gone, protected, or the query is
+    unsupported — callers must treat None as "could not verify" (fail
+    closed), mirroring the ps-error path on POSIX.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    ProcessCommandLineInformation = 60
+
+    class UNICODE_STRING(ctypes.Structure):
+        _fields_ = [
+            ("Length", ctypes.c_ushort),
+            ("MaximumLength", ctypes.c_ushort),
+            ("Buffer", ctypes.c_wchar_p),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    ntdll = ctypes.WinDLL("ntdll")
+    ntdll.NtQueryInformationProcess.restype = ctypes.c_long
+
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return None
+    try:
+        size = wintypes.ULONG(0)
+        ntdll.NtQueryInformationProcess(
+            handle, ProcessCommandLineInformation, None, 0, ctypes.byref(size),
+        )
+        if size.value == 0:
+            return None
+        buf = ctypes.create_string_buffer(size.value)
+        status = ntdll.NtQueryInformationProcess(
+            handle, ProcessCommandLineInformation, buf, size.value, ctypes.byref(size),
+        )
+        if status != 0:
+            return None
+        us = ctypes.cast(buf, ctypes.POINTER(UNICODE_STRING)).contents
+        return us.Buffer
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _pid_is_alive(pid: int) -> bool:
-    """Bare process-liveness probe via ``os.kill(pid, 0)``.
+    """Bare process-liveness probe: ``os.kill(pid, 0)`` on POSIX, native
+    ``OpenProcess`` on Windows (see ``_pid_is_alive_windows`` for why
+    ``os.kill(pid, 0)`` cannot be trusted there).
 
     Fail-safe direction: on a POSIX-unknown OSError, return True (assume alive)
     so we never skip a legitimate reload / never prematurely kill a live session.
-    Windows ``os.kill`` raises OSError [WinError 87] for non-existent PIDs —
-    return False there. On POSIX any unexpected OSError is rare; fail-open.
 
     This is the canonical implementation shared by guard.py, session.py, and
     watchdog.py (GC-3). The guard.py ``_pid_is_alive`` is an alias; session.py
@@ -37,6 +137,8 @@ def _pid_is_alive(pid: int) -> bool:
             return False
     if pid <= 0:
         return False
+    if os.name == "nt":
+        return _pid_is_alive_windows(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -47,9 +149,8 @@ def _pid_is_alive(pid: int) -> bool:
     except OverflowError:
         return False  # pid too large — malformed input
     except OSError:
-        # Windows raises OSError [WinError 87] for a non-existent PID.
-        # On POSIX an unexpected OSError here is rare — fail-open (assume alive).
-        return os.name != "nt"
+        # Unexpected OSError on POSIX is rare — fail-open (assume alive).
+        return True
 
 
 # ── Atomic write primitive ──────────────────────────────────────────────────

--- a/src/cozempic/reload_lock.py
+++ b/src/cozempic/reload_lock.py
@@ -111,10 +111,16 @@ def _is_process_alive(pid: int) -> bool:
     ``PermissionError`` if the process exists but we lack permission.
     Conservative interpretation: PermissionError → alive (not ours, but
     real), since a reload lock held by another user's process must not be
-    stolen. Matches spawn_lock._is_process_alive semantics exactly.
+    stolen. Matches spawn_lock._is_process_alive semantics exactly —
+    including the Windows delegation to the native OpenProcess probe
+    (``os.kill(pid, 0)`` is CTRL_C_EVENT delivery there, not a probe; it
+    read live lock holders as dead, letting peers steal held locks).
     """
     if pid <= 0:
         return False
+    if os.name == "nt":
+        from .helpers import _pid_is_alive_windows
+        return _pid_is_alive_windows(pid)
     try:
         os.kill(pid, 0)
         return True

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -297,8 +297,108 @@ def project_slug_to_path(slug: str) -> str:
     return slug.replace("-", "/")
 
 
+def _windows_process_map() -> dict[int, tuple[int, str]]:
+    """Snapshot all live processes as ``{pid: (ppid, exe_name)}`` via
+    ``CreateToolhelp32Snapshot`` (ctypes).
+
+    Pure Win32 — no subprocess, so no console window can flash and no
+    dependency on ``ps`` (Git Bash's ``ps`` does not support ``-o``, which
+    is why the POSIX walk below always came up empty on Windows, leaving
+    every guard daemon without a Claude PID to watch — the daemon-leak bug).
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    TH32CS_SNAPPROCESS = 0x2
+    INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+    class PROCESSENTRY32W(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_size_t),  # ULONG_PTR
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_wchar * 260),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if snapshot == INVALID_HANDLE_VALUE:
+        raise OSError(ctypes.get_last_error(), "CreateToolhelp32Snapshot failed")
+    pmap: dict[int, tuple[int, str]] = {}
+    try:
+        entry = PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32W)
+        ok = kernel32.Process32FirstW(snapshot, ctypes.byref(entry))
+        while ok:
+            pmap[int(entry.th32ProcessID)] = (
+                int(entry.th32ParentProcessID), entry.szExeFile,
+            )
+            ok = kernel32.Process32NextW(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    return pmap
+
+
+def _walk_up_to_claude(
+    pmap: dict[int, tuple[int, str]], start_pid: int, max_hops: int = 10,
+) -> int | None:
+    """Walk ``pmap`` ancestry from ``start_pid`` looking for a Claude process.
+
+    Mirrors the POSIX ``ps`` walk: check the current PID's executable name
+    for a claude/node marker, then hop to its parent, at most ``max_hops``
+    times. Pure function over the snapshot dict so it is unit-testable on
+    any platform. Stops on a missing entry (parent already exited — a
+    detached daemon's dead ancestry), a self-parented root, or a repeated
+    PID (Toolhelp parent IDs can be stale after PID recycling; a cycle
+    must not loop forever).
+    """
+    pid = start_pid
+    seen: set[int] = set()
+    for _ in range(max_hops):
+        entry = pmap.get(pid)
+        if entry is None or pid in seen:
+            return None
+        seen.add(pid)
+        ppid, exe = entry
+        name = exe.lower()
+        if "node" in name or "claude" in name:
+            return pid
+        if ppid <= 0 or ppid == pid:
+            return None
+        pid = ppid
+    return None
+
+
+def _find_claude_pid_windows() -> int | None:
+    """Windows ancestry walk via a Toolhelp32 snapshot.
+
+    Runs in whichever process calls it: from the SessionStart hook's CLI
+    (a live descendant of Claude Code) the walk succeeds and the resolved
+    PID is handed to the daemon via ``--claude-pid``; from the detached
+    daemon itself the ancestry is already dead and this correctly returns
+    None rather than guessing.
+    """
+    try:
+        pmap = _windows_process_map()
+    except OSError:
+        return None
+    return _walk_up_to_claude(pmap, os.getpid())
+
+
 def find_claude_pid() -> int | None:
     """Walk up the process tree to find the Claude Code node process."""
+    if os.name == "nt":
+        # ``ps -o ppid=,comm=`` is unsupported by Git Bash's ps and native
+        # ancestry is invisible to it anyway — the POSIX walk below always
+        # returned None on Windows, which disarmed the guard daemon's
+        # Claude-exit watchdog and leaked one immortal pythonw per session.
+        return _find_claude_pid_windows()
     try:
         pid = os.getpid()
         for _ in range(10):

--- a/src/cozempic/spawn_lock.py
+++ b/src/cozempic/spawn_lock.py
@@ -232,9 +232,20 @@ def _is_process_alive(pid: int) -> bool:
     ``PermissionError`` if the process exists but we lack permission.
     Conservative interpretation: PermissionError → alive (not ours, but
     real), since a guard daemon under another user counts as in-flight.
+
+    On Windows ``os.kill(pid, 0)`` is not a liveness probe (signal 0 is
+    CTRL_C_EVENT — see ``helpers._pid_is_alive_windows``); it raised
+    OSError for LIVE detached pythonw daemons, so this function classified
+    live peers' pidfiles as stale and every SessionStart hook firing past
+    the fresh window spawned a duplicate daemon for the same session.
+    Delegate to the native OpenProcess probe there. Lazy import keeps this
+    module's import graph (stdlib-only, spawn hot path) unchanged on POSIX.
     """
     if pid <= 0:
         return False
+    if os.name == "nt":
+        from .helpers import _pid_is_alive_windows
+        return _pid_is_alive_windows(pid)
     try:
         os.kill(pid, 0)
         return True

--- a/tests/test_cli_receipts.py
+++ b/tests/test_cli_receipts.py
@@ -23,7 +23,7 @@ def _pr():
 class TestCliEmitsReceipt(unittest.TestCase):
     def test_committed_receipt_written_under_home(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 os.environ.pop("COZEMPIC_NO_RECEIPTS", None)
                 cli._emit_prune_receipt(
                     Path(home) / "sess-xyz.jsonl", _pr(),
@@ -43,7 +43,7 @@ class TestCliEmitsReceipt(unittest.TestCase):
 
     def test_deferred_path_emits_valid_receipt(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 os.environ.pop("COZEMPIC_NO_RECEIPTS", None)
                 cli._emit_prune_receipt(
                     Path(home) / "s.jsonl", _pr(), source="manual",
@@ -61,7 +61,7 @@ class TestCliEmitsReceipt(unittest.TestCase):
         # a malformed result must not propagate out of the cli helper, and must
         # not persist a garbage receipt
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 os.environ.pop("COZEMPIC_NO_RECEIPTS", None)
                 cli._emit_prune_receipt(None, object(), source="manual", outcome="committed")
                 rec_dir = Path(home) / ".cozempic" / "receipts"

--- a/tests/test_codex_inherit.py
+++ b/tests/test_codex_inherit.py
@@ -115,7 +115,7 @@ class TestDashboardInheritance(unittest.TestCase):
 
     def test_agent_filter_isolates_codex(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 write_receipt(self._claude_receipt(session="claudesess"))
                 write_receipt(_codex_receipt(session="codexsess"))
                 # data-level isolation: both load, filter keeps only codex
@@ -138,7 +138,7 @@ class TestDashboardInheritance(unittest.TestCase):
         import io
 
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 write_receipt(_codex_receipt(session="cx"))
                 with patch("webbrowser.open"):
                     buf = io.StringIO()

--- a/tests/test_dashboard_lifetime.py
+++ b/tests/test_dashboard_lifetime.py
@@ -171,7 +171,7 @@ class TestCliLifetimeLine(unittest.TestCase):
         import io
 
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 _ledger_file(home, {"tokens_saved": 456170685, "prune_count": 3309,
                                     "since": "2026-04-09"})
                 with patch("webbrowser.open"):
@@ -187,7 +187,7 @@ class TestCliLifetimeLine(unittest.TestCase):
         import io
 
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 _ledger_file(home, {"tokens_saved": 456170685, "prune_count": 3309})
                 with patch("webbrowser.open"):
                     buf = io.StringIO()

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -157,7 +157,7 @@ class TestWriteDashboard(unittest.TestCase):
 class TestCliDashboardCommand(unittest.TestCase):
     def test_command_writes_file_no_open(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 with patch("webbrowser.open") as wb:
                     cli.cmd_dashboard(argparse.Namespace(no_open=True))
                     wb.assert_not_called()  # --no-open suppresses browser
@@ -167,7 +167,7 @@ class TestCliDashboardCommand(unittest.TestCase):
 
     def test_default_opens_browser(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 with patch("webbrowser.open", return_value=True) as wb:
                     cli.cmd_dashboard(argparse.Namespace(no_open=False))
                     wb.assert_called_once()
@@ -177,7 +177,7 @@ class TestCliDashboardCommand(unittest.TestCase):
         import io
 
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 with patch("webbrowser.open"):
                     buf = io.StringIO()
                     with contextlib.redirect_stdout(buf):

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1174,7 +1174,7 @@ class TestMemdirHonorsConfigDir(unittest.TestCase):
         fake_home = self.tmpdir / "fake_home"
         (fake_home / ".claude" / "projects" / self.project_slug / "memory").mkdir(
             parents=True, exist_ok=True)
-        env = {"HOME": str(fake_home)}
+        env = {"HOME": str(fake_home), "USERPROFILE": str(fake_home)}
         # Explicitly clear CLAUDE_CONFIG_DIR if it's set in the outer env
         with patch.dict("os.environ", env, clear=False):
             # Remove CLAUDE_CONFIG_DIR if present in parent env
@@ -1240,7 +1240,7 @@ class TestMemdirHonorsConfigDir(unittest.TestCase):
         ))
         with patch.dict("os.environ", {
             "CLAUDE_CONFIG_DIR": str(self.config_dir),
-            "HOME": str(fake_home),
+            "HOME": str(fake_home), "USERPROFILE": str(fake_home),
         }):
             sync_to_memdir(store, cwd=self.slug_cwd)
             leaked = shadow_memdir / "cozempic_digest.md"

--- a/tests/test_guard_cleanup.py
+++ b/tests/test_guard_cleanup.py
@@ -158,6 +158,7 @@ class TestPidIsAliveCanonicalBehavior(unittest.TestCase):
         with patch("os.kill", side_effect=ProcessLookupError):
             self.assertFalse(_canonical_pid_is_alive(99999))
 
+    @unittest.skipIf(os.name == "nt", "POSIX os.kill seam — Windows uses the native OpenProcess probe (see tests/test_windows_lifecycle.py)")
     def test_permission_error_returns_true(self):
         """PermissionError: process exists but owned by another user — alive."""
         with patch("os.kill", side_effect=PermissionError):

--- a/tests/test_guard_hardening.py
+++ b/tests/test_guard_hardening.py
@@ -79,6 +79,7 @@ class TestG1_CleanupLegacyPidRequiresArgvVerify(unittest.TestCase):
                 "Legacy cleanup sent SIGTERM to a non-guard PID — confused deputy bug",
             )
 
+    @unittest.skipIf(os.name == "nt", "POSIX ps/os.kill seam — Windows uses native probes (see tests/test_windows_lifecycle.py)")
     def test_sigterms_legitimate_guard_pid(self):
         """Positive case: pidfile points at a real cozempic guard — SIGTERM is allowed."""
         from cozempic.guard import _cleanup_legacy_pid
@@ -228,6 +229,7 @@ class TestG3_IsGuardRunningForSessionVerifiesPidOwnership(unittest.TestCase):
             # (we don't assert on _is_cozempic_guard_process call count, just on
             # the returned contract — some implementations may short-circuit)
 
+    @unittest.skipIf(os.name == "nt", "POSIX ps/os.kill seam — Windows uses native probes (see tests/test_windows_lifecycle.py)")
     def test_returns_pid_when_pid_is_cozempic_guard(self):
         """Positive case: PID is alive AND ps confirms it's a cozempic guard."""
         from cozempic.guard import _is_guard_running_for_session
@@ -853,6 +855,7 @@ class TestNF3_IsCozempicGuardProcessRejectsLooseSubstrings(unittest.TestCase):
             f"cozempic.cli + guard as discrete tokens.",
         )
 
+    @unittest.skipIf(os.name == "nt", "POSIX ps/os.kill seam — Windows uses native probes (see tests/test_windows_lifecycle.py)")
     def test_accepts_real_daemon_invocation(self):
         """Positive: canonical python -m cozempic.cli guard invocation."""
         from cozempic.guard import _is_cozempic_guard_process
@@ -1028,6 +1031,7 @@ class TestNF5_WindowsTaskkillReVerifies(unittest.TestCase):
             f"Discord, etc.).",
         )
 
+    @unittest.skipIf(os.name == "nt", "POSIX ps/os.kill seam — Windows uses native probes (see tests/test_windows_lifecycle.py)")
     def test_windows_taskkill_proceeds_when_identity_still_valid(self):
         """Positive: when _is_claude_process stays True, some taskkill MUST
         run — guards against a fix that over-protects and leaves Claude alive."""
@@ -1067,6 +1071,7 @@ class TestNF5_WindowsTaskkillReVerifies(unittest.TestCase):
 # would be rejected as "not cozempic" → SIGTERM blocked on legitimate daemons,
 # or _is_guard_running_for_session returns None → duplicate daemons spawn.
 # ---------------------------------------------------------------------------
+@unittest.skipIf(os.name == "nt", "POSIX ps parsing seam — Windows cmdline parsing covered in tests/test_windows_lifecycle.py")
 class TestR2REG2_VersionedPythonAccepted(unittest.TestCase):
     """Lock in the regex accept/reject contract for python-like binaries.
 
@@ -1210,6 +1215,7 @@ class TestRegexEdgeCases_IsCozempicGuardProcess(unittest.TestCase):
                 "Unicode fullwidth dot falsely accepted as a version separator",
             )
 
+    @unittest.skipIf(os.name == "nt", "POSIX ps/os.kill seam — Windows uses native probes (see tests/test_windows_lifecycle.py)")
     def test_trailing_whitespace_stripped(self):
         """Trailing whitespace on argv line must not affect acceptance —
         `args.strip()` handles it; tokens[0] remains clean."""
@@ -1709,6 +1715,7 @@ class TestR3_4_PosixPlainTerminalSigtermHasInnerReverify(unittest.TestCase):
             f"tmux/screen/SIGKILL paths. Fix: mirror those guards.",
         )
 
+    @unittest.skipIf(os.name == "nt", "POSIX ps/os.kill seam — Windows uses native probes (see tests/test_windows_lifecycle.py)")
     def test_sigterm_fires_when_identity_remains_valid(self):
         """Positive: when identity stays True across the race window, SIGTERM
         MUST fire (guards against an over-protective fix that skips SIGTERM

--- a/tests/test_guard_receipt.py
+++ b/tests/test_guard_receipt.py
@@ -49,7 +49,7 @@ class TestGuardReceipt(unittest.TestCase):
 
     def test_guard_prune_emits_committed_receipt(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 os.environ.pop("COZEMPIC_NO_RECEIPTS", None)
                 guard._emit_guard_receipt(**_args())
                 rec = _only_receipt(home)
@@ -62,7 +62,7 @@ class TestGuardReceipt(unittest.TestCase):
 
     def test_overflow_source_tagged(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 os.environ.pop("COZEMPIC_NO_RECEIPTS", None)
                 guard._emit_guard_receipt(**_args(trigger_source="overflow"))
                 self.assertEqual(_only_receipt(home)["trigger"]["source"], "overflow")
@@ -71,7 +71,7 @@ class TestGuardReceipt(unittest.TestCase):
         # a malformed pre_te must not propagate out of the guard hot path AND must
         # not persist a garbage receipt
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}):
                 os.environ.pop("COZEMPIC_NO_RECEIPTS", None)
                 guard._emit_guard_receipt(**_args(pre_te=None))  # must not raise
                 recdir = Path(home) / ".cozempic" / "receipts"
@@ -80,7 +80,7 @@ class TestGuardReceipt(unittest.TestCase):
 
     def test_optout_suppresses(self):
         with tempfile.TemporaryDirectory() as home:
-            with patch.dict(os.environ, {"HOME": home, "COZEMPIC_NO_RECEIPTS": "1"}):
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home, "COZEMPIC_NO_RECEIPTS": "1"}):
                 guard._emit_guard_receipt(**_args())
                 self.assertFalse((Path(home) / ".cozempic" / "receipts").exists())
 
@@ -139,7 +139,7 @@ class TestGuardReceiptIntegration(unittest.TestCase):
         # patch can't redirect, so it must be patched to spare the real ledger.
         writer = result.get("_deferred_writer")
         if invoke_writer and writer is not None:
-            with patch.dict(os.environ, {"HOME": home}), \
+            with patch.dict(os.environ, {"HOME": home, "USERPROFILE": home}), \
                     patch("cozempic.guard._PruneLock"), \
                     patch("cozempic.guard.save_messages", return_value=None), \
                     patch("cozempic.guard.cleanup_old_backups"), \

--- a/tests/test_guard_transient_race.py
+++ b/tests/test_guard_transient_race.py
@@ -78,6 +78,7 @@ class TestReloadWritesInFlightSentinel(unittest.TestCase):
              patch("cozempic.guard._is_claude_process", return_value=True), \
              patch("cozempic.guard._wait_for_exit", return_value=True), \
              patch("cozempic.guard.os.kill"), \
+             patch("cozempic.guard._pid_is_alive", return_value=True), \
              patch("cozempic.guard.time.sleep"):
             from cozempic.guard import _terminate_and_resume
             _terminate_and_resume(

--- a/tests/test_interactive_loop.py
+++ b/tests/test_interactive_loop.py
@@ -73,6 +73,11 @@ def _run_guard(token_estimate: int, env: dict, context_window: int = 200_000):
         p("cozempic.guard.find_claude_pid", return_value=4242)
         p("cozempic.guard._record_claude_identity", return_value=None)
         p("cozempic.guard.os.kill", return_value=None)
+        # Windows watchdog probes liveness via guard._pid_is_alive (native
+        # OpenProcess — os.kill(pid, 0) is CTRL_C_EVENT delivery there, not a
+        # probe), so the fake claude_pid=4242 must read alive through that
+        # seam too. Inert on POSIX, where the loop keeps the raw os.kill probe.
+        p("cozempic.guard._pid_is_alive", return_value=True)
         p("cozempic.guard._pid_identity_match", return_value=True)
         p("cozempic.guard._is_claude_process", return_value=True)
         p("cozempic.guard.checkpoint_team", return_value=TeamState())

--- a/tests/test_reload_lock_wave2.py
+++ b/tests/test_reload_lock_wave2.py
@@ -479,6 +479,7 @@ class TestReloadLockProcessAlive(unittest.TestCase):
     returns False, allowing _acquire to unlink a live holder's lock.
     """
 
+    @unittest.skipIf(os.name == "nt", "POSIX os.kill seam — Windows uses the native OpenProcess probe (see tests/test_windows_lifecycle.py)")
     def test_permissionerror_treats_as_alive(self):
         """PermissionError on kill(pid,0) must return True (cross-user = alive)."""
         from cozempic.reload_lock import _is_process_alive

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from types import SimpleNamespace
+
+import pytest
 
 from pathlib import Path
 from unittest.mock import patch
@@ -158,6 +161,11 @@ class TestLoadMessagesLimits:
         assert messages[1][1]["content"] == "second"
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX ps ancestry walk — Windows uses a Toolhelp32 snapshot "
+           "(see tests/test_windows_lifecycle.py::TestWalkUpToClaude)",
+)
 class TestFindClaudePid:
     def test_finds_claude_process_in_ancestor_chain(self):
         with (

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -28,7 +28,7 @@ class _Base(unittest.TestCase):
         self.home = Path(tempfile.mkdtemp(prefix="cz_uninstall_"))
         # redirect HOME and the module-level markers into the temp home
         self._patches = [
-            patch.dict(os.environ, {"HOME": str(self.home)}),
+            patch.dict(os.environ, {"HOME": str(self.home), "USERPROFILE": str(self.home)}),
             patch.object(cz_init, "_GLOBAL_INIT_MARKER", self.home / ".cozempic_global_initialized"),
             patch.object(cz_init, "_REMIND_COUNTER", self.home / ".cozempic_remind_counter"),
             patch("cozempic.session.get_claude_dir", return_value=self.home / ".claude"),

--- a/tests/test_windows_lifecycle.py
+++ b/tests/test_windows_lifecycle.py
@@ -1,0 +1,290 @@
+"""Tests for the Windows guard-daemon lifecycle fixes.
+
+Context (2026-08-03, Windows 11): guard daemons accumulated 10-30 deep in the
+task manager because the entire daemon lifecycle layer was POSIX-only:
+
+1. ``session.find_claude_pid`` walked ancestry with ``ps -o ppid=,comm=`` —
+   Git Bash's ``ps`` has no ``-o``, so the walk ALWAYS returned None on
+   Windows, disarming the Claude-exit watchdog (the only exit path for a
+   normal-size session). Daemons outlived Claude Code indefinitely.
+2. ``os.kill(pid, 0)`` is not a liveness probe on Windows (signal 0 is
+   CTRL_C_EVENT → GenerateConsoleCtrlEvent). It raised OSError for LIVE
+   detached pythonw daemons, so ``spawn_lock._is_process_alive`` classified
+   live peers' pidfiles as stale and any two SessionStart hooks firing more
+   than the 5s fresh window apart spawned DUPLICATE daemons per session
+   (reproduced live before the fix).
+
+The fixes under test: a pure ancestry walk over a Toolhelp32 snapshot
+(``_walk_up_to_claude`` — testable on any platform), the native OpenProcess
+liveness probe (Windows-only integration tests), and the orphan backstop
+env knob (``_read_orphan_exit_seconds``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from cozempic.guard import _split_windows_cmdline
+from cozempic.helpers import _pid_is_alive
+from cozempic.session import _walk_up_to_claude, find_claude_pid
+from cozempic.spawn_lock import _is_process_alive
+
+
+class TestSplitWindowsCmdline(unittest.TestCase):
+    """Pure-function tests for the quote-aware cmdline split (any platform)."""
+
+    def test_unquoted_argv0(self):
+        argv0, tokens = _split_windows_cmdline(
+            r"C:\Python\pythonw.exe -m cozempic.cli guard --cwd C:\proj"
+        )
+        self.assertEqual(argv0, r"C:\Python\pythonw.exe")
+        self.assertEqual(tokens[:3], ["-m", "cozempic.cli", "guard"])
+
+    def test_quoted_argv0_with_spaces(self):
+        argv0, tokens = _split_windows_cmdline(
+            r'"C:\Program Files\Python\python.exe" -m cozempic.cli guard'
+        )
+        self.assertEqual(argv0, r"C:\Program Files\Python\python.exe")
+        self.assertEqual(tokens, ["-m", "cozempic.cli", "guard"])
+
+    def test_bare_quoted_binary(self):
+        argv0, tokens = _split_windows_cmdline('"cozempic.exe" guard --daemon')
+        self.assertEqual(argv0, "cozempic.exe")
+        self.assertEqual(tokens, ["guard", "--daemon"])
+
+    def test_unterminated_quote_degrades(self):
+        argv0, tokens = _split_windows_cmdline('"C:\\broken')
+        self.assertEqual(argv0, "C:\\broken")
+        self.assertEqual(tokens, [])
+
+
+class TestWalkUpToClaude(unittest.TestCase):
+    """Pure-function tests for the snapshot ancestry walk (any platform)."""
+
+    def test_finds_claude_ancestor(self):
+        pmap = {
+            100: (1, "wininit.exe"),
+            200: (100, "Claude.exe"),
+            300: (200, "bash.exe"),
+            400: (300, "python.exe"),
+        }
+        self.assertEqual(_walk_up_to_claude(pmap, 400), 200)
+
+    def test_finds_node_ancestor(self):
+        pmap = {
+            200: (1, "node.exe"),
+            300: (200, "bash.exe"),
+            400: (300, "python.exe"),
+        }
+        self.assertEqual(_walk_up_to_claude(pmap, 400), 200)
+
+    def test_dead_ancestry_returns_none(self):
+        # A detached daemon's parent has exited: ppid points outside the
+        # snapshot. Must return None, never guess.
+        pmap = {400: (399, "pythonw.exe")}
+        self.assertIsNone(_walk_up_to_claude(pmap, 400))
+
+    def test_no_claude_in_chain_returns_none(self):
+        pmap = {
+            100: (0, "wininit.exe"),
+            300: (100, "bash.exe"),
+            400: (300, "python.exe"),
+        }
+        self.assertIsNone(_walk_up_to_claude(pmap, 400))
+
+    def test_self_parented_root_terminates(self):
+        # System idle/root pseudo-processes are self-parented on Windows.
+        pmap = {4: (4, "System"), 400: (4, "python.exe")}
+        self.assertIsNone(_walk_up_to_claude(pmap, 400))
+
+    def test_ppid_cycle_terminates(self):
+        # Toolhelp parent PIDs can be stale after PID recycling and form a
+        # cycle A->B->A. The walk must terminate, not spin.
+        pmap = {400: (300, "python.exe"), 300: (400, "bash.exe")}
+        self.assertIsNone(_walk_up_to_claude(pmap, 400))
+
+    def test_max_hops_bounds_walk(self):
+        # 15-deep chain with claude at the root — more hops than the cap.
+        pmap = {i: (i + 1, "proc.exe") for i in range(100, 115)}
+        pmap[115] = (1, "Claude.exe")
+        self.assertIsNone(_walk_up_to_claude(pmap, 100, max_hops=10))
+        self.assertEqual(_walk_up_to_claude(pmap, 100, max_hops=16), 115)
+
+    def test_missing_start_pid_returns_none(self):
+        self.assertIsNone(_walk_up_to_claude({}, 400))
+
+    def test_matches_current_pid_name(self):
+        # Parity with the POSIX walk: the START pid's own name is checked
+        # too (a `claude` ancestor chain may begin at the probe process
+        # when called from inside a node subprocess).
+        pmap = {400: (1, "node.exe")}
+        self.assertEqual(_walk_up_to_claude(pmap, 400), 400)
+
+
+class TestOrphanExitKnob(unittest.TestCase):
+    """Env parsing for COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS (any platform)."""
+
+    def _read(self, value):
+        from cozempic.guard import _read_orphan_exit_seconds
+        env = {} if value is None else {"COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS": value}
+        with patch.dict(os.environ, env, clear=False):
+            if value is None:
+                os.environ.pop("COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS", None)
+            return _read_orphan_exit_seconds()
+
+    def test_default_when_unset(self):
+        from cozempic.guard import _DEFAULT_ORPHAN_EXIT_SECONDS
+        self.assertEqual(self._read(None), _DEFAULT_ORPHAN_EXIT_SECONDS)
+
+    def test_zero_disables(self):
+        self.assertEqual(self._read("0"), 0.0)
+
+    def test_valid_override(self):
+        self.assertEqual(self._read("600"), 600.0)
+
+    def test_garbage_falls_back(self):
+        from cozempic.guard import _DEFAULT_ORPHAN_EXIT_SECONDS
+        for bad in ("banana", "nan", "inf", "-5", str(365 * 24 * 3600)):
+            self.assertEqual(self._read(bad), _DEFAULT_ORPHAN_EXIT_SECONDS, bad)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only liveness probe")
+class TestWindowsLivenessProbe(unittest.TestCase):
+    """Integration tests for the OpenProcess probe against real processes."""
+
+    def _spawn_detached_windowless(self):
+        """Reproduce the real topology that broke os.kill(pid, 0): a
+        detached, console-less child in its own process group — exactly how
+        start_guard_daemon spawns the guard."""
+        return subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=(
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+            ),
+        )
+
+    def test_live_detached_process_reads_alive(self):
+        # THE regression: the old os.kill(pid, 0) probe raised OSError for
+        # this exact topology, classifying a live daemon as dead — which
+        # made DaemonSpawnClaim unlink its pidfile and spawn a duplicate.
+        proc = self._spawn_detached_windowless()
+        try:
+            self.assertTrue(_pid_is_alive(proc.pid))
+            self.assertTrue(_is_process_alive(proc.pid))
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+
+    def test_exited_process_reads_dead(self):
+        proc = self._spawn_detached_windowless()
+        proc.kill()
+        proc.wait(timeout=10)
+        # Popen keeps a handle open on the exited child — the probe must
+        # see through that via GetExitCodeProcess, not just OpenProcess.
+        self.assertFalse(_pid_is_alive(proc.pid))
+        self.assertFalse(_is_process_alive(proc.pid))
+
+    def test_never_existing_pid_reads_dead(self):
+        # PIDs are multiples of 4 on Windows; 4_000_000+2 cannot exist.
+        self.assertFalse(_pid_is_alive(4_000_002))
+        self.assertFalse(_is_process_alive(4_000_002))
+
+    def test_reload_lock_probe_agrees(self):
+        from cozempic.reload_lock import _is_process_alive as _rl_alive
+        proc = self._spawn_detached_windowless()
+        try:
+            self.assertTrue(_rl_alive(proc.pid))
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+        self.assertFalse(_rl_alive(proc.pid))
+
+    def test_kill0_probe_semantics(self):
+        from cozempic.guard import _kill0_probe
+        proc = self._spawn_detached_windowless()
+        try:
+            _kill0_probe(proc.pid)  # alive — must not raise
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+        with self.assertRaises(ProcessLookupError):
+            _kill0_probe(proc.pid)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only cmdline identity check")
+class TestWindowsGuardIdentity(unittest.TestCase):
+    def test_own_cmdline_readable(self):
+        from cozempic.helpers import _windows_process_cmdline
+        cmdline = _windows_process_cmdline(os.getpid())
+        self.assertIsNotNone(cmdline)
+        self.assertIn("python", cmdline.lower())
+
+    def test_non_guard_python_rejected(self):
+        from cozempic.guard import _is_cozempic_guard_process
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+        try:
+            self.assertFalse(_is_cozempic_guard_process(proc.pid))
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+
+    def test_guard_shaped_cmdline_accepted(self):
+        # A python process whose argv carries the discrete "cozempic.cli" and
+        # "guard" tokens — the exact spawn shape of start_guard_daemon. The
+        # extra argv words are inert for `-c` but visible to the checker,
+        # mirroring what the POSIX ps-token check would also accept.
+        from cozempic.guard import _is_cozempic_guard_process
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)",
+             "cozempic.cli", "guard"],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+        try:
+            self.assertTrue(_is_cozempic_guard_process(proc.pid))
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+
+    def test_dead_pid_rejected(self):
+        from cozempic.guard import _is_cozempic_guard_process
+        self.assertFalse(_is_cozempic_guard_process(4_000_002))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only ancestry snapshot")
+class TestWindowsProcessMap(unittest.TestCase):
+    def test_snapshot_contains_self_and_parent(self):
+        from cozempic.session import _windows_process_map
+        pmap = _windows_process_map()
+        me = pmap.get(os.getpid())
+        self.assertIsNotNone(me)
+        ppid, exe = me
+        self.assertIn("python", exe.lower())
+        # Our parent is live (it is running this test session).
+        self.assertIn(ppid, pmap)
+
+    def test_find_claude_pid_returns_int_or_none(self):
+        # Smoke: must never raise on Windows (the old code silently broke
+        # inside ps; the new code must degrade to None at worst).
+        pid = find_claude_pid()
+        self.assertTrue(pid is None or (isinstance(pid, int) and pid > 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

On Windows, guard daemons never exit and accumulate — 10 to 30 `python`/`pythonw` processes pile up in the task manager across Claude Desktop restarts, surviving the app itself. Worse, sessions frequently end up with **duplicate** daemons: two guards for the same session id, spawned seconds apart.

## Root cause

The daemon lifecycle layer is POSIX-only. Three independent breaks compound on Windows:

1. **`find_claude_pid()` always returns `None`.** It walks ancestry with `ps -o ppid=,comm=` — Git Bash's `ps` doesn't support `-o` at all. With no Claude PID, the daemon's Claude-exit watchdog (its only exit path for a normal-size session) never arms, so every guard polls its transcript forever.
2. **`os.kill(pid, 0)` is not a liveness probe on Windows.** Signal 0 is `CTRL_C_EVENT`, which CPython forwards to `GenerateConsoleCtrlEvent` — a console-group broadcast whose result depends on console topology, not PID existence. Reproduced: it raises `OSError` for a LIVE detached daemon. Every probe built on it (`spawn_lock._is_process_alive`, `reload_lock._is_process_alive`, `_is_guard_running_for_session`, `_wait_for_exit`, `_cleanup_legacy_pid`, `reload_self_daemon`'s stale check, doctor's checks) therefore misreads live processes as dead. Concretely: `_is_guard_running_for_session` classifies a live daemon's pidfile as stale once past the 5s fresh window, **unlinks it**, and the claim re-spawns → duplicate daemon per session whenever two SessionStart hooks fire >5s apart (reproduced deterministically).
3. **`_is_cozempic_guard_process` / identity checks are `ps`-based** — they error on Windows and fail closed, so even a correct liveness probe would fall into the "alive but not a guard" freshness-unlink branch.

## Fix

All Windows-gated; POSIX code paths are byte-identical:

- **`helpers._pid_is_alive_windows`** — native probe via `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess == STILL_ACTIVE` (access-denied → alive, invalid-parameter → dead). No subprocess, no console window. `helpers._pid_is_alive`, `spawn_lock._is_process_alive`, and `reload_lock._is_process_alive` delegate to it on Windows.
- **`guard._kill0_probe`** — drop-in for the raw `os.kill(pid, 0)` probes (raises `ProcessLookupError` when dead) so the existing except-clauses at all call sites keep working unchanged; wired into `_is_guard_running_for_session`, `_wait_for_exit`, `_cleanup_legacy_pid`, `reload_self_daemon`, and doctor.
- **`session.find_claude_pid`** — Windows branch walking ancestry over a `CreateToolhelp32Snapshot` process map (ctypes; pure walk extracted as `_walk_up_to_claude` for unit testing). It resolves in the SessionStart hook's CLI — a live descendant of Claude — and `start_guard_daemon` already forwards the result via `--claude-pid`, so the daemon's watchdog now arms.
- **`guard._is_cozempic_guard_process_windows`** — same argv token rules as the `ps` version, applied to the command line read natively via `NtQueryInformationProcess(ProcessCommandLineInformation)` (quote-aware argv[0] split for `Program Files`-style paths). The Claude-side identity check already had a `tasklist` fallback and is unchanged.
- **Orphan backstop** — if the Claude PID could not be resolved at all AND the transcript has been idle for `COZEMPIC_GUARD_ORPHAN_EXIT_SECONDS` (default 2h, 0 disables), the daemon checkpoints and exits instead of living forever. Dormant whenever a Claude PID is known — the watchdog owns that case.

## Verification (Windows 11)

- **Duplicate spawn, before:** two `guard --daemon` calls 8s apart → 2 live daemons, second overwrote the first's pidfile. **After:** second call returns `Guard already running (PID …)`, pidfile intact.
- **Leak, after:** daemon spawned with a watched PID exits within one poll interval of that process dying (`Guard stopping (Claude exited)`, pidfile unlinked); daemon with no resolvable Claude PID and a stale transcript exits via the orphan backstop (`Guard stopping (orphaned …)`).
- New tests in `tests/test_windows_lifecycle.py`: pure-function coverage of the ancestry walk, cmdline split, and env knob (run on all platforms), plus Windows-gated integration tests that reproduce the exact broken topology (detached, console-less child in its own process group) against the new probes.
- Full suite on Windows: no new failures vs `main` (same pre-existing platform-specific failures). POSIX paths untouched by construction (`os.name == "nt"` gates).
