### PR TITLE
fix: support more Linux terminal emulators for auto-resume

### DIFF
--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -16,7 +16,7 @@ from .doctor import run_doctor
 from .executor import execute_actions, run_prescription
 from .guard import checkpoint_team, start_guard, start_guard_daemon
 from .helpers import (
-    is_ssh_session, shell_quote,
+    is_ssh_session, shell_quote, find_linux_terminal_launch_command,
     compile_protect_patterns, tag_pattern_matches, strip_pattern_tags,
 )
 from .init import run_init
@@ -954,13 +954,19 @@ def _spawn_watcher(claude_pid: int, project_dir: str, recap_path: Path | None = 
         )
     elif system == "Linux":
         inner_cmd = f"cd {shell_quote(project_dir)} && {recap_cmd}claude {resume_flag}; exec bash"
-        resume_cmd = (
-            f"if command -v gnome-terminal >/dev/null 2>&1; then "
-            f"gnome-terminal -- bash -c '{inner_cmd}'; "
-            f"elif command -v xterm >/dev/null 2>&1; then "
-            f"xterm -e '{inner_cmd}' & "
-            f"else echo 'No terminal emulator found' >> /tmp/cozempic_reload.log; fi"
-        )
+        launch_cmd = find_linux_terminal_launch_command(inner_cmd)
+        if launch_cmd is None:
+            # No supported terminal emulator on PATH (Terminator/Konsole/etc.
+            # missing, or an IDE-embedded terminal with nothing launchable at
+            # all — #183). A background watcher can't retry or report back
+            # once Claude has exited, so tell the user now, while this
+            # process can still talk to them, instead of spawning a watcher
+            # that will fail silently later.
+            print(f"  No supported terminal emulator found for auto-resume.")
+            print(f"  After exiting, resume manually:")
+            print(f"    cd {project_dir} && claude {resume_flag}")
+            return
+        resume_cmd = launch_cmd
     else:
         print(f"  WARNING: Auto-resume not supported on {system}.")
         print(f"  Restart manually: cd {project_dir} && claude {resume_flag}")

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -962,8 +962,8 @@ def _spawn_watcher(claude_pid: int, project_dir: str, recap_path: Path | None = 
             # once Claude has exited, so tell the user now, while this
             # process can still talk to them, instead of spawning a watcher
             # that will fail silently later.
-            print(f"  No supported terminal emulator found for auto-resume.")
-            print(f"  After exiting, resume manually:")
+            print("  No supported terminal emulator found for auto-resume.")
+            print("  After exiting, resume manually:")
             print(f"    cd {project_dir} && claude {resume_flag}")
             return
         resume_cmd = launch_cmd

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -197,6 +197,7 @@ from .helpers import (
     _pid_is_alive as _pid_is_alive_canonical,
     is_ssh_session,
     shell_quote,
+    find_linux_terminal_launch_command,
     tag_pattern_matches,
     strip_pattern_tags,
 )
@@ -2479,12 +2480,18 @@ def _spawn_reload_watcher(claude_pid: int, project_dir: str, session_id: str | N
             f"\"cd {shell_quote(project_dir)} && claude {resume_flag}\"'"
         )
     elif system == "Linux":
+        # Only gnome-terminal/xterm were checked here (#183) — missed
+        # Terminator/Konsole/XFCE/etc. entirely, and the xterm fallback also
+        # dropped ``; exec bash`` that the gnome-terminal branch had, closing
+        # the window the instant claude exited instead of leaving a shell.
+        # find_linux_terminal_launch_command applies the same inner_cmd (with
+        # exec bash) to every launcher, fixing both at once.
+        _linux_inner_cmd = f"cd {shell_quote(project_dir)} && claude {resume_flag}; exec bash"
+        _linux_launch_cmd = find_linux_terminal_launch_command(_linux_inner_cmd)
         resume_cmd = (
-            f"if command -v gnome-terminal >/dev/null 2>&1; then "
-            f"gnome-terminal -- bash -c 'cd {shell_quote(project_dir)} && claude {resume_flag}; exec bash'; "
-            f"elif command -v xterm >/dev/null 2>&1; then "
-            f"xterm -e 'cd {shell_quote(project_dir)} && claude {resume_flag}' & "
-            f"else echo 'No terminal emulator found' >> /tmp/cozempic_guard.log; fi"
+            _linux_launch_cmd
+            if _linux_launch_cmd is not None
+            else "echo 'No terminal emulator found' >> /tmp/cozempic_guard.log"
         )
     elif system == "Windows":
         # Windows has no bash, and the POSIX watcher below uses kill -0 / pgrep /

--- a/src/cozempic/helpers.py
+++ b/src/cozempic/helpers.py
@@ -388,6 +388,43 @@ def is_ssh_session() -> bool:
     )
 
 
+# Linux terminal emulators to try, in priority order, each paired with the
+# argv form that runs a command and keeps the window open afterwards.
+# gnome-terminal/xterm were the only two previously checked (#183) — this
+# silently failed for anyone on Terminator, KDE, XFCE, or a tiling-WM-style
+# GPU terminal, since none of those install gnome-terminal or xterm by
+# default. An IDE-embedded terminal (e.g. IntelliJ's) isn't a launchable
+# binary at all, so it's out of scope here by construction — callers should
+# treat a ``None`` return the same way they already treat "no terminal found".
+_LINUX_TERMINAL_LAUNCHERS: tuple[tuple[str, str], ...] = (
+    ("gnome-terminal", "gnome-terminal -- bash -c {cmd}"),
+    ("konsole", "konsole -e bash -c {cmd}"),
+    ("xfce4-terminal", "xfce4-terminal -x bash -c {cmd}"),
+    ("terminator", "terminator -x bash -c {cmd}"),
+    ("tilix", "tilix -e bash -c {cmd}"),
+    ("alacritty", "alacritty -e bash -c {cmd}"),
+    ("kitty", "kitty bash -c {cmd}"),
+    ("xterm", "xterm -e {cmd}"),
+)
+
+
+def find_linux_terminal_launch_command(inner_cmd: str) -> str | None:
+    """Return a shell command that opens *some* installed terminal emulator
+    running ``inner_cmd``, or ``None`` if none of the known emulators are on
+    ``PATH``.
+
+    Checked in the priority order of ``_LINUX_TERMINAL_LAUNCHERS`` via
+    ``shutil.which`` — the first match wins. ``inner_cmd`` is shell-quoted
+    once here so every launcher template receives it pre-quoted.
+    """
+    import shutil
+    quoted = shell_quote(inner_cmd)
+    for binary, template in _LINUX_TERMINAL_LAUNCHERS:
+        if shutil.which(binary):
+            return template.format(cmd=quoted)
+    return None
+
+
 _PROTECTED_TYPES = frozenset({
     "content-replacement",
     "marble-origami-commit",

--- a/tests/test_linux_terminal_launcher.py
+++ b/tests/test_linux_terminal_launcher.py
@@ -66,7 +66,7 @@ class TestFindLinuxTerminalLaunchCommand(unittest.TestCase):
             cmd = find_linux_terminal_launch_command("echo 'it'\"'\"'s a test'")
         # Should produce one shell-quoted argument, not a syntax-breaking mix.
         self.assertIn("gnome-terminal -- bash -c ", cmd)
-        self.assertTrue(cmd.count("bash -c ") == 1)
+        self.assertEqual(cmd.count("bash -c "), 1)
 
 
 class TestSpawnWatcherLinuxTerminalFallback(unittest.TestCase):

--- a/tests/test_linux_terminal_launcher.py
+++ b/tests/test_linux_terminal_launcher.py
@@ -1,0 +1,102 @@
+"""Tests for find_linux_terminal_launch_command (#183).
+
+The Linux auto-resume path in _spawn_watcher (cli.py) and
+_spawn_reload_watcher (guard.py) only ever checked gnome-terminal and xterm,
+so anyone on Terminator, KDE, XFCE, or most tiling-WM terminal emulators got
+a silent no-op instead of a resumed session. This also covers the follow-on
+fix in _spawn_watcher: when no terminal is found, it must print manual
+resume instructions and return without spawning a background watcher that
+can never report back once the original Claude process has exited.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _which_only(*allowed: str):
+    """Return a shutil.which stand-in that reports only `allowed` binaries as installed."""
+    def _which(binary, *a, **k):
+        return f"/usr/bin/{binary}" if binary in allowed else None
+    return _which
+
+
+class TestFindLinuxTerminalLaunchCommand(unittest.TestCase):
+    def test_returns_none_when_no_terminal_is_installed(self):
+        from cozempic.helpers import find_linux_terminal_launch_command
+        with patch("shutil.which", side_effect=_which_only()):
+            self.assertIsNone(find_linux_terminal_launch_command("echo hi"))
+
+    def test_prefers_gnome_terminal_when_multiple_are_installed(self):
+        from cozempic.helpers import find_linux_terminal_launch_command
+        with patch("shutil.which", side_effect=_which_only("xterm", "gnome-terminal", "konsole")):
+            cmd = find_linux_terminal_launch_command("echo hi")
+        self.assertIn("gnome-terminal", cmd)
+        self.assertNotIn("konsole", cmd)
+
+    def test_falls_through_to_terminator_when_gnome_terminal_is_missing(self):
+        from cozempic.helpers import find_linux_terminal_launch_command
+        with patch("shutil.which", side_effect=_which_only("terminator")):
+            cmd = find_linux_terminal_launch_command("echo hi")
+        self.assertIn("terminator", cmd)
+        self.assertIn("-x bash -c", cmd)
+
+    def test_falls_through_to_konsole_xfce4_terminal_tilix_alacritty_kitty(self):
+        from cozempic.helpers import find_linux_terminal_launch_command
+        for binary in ("konsole", "xfce4-terminal", "tilix", "alacritty", "kitty"):
+            with patch("shutil.which", side_effect=_which_only(binary)):
+                cmd = find_linux_terminal_launch_command("echo hi")
+            self.assertIn(binary, cmd, f"expected {binary} in launch command: {cmd!r}")
+
+    def test_xterm_is_the_last_resort(self):
+        from cozempic.helpers import find_linux_terminal_launch_command
+        with patch("shutil.which", side_effect=_which_only("xterm")):
+            cmd = find_linux_terminal_launch_command("echo hi")
+        self.assertIn("xterm -e", cmd)
+
+    def test_inner_command_is_shell_quoted_exactly_once(self):
+        from cozempic.helpers import find_linux_terminal_launch_command
+        with patch("shutil.which", side_effect=_which_only("gnome-terminal")):
+            cmd = find_linux_terminal_launch_command("echo 'it'\"'\"'s a test'")
+        # Should produce one shell-quoted argument, not a syntax-breaking mix.
+        self.assertIn("gnome-terminal -- bash -c ", cmd)
+        self.assertTrue(cmd.count("bash -c ") == 1)
+
+
+class TestSpawnWatcherLinuxTerminalFallback(unittest.TestCase):
+    """cli.py's _spawn_watcher: no terminal found → print instructions, no Popen."""
+
+    def _run_spawn_watcher(self, which_side_effect):
+        from cozempic import cli
+        with patch("cozempic.cli.platform.system", return_value="Linux"), \
+             patch("cozempic.cli.is_ssh_session", return_value=False), \
+             patch("cozempic.guard._detect_claude_flags", return_value=""), \
+             patch("shutil.which", side_effect=which_side_effect), \
+             patch("cozempic.cli.subprocess.Popen") as mock_popen, \
+             patch("builtins.print") as mock_print:
+            cli._spawn_watcher(claude_pid=4321, project_dir="/tmp/proj", session_id="abc123")
+        return mock_popen, mock_print
+
+    def test_no_terminal_found_prints_manual_instructions_and_does_not_spawn(self):
+        mock_popen, mock_print = self._run_spawn_watcher(_which_only())
+        mock_popen.assert_not_called()
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("claude", printed)
+        self.assertIn("--resume", printed)
+
+    def test_terminal_found_still_spawns_the_watcher(self):
+        mock_popen, _ = self._run_spawn_watcher(_which_only("gnome-terminal"))
+        mock_popen.assert_called_once()
+        argv = mock_popen.call_args[0][0]
+        script = argv[-1]
+        self.assertIn("gnome-terminal", script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #183.

## What

`_spawn_watcher` (cli.py) and `_spawn_reload_watcher` (guard.py) only ever checked `gnome-terminal` and `xterm` on Linux. Anyone running Terminator, KDE, XFCE, or most other terminal emulators got a silent no-op after `/cozempic:reload` — no window opened, and nothing told them why. IDE-embedded terminals (e.g. IntelliJ's) aren't a launchable external process at all, so no CLI command can reopen one; that case is out of scope by construction rather than "fixed."

## Changes

- New `find_linux_terminal_launch_command()` in `helpers.py`, checked via `shutil.which` in priority order: `gnome-terminal`, `konsole`, `xfce4-terminal`, `terminator`, `tilix`, `alacritty`, `kitty`, then `xterm` as a last resort. Returns `None` if nothing on the list is installed.
- `cli.py`'s `_spawn_watcher`: when no supported terminal is found, print the manual resume command immediately (same shape as the existing SSH branch) instead of spawning a background watcher — a detached watcher can't retry or report back once the original Claude process has already exited, so failing loud *before* backgrounding is the only point where the user can actually be told.
- `guard.py`'s `_spawn_reload_watcher`: same expanded terminal list. Left its existing log-only failure behavior (`/tmp/cozempic_guard.log`) unchanged rather than restructuring the daemon's failure-observability model, which is a bigger, more test-sensitive change than this PR's scope. As a side effect, unifying both branches onto one `inner_cmd` also fixes a pre-existing inconsistency where the xterm fallback dropped the `; exec bash` the gnome-terminal branch had, closing the window immediately instead of leaving a shell open.

## Testing

- New `tests/test_linux_terminal_launcher.py` (8 tests): priority ordering, fallthrough for each newly-supported terminal, `None` when nothing is installed, quoting, and `_spawn_watcher`'s print-and-return-without-Popen behavior when no terminal is found.
- Full suite: `1891 passed, 17 skipped`, plus the pre-existing `test_space_in_flag_value_preserved` failure — confirmed present identically on `main` with these changes stashed out, unrelated to this PR.
