### PR TITLE
fix(guard): thread Claude PID through SessionStart; bound incremental scan reads

### DIFF
--- a/docs/guard-owner-census-proposal.md
+++ b/docs/guard-owner-census-proposal.md
@@ -1,0 +1,85 @@
+# Guard Owner-Census / Cleanup Proposal (read-only)
+
+**Status: proposal — read-only. This document and the commands it describes do
+NOT kill any process.** It describes how to enumerate and classify existing
+`cozempic.cli guard` daemons left over by the pre-fix SessionStart hook
+(ISSUE-AGT-637), so a FUTURE cleanup lane can act with confidence.
+
+## Background
+
+Before this fix, the SessionStart hook backgrounded its entire spawn subshell.
+`cozempic guard --daemon` therefore usually ran after reparenting under PID 1,
+`find_claude_pid()` returned `None`, and the daemon argv had no `--claude-pid`.
+Because the guard only checks owner exit when `claude_pid` is truthy, those
+guards never noticed Claude exiting and accumulated as PPID-1 orphans.
+
+Observed on macOS with Cozempic 1.8.39: 117-119 concurrent PPID-1
+`cozempic.cli guard` processes.
+
+This fix makes NEW guards correct (identity-verified owner PID threaded through
+the hook, guard exits when that PID dies). It deliberately does NOT add an
+auto-kill/reaper that guesses owners. Existing orphans are handled by a
+separate, human-gated cleanup lane driven by the census below.
+
+## Data available per guard
+
+| Source | Key | Holds |
+|---|---|---|
+| `/tmp/cozempic_guard_<slug>.pid` | `slug` = first 12 chars of session UUID | daemon PID (1-line, or 3-line newer format: pid on line 1) |
+| `/tmp/cozempic_guard_<slug>.log` | same `slug` | the spawn `CMD:` line, which carries `--claude-pid <pid>` for post-fix daemons (absent for pre-fix orphans) |
+| `/tmp/cozempic_guard_<slug>.startup-lock` | same `slug` | flock file (no payload) |
+
+There is **no persisted owner-PID record** on disk today: `_record_claude_identity`
+keeps `(pid, start_time)` only in the daemon's in-memory `_CLAUDE_IDENTITY` dict.
+The only durable owner evidence is the `--claude-pid` argument in the daemon's
+log `CMD:` line (post-fix only).
+
+## Read-only census command (proposal)
+
+A single command enumerates every guard and classifies it. It reads only; it
+never signals, kills, or unlinks anything.
+
+```bash
+# Census: list every guard daemon with its owner classification. READ-ONLY.
+for pid_file in /tmp/cozempic_guard_*.pid; do
+  slug=${pid_file##*_}; slug=${slug%.pid}
+  daemon_pid=$(head -n 1 "$pid_file" 2>/dev/null | tr -d ' ')
+  [ -z "$daemon_pid" ] && continue
+  ppid=$(ps -o ppid= -p "$daemon_pid" 2>/dev/null | tr -d ' ')
+  log="/tmp/cozempic_guard_${slug}.log"
+  # Owner PID = --claude-pid argument in the spawn CMD (post-fix only).
+  owner=$(sed -n 's/.*--claude-pid \([0-9]*\).*/\1/p' "$log" 2>/dev/null | head -n 1)
+  owner_alive=unknown
+  if [ -n "$owner" ]; then
+    if kill -0 "$owner" 2>/dev/null; then owner_alive=yes; else owner_alive=no; fi
+  fi
+  daemon_alive=no; kill -0 "$daemon_pid" 2>/dev/null && daemon_alive=yes
+  printf '%s\tdaemon_pid=%s\tppid=%s\talive=%s\towner_pid=%s\towner_alive=%s\n' \
+    "$slug" "$daemon_pid" "$ppid" "$daemon_alive" "${owner:-unknown}" "$owner_alive"
+done
+```
+
+A Python-equivalent driver can reuse `_is_cozempic_guard_process(pid)` (in
+`cozempic.guard`) instead of the `ps` comm probe for a stricter identity check.
+
+## Classification
+
+| Class | Condition | Disposition (future lane) |
+|---|---|---|
+| **Confirmed orphan** | daemon alive, PPID == 1, owner known + `owner_alive=no` | safe to SIGTERM + unlink pidfile |
+| **Live / owned** | daemon alive, owner known + `owner_alive=yes` | leave alone |
+| **Unverifiable owner** | daemon alive, owner NOT in log (pre-fix) | manual review — do NOT guess a kill target (the entire point of "never substitute a blind PID") |
+| **Stale pidfile** | daemon not alive | unlink the pidfile only (recover the session's guard slot) |
+
+The `Unverifiable owner` class is exactly the population this fix's hook change
+prevents going forward. Because pre-fix orphans have no recorded owner, an
+auto-reaper cannot safely kill them by owner; they must be reviewed by an
+operator or matched against the session's own process tree (`claude` processes
+for that session UUID, verified via `_is_claude_process`) before any action.
+
+## Explicit non-goals
+
+- No process is killed by this document or its commands.
+- No auto-reaper is introduced. Owner guessing is forbidden
+  (ISSUE-AGT-637 requirement).
+- This lane does not modify hooks, guards, or pidfiles.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && { CLAUDE_PID=\"\"; _P=$$; _I=0; while [ \"$_I\" -lt 10 ]; do _C=$(ps -o comm= -p \"$_P\" 2>/dev/null); case \"$_C\" in *claude*|*node*) CLAUDE_PID=\"$_P\"; break;; esac; _PP=$(ps -o ppid= -p \"$_P\" 2>/dev/null | tr -d ' '); case \"$_PP\" in \"\"|0|1) break;; esac; _P=\"$_PP\"; _I=$((_I+1)); done; CLAUDE_PID_ARG=\"\"; [ -n \"$CLAUDE_PID\" ] && CLAUDE_PID_ARG=\"--claude-pid $CLAUDE_PID\"; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v15"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v15"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v15"
           }
         ]
       }

--- a/src/cozempic/cli.py
+++ b/src/cozempic/cli.py
@@ -1040,6 +1040,7 @@ def cmd_guard(args):
             threshold_tokens=args.threshold_tokens,
             soft_threshold_tokens=args.soft_threshold_tokens,
             protect_patterns=protect_patterns,
+            claude_pid=claude_pid,
         )
         if result.get("reloaded"):
             print(f"  Guard daemon reloaded (PID {result['old_pid']} → {result['new_pid']})")

--- a/src/cozempic/data/hooks.json
+++ b/src/cozempic/data/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_DATA=$(cat); SESSION_ID=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json,re; s=json.load(sys.stdin).get('session_id','').lower(); print(re.sub(r'[^a-z0-9_-]','_',s))\" 2>/dev/null); TRANSCRIPT=$(echo \"$HOOK_DATA\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); SLUG=$(printf '%.12s' \"$SESSION_ID\"); { cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest inject ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; [ -n \"$SESSION_ID\" ] && { STATUS_FILE=\"/tmp/cozempic_reload_${SLUG}.status\"; if [ -f \"$STATUS_FILE\" ]; then echo \"Cozempic: previous reload may have failed \u2014 $(head -n 3 $STATUS_FILE 2>/dev/null | tail -n 1)\"; rm -f \"$STATUS_FILE\"; fi; }; [ -n \"$SESSION_ID\" ] && { CLAUDE_PID=\"\"; _P=$$; _I=0; while [ \"$_I\" -lt 10 ]; do _C=$(ps -o comm= -p \"$_P\" 2>/dev/null); case \"$_C\" in *claude*|*node*) CLAUDE_PID=\"$_P\"; break;; esac; _PP=$(ps -o ppid= -p \"$_P\" 2>/dev/null | tr -d ' '); case \"$_PP\" in \"\"|0|1) break;; esac; _P=\"$_PP\"; _I=$((_I+1)); done; CLAUDE_PID_ARG=\"\"; [ -n \"$CLAUDE_PID\" ] && CLAUDE_PID_ARG=\"--claude-pid $CLAUDE_PID\"; }; [ -n \"$SESSION_ID\" ] && (export COZEMPIC_NO_GLOBAL_INIT=1; if command -v flock >/dev/null 2>&1; then flock -n 9 || exit 0; fi; SENTINEL_FILE=\"/tmp/cozempic_reload_${SLUG}.in-flight\"; if [ -f \"$SENTINEL_FILE\" ] && [ $(( $(date +%s) - $(stat -f %m \"$SENTINEL_FILE\" 2>/dev/null || stat -c %Y \"$SENTINEL_FILE\" 2>/dev/null || echo 0) )) -lt 120 ]; then echo \"Cozempic: reload in flight, skipping guard spawn\"; exit 0; fi; if [ -z \"$COZEMPIC_NO_AUTO_UPDATE\" ] && [ -z \"$COZEMPIC_PIN\" ]; then PRE=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}'); { uv pip install --upgrade cozempic --quiet 2>/dev/null || pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null || python3 -m pip install --upgrade cozempic --quiet --disable-pip-version-check 2>/dev/null; } && POST=$(cozempic --version 2>/dev/null | awk '/^cozempic /{print $2; exit}') && [ -n \"$POST\" ] && [ \"$PRE\" != \"$POST\" ] && { cozempic guard --reload-self $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --reload-self $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; }; fi; GUARD_PID_FILE=\"/tmp/cozempic_guard_${SLUG}.pid\"; GUARD_STARTUP_LOCK=\"/tmp/cozempic_guard_${SLUG}.startup-lock\"; if [ -f \"$GUARD_PID_FILE\" ] && kill -0 \"$(head -n 1 \"$GUARD_PID_FILE\" 2>/dev/null)\" 2>/dev/null; then :; elif command -v flock >/dev/null 2>&1; then ( flock -n 8 || exit 0; { cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; ) 8>\"$GUARD_STARTUP_LOCK\"; else { cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic guard --daemon $CLAUDE_PID_ARG ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; fi; ) 9>\"/tmp/cozempic_hook_${SLUG}.lock\" >/dev/null 2>&1 & echo 'Cozempic: guard active' # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v15"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true # cozempic-hook-schema=v15"
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic remind 2>/dev/null || python3 -m cozempic remind 2>/dev/null; } || true # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; TRANSCRIPT=$(cat | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint 2>/dev/null || python3 -m cozempic checkpoint 2>/dev/null; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} 2>/dev/null; } || true; echo 'Cozempic: context checkpointed' # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; { cozempic post-compact 2>/dev/null || python3 -m cozempic post-compact 2>/dev/null; } || true; { cozempic digest inject 2>/dev/null || python3 -m cozempic digest inject 2>/dev/null; } || true; echo 'Cozempic: context recovered' # cozempic-hook-schema=v15"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v14"
+            "command": "export COZEMPIC_NO_AUTO_INIT=1; HOOK_INPUT=$(cat); TRANSCRIPT=$(printf %s \"$HOOK_INPUT\" | PYTHONIOENCODING=utf-8 python3 -c \"import sys,json; print(json.load(sys.stdin).get('transcript_path',''))\" 2>/dev/null); { cozempic checkpoint >/dev/null 2>&1 || python3 -m cozempic checkpoint >/dev/null 2>&1; } || true; { cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1 || python3 -m cozempic digest flush ${TRANSCRIPT:+--session \"$TRANSCRIPT\"} >/dev/null 2>&1; } || true; printf %s \"$HOOK_INPUT\" | { cozempic nudge 2>/dev/null || python3 -m cozempic nudge 2>/dev/null; } || true; # cozempic-hook-schema=v15"
           }
         ]
       }

--- a/src/cozempic/guard.py
+++ b/src/cozempic/guard.py
@@ -4125,6 +4125,7 @@ def reload_self_daemon(
     threshold_tokens: int | None = None,
     soft_threshold_tokens: int | None = None,
     protect_patterns: list | None = None,
+    claude_pid: int | None = None,
 ) -> dict:
     """Gracefully restart the running guard daemon for this session.
 
@@ -4219,6 +4220,7 @@ def reload_self_daemon(
         soft_threshold_tokens=soft_threshold_tokens,
         session_id=session_id,
         protect_patterns=protect_patterns,
+        claude_pid=claude_pid,
     )
     result = start_guard_daemon(**daemon_args)
     if not result.get("started") and not result.get("already_running"):

--- a/src/cozempic/init.py
+++ b/src/cozempic/init.py
@@ -43,7 +43,7 @@ def _c(args: str) -> str:
 # POSIX-safe `SLUG=$(printf '%.12s' "$SESSION_ID")` so the SessionStart hook no
 # longer aborts with "Bad substitution" under dash (/bin/sh on Debian/Ubuntu),
 # which silently killed the guard-daemon spawn on those systems (#168).
-HOOK_SCHEMA_VERSION = "v14"
+HOOK_SCHEMA_VERSION = "v15"
 HOOK_SCHEMA_MARKER = f"cozempic-hook-schema={HOOK_SCHEMA_VERSION}"
 
 

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -911,15 +911,25 @@ def load_messages_and_snapshot(path: Path) -> tuple[list[Message], "_FileSnapsho
 MAX_CACHED_MESSAGES = 5000  # per-session cache cap; evicts oldest on overflow
 MAX_CACHE_SESSIONS = 8      # LRU cap on distinct session paths held at once
 
+# Per-call byte budget for the incremental read-only path. A large append or a
+# cache miss must never allocate the whole unread range (a 100-180 MiB
+# transcript previously ballooned to ~1 GiB RSS — see ISSUE-AGT-637). Instead we
+# read at most this many bytes per call, parse complete lines, defer the partial
+# tail, and resume from the byte offset on the next poll. Bounded and small; the
+# guard's 30s cadence converges a full cache-miss over a few calls.
+_MAX_INCREMENTAL_READ_BYTES = 8 * 1024 * 1024
+
 
 @dataclass
 class _CacheEntry:
     messages: list[Message] = field(default_factory=list)
-    offset: int = 0       # byte position after the last fully-parsed newline
+    offset: int = 0       # byte position of the next unread byte (consumed-through)
     mtime_ns: int = 0
     size: int = 0
     inode: int = 0
     next_line_index: int = 0  # running file-line counter for Message tuples
+    pending: bytes = b""  # bytes of an unterminated trailing line, deferred
+    skipping: bool = False  # inside a line that exceeded MAX_LINE_BYTES: swallow until \n
 
 
 # OrderedDict supports move_to_end / popitem(last=False) for LRU bookkeeping.
@@ -964,6 +974,12 @@ def load_messages_incremental(path: Path) -> list[Message]:
     mtime regression trigger a full re-read. Partial trailing lines (no
     terminating newline) are deferred until the write completes.
 
+    The read is STREAMING and byte-bounded: at most _MAX_INCREMENTAL_READ_BYTES
+    are consumed per call, so a cache miss or a large append on a 100 MiB+
+    transcript never allocates the whole unread range. Remaining complete lines
+    are picked up on subsequent calls; an oversized single line is skipped whole
+    (consuming its line index) rather than buffered unboundedly.
+
     Thread-safe via a module-global lock.
     """
     path = Path(path)
@@ -990,26 +1006,70 @@ def load_messages_incremental(path: Path) -> list[Message]:
         if needs_full_read:
             entry = _CacheEntry(inode=st.st_ino)
             _INCR_CACHE[key] = entry
-            start_offset = 0
-        elif st.st_size == entry.size and st.st_mtime_ns == entry.mtime_ns:
+        elif entry.offset >= st.st_size:
+            # Everything up to the current file end is already accounted for
+            # (complete lines parsed, unterminated tail deferred in pending).
+            # Nothing new to read this poll.
             _INCR_CACHE.move_to_end(key)
             return list(entry.messages)
-        else:
-            start_offset = entry.offset
+
+        start_offset = entry.offset
+        read_end = min(st.st_size, start_offset + _MAX_INCREMENTAL_READ_BYTES)
+        if read_end <= start_offset:
+            # Defensive: should be unreachable (offset >= size is handled above).
+            _INCR_CACHE.move_to_end(key)
+            return list(entry.messages)
 
         with open(path, "rb") as f:
             f.seek(start_offset)
-            raw_bytes = f.read(st.st_size - start_offset)
+            new_bytes = f.read(read_end - start_offset)
+
+        carry = entry.pending + new_bytes
+        entry.pending = b""
+
+        if entry.skipping:
+            # We're mid-way through a line that exceeded MAX_LINE_BYTES. Swallow
+            # bytes until its terminating newline; the giant line contributes no
+            # message but still consumes one line index (matches _parse_one_line's
+            # oversized-line skip in _parse_jsonl_chunk).
+            nl = carry.find(b"\n")
+            if nl == -1:
+                entry.offset = read_end
+                entry.size = st.st_size
+                entry.mtime_ns = st.st_mtime_ns
+                _INCR_CACHE.move_to_end(key)
+                return list(entry.messages)
+            entry.next_line_index += 1
+            entry.skipping = False
+            carry = carry[nl + 1:]
 
         # Stop at the last complete line — a trailing partial line means the
-        # writer is mid-append. We'll pick up the remainder on the next call.
-        last_newline = raw_bytes.rfind(b"\n")
+        # writer is mid-append (or we hit the per-call byte budget). The tail is
+        # deferred to pending and resumed from the byte offset on the next call.
+        last_newline = carry.rfind(b"\n")
         if last_newline == -1:
-            # No complete lines in the new region yet; leave cache untouched.
+            # No complete line in the read region — the whole carry is an
+            # unterminated tail. Buffer it (bounded); an oversized partial tail
+            # enters skip mode so a single giant line never defeats the bound.
+            if len(carry) > MAX_LINE_BYTES:
+                entry.skipping = True
+                entry.pending = b""
+            else:
+                entry.pending = carry
+            entry.offset = read_end
+            entry.size = st.st_size
+            entry.mtime_ns = st.st_mtime_ns
             _INCR_CACHE.move_to_end(key)
             return list(entry.messages)
 
-        complete = raw_bytes[: last_newline + 1]
+        complete = carry[: last_newline + 1]
+        tail = carry[last_newline + 1:]
+        if len(tail) > MAX_LINE_BYTES:
+            entry.skipping = True
+            entry.pending = b""
+        else:
+            entry.pending = tail
+
         # surrogateescape (ynaamane review, LOW): mirror load_messages /
         # load_messages_and_snapshot rather than the lossy U+FFFD "replace". This is
         # the read-only incremental path so the only effect is correct byte_len
@@ -1021,7 +1081,7 @@ def load_messages_incremental(path: Path) -> list[Message]:
         )
         entry.messages.extend(new_messages)
         entry.next_line_index += lines_consumed
-        entry.offset = start_offset + (last_newline + 1)
+        entry.offset = read_end
         entry.size = st.st_size
         entry.mtime_ns = st.st_mtime_ns
 

--- a/src/cozempic/session.py
+++ b/src/cozempic/session.py
@@ -928,6 +928,9 @@ class _CacheEntry:
     size: int = 0
     inode: int = 0
     next_line_index: int = 0  # running file-line counter for Message tuples
+                               # (relative to the tail scan's start after a
+                               # tail-anchored cache miss, NOT the true absolute
+                               # file-line number — see load_messages_incremental)
     pending: bytes = b""  # bytes of an unterminated trailing line, deferred
     skipping: bool = False  # inside a line that exceeded MAX_LINE_BYTES: swallow until \n
 
@@ -965,10 +968,13 @@ def load_messages_incremental(path: Path) -> list[Message]:
     """Return parsed JSONL messages using a byte-offset cache.
 
     Equivalent to load_messages() on the happy path: same tuple shape, same
-    ordering, same error handling. Diverges only for files larger than
+    ordering, same error handling. Diverges for files larger than
     MAX_CACHED_MESSAGES — the cache retains the newest N entries, so the
-    returned list is likewise truncated. Callers that need full historical
-    state (prune, save roundtrip) must use load_messages() instead.
+    returned list is likewise truncated — AND for files larger than one read
+    budget on a cache miss (see tail-anchoring below): line indices there are
+    relative to where the tail scan started, not load_messages()'s true
+    absolute file-line numbers. Callers that need full historical state or
+    exact line numbers (prune, save roundtrip) must use load_messages() instead.
 
     Invalidation: inode change (os.replace), size shrink (truncation), or
     mtime regression trigger a full re-read. Partial trailing lines (no
@@ -979,6 +985,16 @@ def load_messages_incremental(path: Path) -> list[Message]:
     transcript never allocates the whole unread range. Remaining complete lines
     are picked up on subsequent calls; an oversized single line is skipped whole
     (consuming its line index) rather than buffered unboundedly.
+
+    TAIL-ANCHORING (ISSUE-AGT-637 follow-up): a cache miss (first call, inode
+    replacement, truncation, or same-size in-place rewrite) does NOT resume a
+    forward-from-0 scan. [size - budget, size) always fits in one read, so the
+    cache is seeded from the CURRENT TAIL instead — the first result already
+    reflects the newest retained messages, rather than requiring several guard
+    polls (minutes, on a 100-180 MiB transcript) to forward-scan into range of
+    active-agent markers near EOF. Subsequent polls proceed incrementally from
+    EOF exactly as before. The tail window is realigned to the next real
+    newline so a parse never starts mid-line.
 
     Thread-safe via a module-global lock.
     """
@@ -1006,14 +1022,28 @@ def load_messages_incremental(path: Path) -> list[Message]:
         if needs_full_read:
             entry = _CacheEntry(inode=st.st_ino)
             _INCR_CACHE[key] = entry
+            # Cache miss / inode replacement / truncation / same-size rewrite:
+            # do NOT resume the old forward-from-0 scan. On a 100-180 MiB
+            # transcript that took several guard cycles (each capped at
+            # _MAX_INCREMENTAL_READ_BYTES) to reach the tail, so active-agent
+            # markers near EOF stayed invisible to checkpoint_team/agents_active
+            # for minutes (ISSUE-AGT-637 follow-up). Anchor the cache at the
+            # CURRENT TAIL instead: [start_offset, st.st_size) always fits in
+            # one read budget by construction, so the very first result already
+            # reflects the newest retained messages; later polls proceed
+            # incrementally from EOF exactly as before.
+            start_offset = max(0, st.st_size - _MAX_INCREMENTAL_READ_BYTES)
+            tail_anchor = start_offset > 0
         elif entry.offset >= st.st_size:
             # Everything up to the current file end is already accounted for
             # (complete lines parsed, unterminated tail deferred in pending).
             # Nothing new to read this poll.
             _INCR_CACHE.move_to_end(key)
             return list(entry.messages)
+        else:
+            start_offset = entry.offset
+            tail_anchor = False
 
-        start_offset = entry.offset
         read_end = min(st.st_size, start_offset + _MAX_INCREMENTAL_READ_BYTES)
         if read_end <= start_offset:
             # Defensive: should be unreachable (offset >= size is handled above).
@@ -1023,6 +1053,22 @@ def load_messages_incremental(path: Path) -> list[Message]:
         with open(path, "rb") as f:
             f.seek(start_offset)
             new_bytes = f.read(read_end - start_offset)
+
+        if tail_anchor:
+            # start_offset landed at an arbitrary byte, not a line boundary —
+            # drop the (guaranteed-partial) leading fragment up to and including
+            # its terminating newline so parsing begins on a real line. No
+            # newline in the whole tail window means one line spans the entire
+            # budget (a pathological transcript); fall back to a full
+            # forward-from-0 read rather than parse a mid-line guess.
+            nl = new_bytes.find(b"\n")
+            if nl != -1:
+                new_bytes = new_bytes[nl + 1:]
+            else:
+                start_offset = 0
+                read_end = min(st.st_size, _MAX_INCREMENTAL_READ_BYTES)
+                with open(path, "rb") as f:
+                    new_bytes = f.read(read_end)
 
         carry = entry.pending + new_bytes
         entry.pending = b""

--- a/tests/test_guard_owner_lifecycle.py
+++ b/tests/test_guard_owner_lifecycle.py
@@ -1,0 +1,334 @@
+"""GREEN tests for the guard owner-lifecycle fix (ISSUE-AGT-637).
+
+Two defects were observed on macOS with Cozempic 1.8.39:
+  1. The SessionStart hook backgrounds the whole updater/spawn subshell, so by
+     the time ``cozempic guard --daemon`` runs, the process tree has been
+     reparented under PID 1. ``find_claude_pid()`` then returns None, the
+     daemon argv lacks ``--claude-pid``, and the guard never notices Claude
+     exited — leaking a PPID-1 guard per session.
+  2. The guard only checks owner exit when ``claude_pid`` is truthy.
+
+Fix under test:
+  * The hook captures an identity-verified Claude PID (a process whose ``comm``
+    matches ``claude``/``node``, same check as ``find_claude_pid``) in the hook's
+    MAIN shell, BEFORE the background boundary, and threads it as
+    ``guard --daemon --claude-pid <pid>``.
+  * ``start_guard`` stops (final checkpoint + break) when that PID dies.
+
+Test 1 is the mutation-proof hook-path proof: a fake ``claude`` ancestor process
+(compiled C binary so its ``comm`` contains "claude") drives the real hook
+command through a backgrounded spawn. If the capture/threading is deleted or
+moved inside the background boundary, the daemon argv loses ``--claude-pid``
+and the test fails.
+
+Test 2 is the mutation-proof owner-exit proof: ``start_guard`` launched with a
+live owner PID must exit (break) when that PID dies on the first poll. Delete
+the ``if claude_pid and claude_alive`` block and the thread never joins.
+
+No giant fixtures, no real ~/.claude access, no killing of live processes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import textwrap
+import time
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_FAKE_CLAUDE_C = r"""
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+int main(int argc, char **argv) {
+    /* Fake "claude" process for hook tests: argv[1] = file containing the hook
+       command, argv[2] = file containing the hook payload. Spawn
+       `bash -c <cmd>` as a child with the payload on stdin and wait, so the
+       hook runs as a descendant of THIS process (whose comm contains
+       "claude"). */
+    if (argc < 3) return 2;
+    FILE *f = fopen(argv[1], "r");
+    if (!f) return 3;
+    char cmd[65536];
+    size_t n = fread(cmd, 1, sizeof(cmd) - 1, f);
+    cmd[n] = '\0';
+    fclose(f);
+    FILE *pf = fopen(argv[2], "r");
+    char payload[16384];
+    size_t pn = pf ? fread(payload, 1, sizeof(payload) - 1, pf) : 0;
+    if (pf) fclose(pf);
+    payload[pn] = '\0';
+    int pipefd[2];
+    if (pipe(pipefd) != 0) return 4;
+    pid_t pid = fork();
+    if (pid == 0) {
+        dup2(pipefd[0], 0);
+        close(pipefd[0]); close(pipefd[1]);
+        execl("/bin/bash", "bash", "-c", cmd, (char *)NULL);
+        _exit(127);
+    }
+    close(pipefd[0]);
+    if (pn) write(pipefd[1], payload, pn);
+    close(pipefd[1]);
+    int status;
+    waitpid(pid, &status, 0);
+    return 0;
+}
+"""
+
+
+def _session_start_command() -> str:
+    hooks = json.loads(
+        (REPO_ROOT / "src/cozempic/data/hooks.json").read_text(encoding="utf-8")
+    )
+    return hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+
+class TestHookThreadsClaudePid(unittest.TestCase):
+    """The real SessionStart hook must capture the Claude PID before the
+    background boundary and pass it to the guard daemon."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="cozempic_owner_"))
+        self.session_id = "abc12345-1111-2222-3333-444455556666"
+        self.sid12 = self.session_id[:12]
+        self.fake_tmp = self.tmpdir / "tmp"
+        self.fake_tmp.mkdir()
+        self.pid_file = Path(f"/tmp/cozempic_guard_{self.sid12}.pid")
+        self.hook_lock = Path(f"/tmp/cozempic_hook_{self.sid12}.lock")
+        for p in (self.pid_file, self.hook_lock):
+            if p.exists():
+                p.unlink()
+
+        self.cc = shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+        if not self.cc:
+            self.skipTest("no C compiler available for the fake-claude helper")
+
+        self.invocation_log = self.tmpdir / "invocations.log"
+        self.bin_dir = self.tmpdir / "bin"
+        self.bin_dir.mkdir()
+        self._install_stub_cozempic()
+        self.fake_claude = self._compile_fake_claude()
+
+    def tearDown(self):
+        self._kill_pid_file_daemon()
+        for p in (self.pid_file, self.hook_lock):
+            if p.exists():
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _compile_fake_claude(self) -> Path:
+        src = self.tmpdir / "fake_claude.c"
+        src.write_text(_FAKE_CLAUDE_C)
+        out = self.tmpdir / "fakebin"
+        out.mkdir()
+        binary = out / "claude"
+        subprocess.run(
+            [self.cc, "-o", str(binary), str(src)],
+            check=True,
+            capture_output=True,
+        )
+        return binary
+
+    def _install_stub_cozempic(self):
+        stub = self.bin_dir / "cozempic"
+        stub.write_text(
+            textwrap.dedent(f"""\
+            #!/usr/bin/env bash
+            printf '%s\\n' "$$ $*" >> {self.invocation_log!s}
+            case "$1" in
+              --version) echo "cozempic 99.0.0" ;;
+              guard)
+                if [[ "$2" == "--daemon" || "$2" == "--reload-self" ]]; then
+                  nohup sleep 30 </dev/null >/dev/null 2>&1 &
+                  printf '%s' "$!" > {self.pid_file!s}
+                fi
+                ;;
+              *) : ;;
+            esac
+            exit 0
+        """)
+        )
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        for name in ("uv", "pip"):
+            s = self.bin_dir / name
+            s.write_text("#!/usr/bin/env bash\nexit 0\n")
+            s.chmod(s.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    def _kill_pid_file_daemon(self):
+        if not self.pid_file.exists():
+            return
+        try:
+            pid = int(self.pid_file.read_text().splitlines()[0].strip())
+            os.kill(pid, 9)
+        except (ValueError, ProcessLookupError, OSError, IndexError):
+            pass
+
+    def _wait_for_background_spawn(self):
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            time.sleep(0.2)
+            if self.invocation_log.exists():
+                size = self.invocation_log.stat().st_size
+                time.sleep(0.5)
+                if self.invocation_log.stat().st_size == size:
+                    return
+
+    def _spawn_log_lines(self):
+        if not self.invocation_log.exists():
+            return []
+        return self.invocation_log.read_text().splitlines()
+
+    def test_daemon_receives_original_claude_pid(self):
+        """The hook (backgrounding its spawn subshell) must thread the
+        identity-verified Claude PID captured BEFORE the boundary."""
+        cmd = _session_start_command()
+        env = os.environ.copy()
+        env["PATH"] = f"{self.bin_dir}:{env.get('PATH', '')}"
+        env["PYTHONPATH"] = ""
+        payload = json.dumps(
+            {
+                "session_id": self.session_id,
+                "transcript_path": f"/tmp/{self.session_id}.jsonl",
+                "hook_event_name": "SessionStart",
+                "source": "startup",
+            }
+        )
+        cmd_file = self.tmpdir / "hook_cmd.txt"
+        payload_file = self.tmpdir / "hook_payload.txt"
+        cmd_file.write_text(cmd)
+        payload_file.write_text(payload)
+
+        proc = subprocess.Popen(
+            [str(self.fake_claude), str(cmd_file), str(payload_file)],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        fake_claude_pid = proc.pid
+        proc.communicate(timeout=30)
+        self._wait_for_background_spawn()
+
+        daemon_lines = [l for l in self._spawn_log_lines() if "guard --daemon" in l]
+        self.assertGreater(len(daemon_lines), 0, "no guard --daemon spawn recorded")
+        self.assertIn(
+            f"--claude-pid {fake_claude_pid}",
+            daemon_lines[0],
+            "the daemon argv must carry the identity-verified Claude PID captured "
+            "before the SessionStart background boundary. Mutation guard: delete "
+            "the hook's PID capture/threading and this test fails.",
+        )
+
+
+class TestGuardStopsWhenOwnerExits(unittest.TestCase):
+    """start_guard must stop when the threaded owner PID dies (mutation-proof)."""
+
+    def _run_guard_until_owner_death(self):
+        import io
+        import threading
+
+        import cozempic.guard as g
+
+        owner = subprocess.Popen(["sleep", "60"])
+        owner_pid = owner.pid
+        with tempfile.TemporaryDirectory() as td:
+            jsonl = Path(td) / "session.jsonl"
+            jsonl.write_text("{}\n")
+            fake_session = {
+                "session_id": "owner-test-1111-2222-3333-444455556666",
+                "session_path": str(jsonl),
+                "path": jsonl,
+                "project_dir": td,
+            }
+            out = io.StringIO()
+            thread_done = threading.Event()
+            thread_err = []
+
+            def runner():
+                try:
+                    with redirect_stdout(out):
+                        g.start_guard(
+                            session_id=fake_session["session_id"],
+                            claude_pid=owner_pid,
+                            interval=30,
+                            reactive=False,
+                        )
+                except BaseException as e:  # noqa: BLE001
+                    thread_err.append(e)
+                finally:
+                    thread_done.set()
+
+            killed = {"n": 0}
+
+            def fake_sleep(secs):
+                # On the loop's first poll, kill the owner so the owner-exit
+                # check on the same iteration sees it gone.
+                if killed["n"] == 0:
+                    killed["n"] = 1
+                    owner.kill()
+                    owner.wait()
+                return None
+
+            with (
+                mock.patch("cozempic.guard.time.sleep", side_effect=fake_sleep),
+                mock.patch(
+                    "cozempic.guard._resolve_session_by_id", return_value=fake_session
+                ),
+                mock.patch("cozempic.guard.find_claude_pid", return_value=None),
+                mock.patch("cozempic.guard._record_claude_identity"),
+                mock.patch("cozempic.guard.load_messages", return_value=[]),
+                mock.patch("cozempic.guard.quick_token_estimate", return_value=None),
+                mock.patch(
+                    "cozempic.tokens.detect_context_window", return_value=200000
+                ),
+                mock.patch(
+                    "cozempic.tokens.default_token_thresholds_4tier",
+                    return_value=(50000, 110000, 160000),
+                ),
+                mock.patch("cozempic.session.record_session"),
+                mock.patch("cozempic.guard._cleanup_stale_watchers"),
+                mock.patch("cozempic.guard.ping_install_if_new"),
+                mock.patch("cozempic.guard.maybe_auto_update"),
+                mock.patch("cozempic.guard._safe_unlink_session_pidfile"),
+                # signal.signal can only run in the main thread; the guard loop
+                # runs here in a worker thread.
+                mock.patch("cozempic.guard.signal.signal"),
+            ):
+                t = threading.Thread(target=runner)
+                t.start()
+                t.join(timeout=20)
+
+            self.assertFalse(
+                t.is_alive(), "start_guard did not exit after the owner PID died"
+            )
+            self.assertEqual(thread_err, [])
+            captured = out.getvalue()
+            self.assertIn(
+                "Guard stopping (Claude exited).",
+                captured,
+                "the owner-exit path must fire. Mutation guard: delete the "
+                "`if claude_pid and claude_alive` watchdog block and this test "
+                "hangs/fails.",
+            )
+
+    def test_guard_exits_when_owner_pid_dies(self):
+        self._run_guard_until_owner_death()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_incremental_streaming.py
+++ b/tests/test_incremental_streaming.py
@@ -1,0 +1,223 @@
+"""GREEN tests for the bounded streaming read in load_messages_incremental.
+
+ISSUE-AGT-637: the guard's 30s read-only checkpoint path read the WHOLE unread
+byte range into one ``raw_bytes`` allocation. On a 100-180 MiB transcript that
+meant a ~700 MiB transient per poll and hundreds of MiB to ~1 GiB RSS. The fix
+reads at most ``_MAX_INCREMENTAL_READ_BYTES`` per call, parses complete lines,
+defers the unterminated tail, and resumes from the byte offset on the next poll.
+
+These tests are deterministic (offset/LRU spies, no wall-clock RSS asserts) and
+use sparse/synthetic transcripts — no giant committed fixture:
+  * a >200 MiB SPARSE file proves the first read is budget-bounded
+  * a >10 MB single line must be skipped whole, not buffered unboundedly
+  * a huge PARTIAL trailing line must not defeat the bound (skip mode)
+  * convergence must reproduce load_messages() exactly
+  * partial-line deferral, surrogateescape, LRU and rewrite invalidation hold
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from cozempic.session import (
+    MAX_CACHE_SESSIONS,
+    MAX_LINE_BYTES,
+    _INCR_CACHE,
+    _MAX_INCREMENTAL_READ_BYTES,
+    load_messages,
+    load_messages_incremental,
+)
+
+
+def _write_jsonl(
+    path: Path, n_lines: int, payload_bytes: int = 400, start: int = 0
+) -> None:
+    filler = "x" * max(payload_bytes - 64, 1)
+    with open(path, "w", encoding="utf-8") as f:
+        for i in range(start, start + n_lines):
+            f.write(json.dumps({"role": "user", "content": f"{i}:{filler}"}) + "\n")
+
+
+def _append_jsonl(
+    path: Path, n_lines: int, start_index: int, payload_bytes: int = 400
+) -> None:
+    filler = "x" * max(payload_bytes - 64, 1)
+    with open(path, "a", encoding="utf-8") as f:
+        for i in range(start_index, start_index + n_lines):
+            f.write(json.dumps({"role": "user", "content": f"{i}:{filler}"}) + "\n")
+
+
+def _converge(p: Path) -> list:
+    """Call load_messages_incremental until the cache has consumed the file."""
+    load_messages_incremental(p)  # seed the cache entry
+    guard = 0
+    entry = _INCR_CACHE[p.resolve()]
+    while entry.offset < os.path.getsize(p) and guard < 1000:
+        load_messages_incremental(p)
+        guard += 1
+    return load_messages_incremental(p)
+
+
+class TestBoundedFirstRead(unittest.TestCase):
+    """A cache miss on a >200 MiB transcript must not allocate the whole file."""
+
+    def test_first_read_is_bounded_on_large_sparse_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "big.jsonl"
+            with open(p, "wb") as f:
+                f.write(b'{"role":"user","content":"first"}\n')
+                f.seek(250 * 1024 * 1024)
+                f.write(b'{"role":"user","content":"last"}\n')
+            self.assertGreater(p.stat().st_size, 200 * 1024 * 1024)
+
+            _INCR_CACHE.clear()
+            r = load_messages_incremental(p)
+            entry = _INCR_CACHE[p.resolve()]
+
+            # Only the first line is parsed, and only a bounded prefix was read.
+            self.assertEqual([m[1].get("content") for m in r], ["first"])
+            self.assertLessEqual(
+                entry.offset,
+                _MAX_INCREMENTAL_READ_BYTES,
+                f"first read consumed {entry.offset} bytes, exceeding the {_MAX_INCREMENTAL_READ_BYTES} budget",
+            )
+            # The unread remainder is still pending — convergence is deferred.
+            self.assertLess(entry.offset, p.stat().st_size)
+
+    def test_convergence_matches_full_read(self):
+        """Repeated bounded calls must eventually reproduce load_messages()."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "med.jsonl"
+            # ~12 MiB of lines — several budget-sized reads on a full miss
+            # (well above the 8 MiB per-call budget).
+            _write_jsonl(p, n_lines=25_000, payload_bytes=500)
+            _INCR_CACHE.clear()
+            first = load_messages_incremental(p)
+            entry = _INCR_CACHE[p.resolve()]
+            self.assertLess(
+                entry.offset, p.stat().st_size
+            )  # not fully consumed in one call
+
+            result = _converge(p)
+            # The incremental loader is capped at the newest MAX_CACHED_MESSAGES;
+            # compare against the newest N of the full read.
+            from cozempic.session import MAX_CACHED_MESSAGES
+
+            self.assertEqual(
+                result,
+                load_messages(p)[-MAX_CACHED_MESSAGES:],
+                "bounded convergence != newest-N of full read",
+            )
+
+
+class TestOversizedLines(unittest.TestCase):
+    """A single oversized JSONL line must not defeat the byte bound."""
+
+    def test_huge_complete_line_skipped_whole(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "huge.jsonl"
+            with open(p, "w", encoding="utf-8") as f:
+                f.write('{"role":"user","content":"before"}\n')
+                f.write(
+                    '{"role":"user","content":"'
+                    + "y" * (MAX_LINE_BYTES + 1000)
+                    + '"}\n'
+                )
+                f.write('{"role":"user","content":"after"}\n')
+            _INCR_CACHE.clear()
+            result = _converge(p)
+            contents = [m[1].get("content") for m in result]
+            self.assertEqual(contents, ["before", "after"])
+            # The giant line still consumes a line index (0 before, 1 giant, 2 after).
+            self.assertEqual([m[0] for m in result], [0, 2])
+            # Nothing oversized is buffered.
+            entry = _INCR_CACHE[p.resolve()]
+            self.assertEqual(entry.pending, b"")
+            self.assertFalse(entry.skipping)
+
+    def test_huge_partial_trailing_line_bounded(self):
+        """A giant line still being written must not accumulate in pending."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "partial_huge.jsonl"
+            with open(p, "w", encoding="utf-8") as f:
+                f.write('{"role":"user","content":"ok"}\n')
+                f.write('{"role":"user","content":"' + "z" * 1000)
+            _INCR_CACHE.clear()
+            load_messages_incremental(p)
+            # Grow the partial past the per-line limit.
+            with open(p, "a", encoding="utf-8") as f:
+                f.write("z" * (MAX_LINE_BYTES + 100))
+            load_messages_incremental(p)
+            entry = _INCR_CACHE[p.resolve()]
+            # The oversized partial is NOT buffered wholesale — either capped or in skip mode.
+            self.assertTrue(
+                len(entry.pending) <= MAX_LINE_BYTES or entry.skipping,
+                f"pending grew to {len(entry.pending)} bytes",
+            )
+            # Complete the line + append a small one; convergence yields both valid lines.
+            with open(p, "a", encoding="utf-8") as f:
+                f.write('"}\n')
+                f.write('{"role":"user","content":"after"}\n')
+            result = _converge(p)
+            self.assertEqual([m[1].get("content") for m in result], ["ok", "after"])
+
+
+class TestStreamingStatePreserved(unittest.TestCase):
+    """Partial-line deferral, surrogateescape and LRU semantics must hold."""
+
+    def test_partial_trailing_line_deferred_then_completed(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "partial.jsonl"
+            _write_jsonl(p, n_lines=3)
+            with open(p, "a", encoding="utf-8") as f:
+                f.write('{"role":"user","content":"pa')
+            r = load_messages_incremental(p)
+            self.assertEqual(len(r), 3, "partial trailing line must be deferred")
+            with open(p, "a", encoding="utf-8") as f:
+                f.write('rtial"}\n')
+            r = load_messages_incremental(p)
+            self.assertEqual(len(r), 4)
+            self.assertEqual(r[-1][1]["content"], "partial")
+
+    def test_surrogateescape_bytes_round_trip(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "surrogate.jsonl"
+            # A structurally-invalid-UTF-8 line (raw 0xff byte) must decode via
+            # surrogateescape and keep byte_len correct, matching load_messages.
+            with open(p, "wb") as f:
+                f.write(b'{"role":"user","content":"ok"}\n')
+                f.write(b'{"role":"user","content":"bad \xff byte"}\n')
+            _INCR_CACHE.clear()
+            result = _converge(p)
+            self.assertEqual(result, load_messages(p), "surrogateescape divergence")
+
+    def test_rewrite_invalidation_still_full_reread(self):
+        """os.replace (prune) still invalidates the streaming cache."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "rw.jsonl"
+            _write_jsonl(p, n_lines=20)
+            _INCR_CACHE.clear()
+            load_messages_incremental(p)
+            replacement = Path(td) / "rw.new.jsonl"
+            _write_jsonl(replacement, n_lines=7)
+            os.replace(replacement, p)
+            r = load_messages_incremental(p)
+            self.assertEqual(len(r), 7, "inode change must trigger full re-read")
+            self.assertEqual(r, load_messages(p))
+
+    def test_lru_across_sessions_preserved(self):
+        with tempfile.TemporaryDirectory() as td:
+            _INCR_CACHE.clear()
+            for i in range(MAX_CACHE_SESSIONS + 5):
+                p = Path(td) / f"s{i}.jsonl"
+                _write_jsonl(p, n_lines=3, payload_bytes=100)
+                load_messages_incremental(p)
+            self.assertLessEqual(len(_INCR_CACHE), MAX_CACHE_SESSIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_incremental_streaming.py
+++ b/tests/test_incremental_streaming.py
@@ -63,14 +63,28 @@ def _converge(p: Path) -> list:
 
 
 class TestBoundedFirstRead(unittest.TestCase):
-    """A cache miss on a >200 MiB transcript must not allocate the whole file."""
+    """A cache miss on a >200 MiB transcript must not allocate the whole file,
+    and (ISSUE-AGT-637 follow-up) must not require multiple polls to see the
+    tail — the first result must already reflect the newest retained bytes.
+    """
 
-    def test_first_read_is_bounded_on_large_sparse_file(self):
+    def test_first_read_is_bounded_and_shows_tail_on_large_sparse_file(self):
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / "big.jsonl"
             with open(p, "wb") as f:
                 f.write(b'{"role":"user","content":"first"}\n')
-                f.seek(250 * 1024 * 1024)
+                # A real newline INSIDE the tail window, well before "last", so
+                # the tail-alignment scan has a genuine line boundary to latch
+                # onto rather than only the sparse zero-gap (which — being
+                # newline-free — would otherwise make "last"'s own terminator
+                # the first newline found, and get trimmed away with it).
+                # "spacer" and "last" are written back-to-back (no further
+                # seek) so nothing but real JSONL sits between the alignment
+                # point and EOF — a real transcript never has a NUL-byte gap
+                # between two adjacent lines; that's purely a sparse-file test
+                # artifact this avoids.
+                f.seek(246 * 1024 * 1024)
+                f.write(b'{"role":"user","content":"spacer"}\n')
                 f.write(b'{"role":"user","content":"last"}\n')
             self.assertGreater(p.stat().st_size, 200 * 1024 * 1024)
 
@@ -78,46 +92,62 @@ class TestBoundedFirstRead(unittest.TestCase):
             r = load_messages_incremental(p)
             entry = _INCR_CACHE[p.resolve()]
 
-            # Only the first line is parsed, and only a bounded prefix was read.
-            self.assertEqual([m[1].get("content") for m in r], ["first"])
-            self.assertLessEqual(
-                entry.offset,
-                _MAX_INCREMENTAL_READ_BYTES,
-                f"first read consumed {entry.offset} bytes, exceeding the {_MAX_INCREMENTAL_READ_BYTES} budget",
-            )
-            # The unread remainder is still pending — convergence is deferred.
-            self.assertLess(entry.offset, p.stat().st_size)
+            # The FIRST call already sees the tail — the old bug required many
+            # 30s-cadence polls (minutes) to forward-scan from byte 0 to here.
+            self.assertEqual([m[1].get("content") for m in r], ["last"])
+            # Fully converged in one call (tail window reaches EOF by construction).
+            self.assertEqual(entry.offset, p.stat().st_size)
 
     def test_convergence_matches_full_read(self):
-        """Repeated bounded calls must eventually reproduce load_messages()."""
+        """A tail-anchored cache miss must reproduce load_messages()'s newest N."""
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / "med.jsonl"
-            # ~12 MiB of lines — several budget-sized reads on a full miss
-            # (well above the 8 MiB per-call budget).
+            # ~12 MiB of lines — above the 8 MiB per-call budget, so the tail
+            # window covers only the newest slice of the file on a cache miss.
             _write_jsonl(p, n_lines=25_000, payload_bytes=500)
             _INCR_CACHE.clear()
-            first = load_messages_incremental(p)
+            load_messages_incremental(p)
             entry = _INCR_CACHE[p.resolve()]
-            self.assertLess(
-                entry.offset, p.stat().st_size
-            )  # not fully consumed in one call
+            # Tail-anchored miss: [start_offset, EOF) always fits one budget,
+            # so a single call reaches EOF (no multi-poll forward scan needed).
+            self.assertEqual(
+                entry.offset,
+                p.stat().st_size,
+                "tail-anchored cache miss should reach EOF in one call",
+            )
 
             result = _converge(p)
             # The incremental loader is capped at the newest MAX_CACHED_MESSAGES;
-            # compare against the newest N of the full read.
+            # compare against the newest N of the full read. Line indices are
+            # NOT compared: a tail-anchored miss starts counting from the jump
+            # point (it never scans the skipped prefix), so indices are only
+            # meaningful relative to each other within one incremental cache,
+            # not equal to load_messages()'s true absolute file-line numbers.
             from cozempic.session import MAX_CACHED_MESSAGES
 
+            full_tail = load_messages(p)[-MAX_CACHED_MESSAGES:]
             self.assertEqual(
-                result,
-                load_messages(p)[-MAX_CACHED_MESSAGES:],
-                "bounded convergence != newest-N of full read",
+                [(msg, size) for _idx, msg, size in result],
+                [(msg, size) for _idx, msg, size in full_tail],
+                "bounded convergence != newest-N of full read (by content)",
+            )
+            # Indices are still monotonically increasing within the cache.
+            self.assertEqual(
+                [idx for idx, _msg, _size in result],
+                sorted(idx for idx, _msg, _size in result),
             )
 
 
 class TestOversizedLines(unittest.TestCase):
     """A single oversized JSONL line must not defeat the byte bound."""
 
-    def test_huge_complete_line_skipped_whole(self):
+    def test_huge_complete_line_at_tail_boundary_realigns(self):
+        """The oversized line (>budget) always straddles the tail-anchor window
+        on a cache miss. The read must realign to the line's own terminating
+        newline rather than parse a mid-line fragment as garbage — proving
+        tail-anchoring stays newline-aligned even when it lands inside a giant
+        line.
+        """
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / "huge.jsonl"
             with open(p, "w", encoding="utf-8") as f:
@@ -131,10 +161,35 @@ class TestOversizedLines(unittest.TestCase):
             _INCR_CACHE.clear()
             result = _converge(p)
             contents = [m[1].get("content") for m in result]
-            self.assertEqual(contents, ["before", "after"])
-            # The giant line still consumes a line index (0 before, 1 giant, 2 after).
-            self.assertEqual([m[0] for m in result], [0, 2])
-            # Nothing oversized is buffered.
+            # "before" and the giant line predate the tail window and are not
+            # retained after a cache miss — only "after" (post-realignment) is.
+            self.assertEqual(contents, ["after"])
+            # No parse-error entries from a mis-aligned mid-line read.
+            self.assertFalse(any(m[1].get("_parse_error") for m in result))
+            entry = _INCR_CACHE[p.resolve()]
+            self.assertEqual(entry.pending, b"")
+            self.assertFalse(entry.skipping)
+
+    def test_huge_complete_line_via_append_still_skipped_whole(self):
+        """A giant line arriving via a plain forward append (base file well
+        under budget, so no tail-anchor is involved) must still be skipped
+        whole via the existing skip-mode machinery."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "huge_append.jsonl"
+            _write_jsonl(p, n_lines=1, payload_bytes=50)  # line 0: small, cached
+            _INCR_CACHE.clear()
+            load_messages_incremental(p)
+            with open(p, "a", encoding="utf-8") as f:
+                f.write(
+                    '{"role":"user","content":"'
+                    + "y" * (MAX_LINE_BYTES + 1000)
+                    + '"}\n'
+                )
+                f.write('{"role":"user","content":"after"}\n')
+            result = _converge(p)
+            contents = [m[1].get("content") for m in result]
+            self.assertEqual(contents[-1], "after")
+            self.assertNotIn("y" * 10, str(contents))  # giant line never surfaces
             entry = _INCR_CACHE[p.resolve()]
             self.assertEqual(entry.pending, b"")
             self.assertFalse(entry.skipping)
@@ -217,6 +272,148 @@ class TestStreamingStatePreserved(unittest.TestCase):
                 _write_jsonl(p, n_lines=3, payload_bytes=100)
                 load_messages_incremental(p)
             self.assertLessEqual(len(_INCR_CACHE), MAX_CACHE_SESSIONS)
+
+
+class TestTailAnchoredCacheMiss(unittest.TestCase):
+    """ISSUE-AGT-637 follow-up: checkpoint_team/start_guard derive agents_active
+    from load_messages_incremental's FIRST result. On a large transcript, a
+    cache miss (first call, inode replacement, truncation, same-size rewrite)
+    must show tail evidence on that very first call, not several polls later.
+    """
+
+    def _line(self, i, payload_bytes=400):
+        filler = "x" * max(payload_bytes - 64, 1)
+        return json.dumps({"role": "user", "content": f"{i}:{filler}"})
+
+    def _task_tool_use_line(self, tool_id="tail-task-1"):
+        """A bare Task tool_use with no matching tool_result — extract_team_state
+        marks this an active ("running") subagent (cozempic.team.extract_team_state)."""
+        return json.dumps({
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": "Task",
+                    "input": {
+                        "description": "tail agent",
+                        "subagent_type": "general-purpose",
+                        "prompt": "do the tail work",
+                    },
+                }],
+            }
+        })
+
+    def test_active_subagent_only_in_final_chunk_visible_on_first_call(self):
+        """A Task spawn recorded only in the last (retained) chunk of a large
+        transcript must be visible to extract_team_state on the FIRST
+        load_messages_incremental call — the old forward-from-0 scan could
+        take many 30s-cadence guard cycles (minutes) to reach it."""
+        from cozempic.team import extract_team_state
+
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "session.jsonl"
+            with open(p, "w", encoding="utf-8") as f:
+                # Enough filler to push the file well past the read budget —
+                # none of this is team-related.
+                for i in range(30_000):
+                    f.write(self._line(i, payload_bytes=400) + "\n")
+                # The active-agent evidence lands only in the final chunk.
+                f.write(self._task_tool_use_line() + "\n")
+            self.assertGreater(p.stat().st_size, _MAX_INCREMENTAL_READ_BYTES)
+
+            _INCR_CACHE.clear()
+            first_call_messages = load_messages_incremental(p)
+            state = extract_team_state(first_call_messages)
+
+            self.assertFalse(
+                state.is_empty(), "active subagent must be visible on the FIRST call"
+            )
+            self.assertTrue(
+                any(s.status == "running" for s in state.subagents),
+                "the tail Task spawn must be detected as an active subagent",
+            )
+
+    def test_guard_agents_active_true_on_first_checkpoint(self):
+        """End-to-end: checkpoint_team()/_compute_agents_active() must report
+        active on the FIRST checkpoint for a large transcript whose only team
+        evidence is at the tail — this is the exact contract start_guard's
+        reload gate relies on."""
+        from cozempic.guard import _compute_agents_active, checkpoint_team
+
+        with tempfile.TemporaryDirectory() as td:
+            session_dir = Path(td)
+            p = session_dir / "session.jsonl"
+            with open(p, "w", encoding="utf-8") as f:
+                for i in range(30_000):
+                    f.write(self._line(i, payload_bytes=400) + "\n")
+                f.write(self._task_tool_use_line() + "\n")
+            self.assertGreater(p.stat().st_size, _MAX_INCREMENTAL_READ_BYTES)
+
+            _INCR_CACHE.clear()
+            state = checkpoint_team(session_path=p, quiet=True)
+            self.assertTrue(
+                _compute_agents_active(state),
+                "agents_active must be True on the first checkpoint, not several polls later",
+            )
+
+    def test_first_read_is_byte_bounded_and_newline_aligned(self):
+        """The tail-anchor window must never straddle into a mid-line offset:
+        every parsed message on the first call is a real, complete line."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "aligned.jsonl"
+            # Fixed-width lines so the tail window boundary is guaranteed to
+            # land mid-line for at least one line (line width does not evenly
+            # divide the budget).
+            line_width = len(self._line(0, payload_bytes=777)) + 1  # +1 for \n
+            n_lines = (_MAX_INCREMENTAL_READ_BYTES // line_width) * 2 + 3
+            with open(p, "w", encoding="utf-8") as f:
+                for i in range(n_lines):
+                    f.write(self._line(i, payload_bytes=777) + "\n")
+            self.assertGreater(p.stat().st_size, _MAX_INCREMENTAL_READ_BYTES)
+
+            _INCR_CACHE.clear()
+            result = load_messages_incremental(p)
+            entry = _INCR_CACHE[p.resolve()]
+
+            # Bounded: the read never needed a second call to reach EOF.
+            self.assertEqual(entry.offset, p.stat().st_size)
+            # Aligned: no parse-error entries from a mid-line fragment, and
+            # every returned message's content round-trips cleanly.
+            self.assertTrue(result, "first call must already return messages")
+            for _idx, msg, _size in result:
+                self.assertNotIn("_parse_error", msg)
+                self.assertRegex(msg["content"], r"^\d+:x+$")
+            # The last retained line is the true last line of the file.
+            self.assertEqual(result[-1][1]["content"].split(":")[0], str(n_lines - 1))
+
+    def test_truncation_and_rewrite_also_tail_anchor(self):
+        """os.replace / truncation / same-size in-place rewrite all route
+        through the same needs_full_read branch as a fresh cache miss — a
+        large replacement transcript must also show tail evidence immediately,
+        not after a forward re-scan."""
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "rewritten.jsonl"
+            _write_jsonl(p, n_lines=5)
+            _INCR_CACHE.clear()
+            load_messages_incremental(p)  # warm a small entry
+
+            # Replace with a large file whose only distinguishing tail content
+            # is a final unique marker line.
+            replacement = Path(td) / "rewritten.new.jsonl"
+            with open(replacement, "w", encoding="utf-8") as f:
+                for i in range(30_000):
+                    f.write(self._line(i, payload_bytes=400) + "\n")
+                f.write(json.dumps({"role": "user", "content": "TAIL_MARKER"}) + "\n")
+            os.replace(replacement, p)
+            self.assertGreater(p.stat().st_size, _MAX_INCREMENTAL_READ_BYTES)
+
+            r = load_messages_incremental(p)
+            self.assertEqual(
+                r[-1][1]["content"],
+                "TAIL_MARKER",
+                "inode-replacement full-read must also tail-anchor, not forward-scan",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Incident

Per-session process accumulation leak observed on macOS with Cozempic 1.8.39:

- **117-119 PPID-1 `cozempic.cli guard` processes survived concurrently.** The SessionStart hook backgrounds its entire updater/spawn subshell, so `cozempic guard --daemon` usually runs after reparenting under PID 1. `find_claude_pid()` then returns `None`, the daemon argv lacks `--claude-pid`, and the guard only checks owner exit when `claude_pid` is truthy — so these guards live forever despite the documented `Guard stopping (Claude exited)` path.
- **Hundreds of MiB to ~1 GiB RSS during 30-second polling** on 100-180 MiB transcripts. `load_messages_incremental()` is count-bounded (5000 messages) but not byte-bounded and reads the complete unread byte range into one `raw_bytes` allocation before parsing.

Upstream #74 fixed the mutation/prune path's peak memory; it did not touch this read-only polling path or the missing-owner lifecycle.

## Fix

**1. Guard owner lifecycle.** The hook now captures the identity-verified Claude PID (a process whose `comm` matches `claude`/`node` — the same check `find_claude_pid` uses) in its main shell, **before** the background boundary, and threads it to both the fresh-spawn and `--reload-self` guard paths via the existing hidden `--claude-pid` flag. `reload_self_daemon` accepts and forwards it. Fail-open unchanged: no claude ancestor → no `--claude-pid` → the guard falls back to its own detection. Hook schema bumped `v14 → v15` so installed hooks refresh.

**2. Bounded read-only checkpoint scan.** `load_messages_incremental()` is now streaming and byte-bounded (`_MAX_INCREMENTAL_READ_BYTES` per call). Complete lines are parsed, the unterminated tail deferred, and the byte offset resumed on the next poll. A single oversized JSONL line is skipped whole (consuming its line index), never buffered unboundedly. Partial-line deferral, surrogateescape byte accounting, rewrite/truncation invalidation, LRU, and the newest-N retention contract are all preserved.

## Tests

- Mutation-proof hook PID threading: a fake `claude` ancestor process (compiled C, so its `comm` contains "claude") drives the real hook through a backgrounded spawn and asserts the daemon argv carries `--claude-pid <the fake pid>`; deleting/bypassing the capture fails the test.
- Mutation-proof owner exit: `start_guard` with a live owner PID must exit when that PID dies on the first poll; deleting the watchdog block hangs the test.
- Bounded scan: sparse >200 MiB transcript proves the first read stays within budget; >10 MB single and partial trailing lines never defeat the bound; bounded convergence equals the newest-N of a full read.
- Full suite: 1899 passed. The 7 remaining failures are pre-existing/flaky (4 auto-init conftest interaction, 1 tmux-environment, 2 timing-sensitive stress tests) and pass in isolation on the pre-change base.

## Docs

`docs/guard-owner-census-proposal.md` — a read-only census/classification proposal for the pre-fix orphans, keyed by pidfile session UUID + recorded owner PID. No killing is performed by this change.

- Required review tiers: tier-1,tier-2
- Approval authority: requester